### PR TITLE
[Feat] Skip data scan < _id in MongoDB #83

### DIFF
--- a/types/stream.go
+++ b/types/stream.go
@@ -27,7 +27,8 @@ type Stream struct {
 	AdditionalProperties string `json:"additional_properties,omitempty"`
 	// Renderable JSON Schema for additional properties supported by respective driver for individual stream
 	AdditionalPropertiesSchema schema.JSONSchema `json:"additional_properties_schema,omitempty"`
-	SyncMode                   SyncMode          `json:"sync_mode,omitempty"` // Mode being used for syncing data
+	SyncMode                   SyncMode          `json:"sync_mode,omitempty"`     // Mode being used for syncing data
+	MinTimestamp               int64             `json:"min_timestamp,omitempty"` // Minimum unix timestamp in seconds required for processing an entry
 }
 
 func NewStream(name, namespace string) *Stream {


### PR DESCRIPTION
# Description

<!-- Requirement primarily comes when you have a lot of data and you want to only full load last 2 years worth of data (Just for example).

You should be able to specify the min timestamp in seconds so we will sync all newer data which came after specified value. -->



## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
