### PR TITLE
fix: Concurrency based on number of max threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __debug_bin*
 go.sum
 go.work.sum
 **/examples
+.cursorrules

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -132,7 +132,7 @@ func (m *Mongo) backfill(stream protocol.Stream, pool *protocol.WriterPool) erro
 	sort.Slice(chunksArray, func(i, j int) bool {
 		return chunksArray[i].Min.(*primitive.ObjectID).Hex() < chunksArray[j].Min.(*primitive.ObjectID).Hex()
 	})
-	return utils.Concurrent(backfillCtx, chunksArray, m.config.MaxThreads, func(ctx context.Context, one types.Chunk, number int) error {
+	return utils.ConcurrentReader(backfillCtx, chunksArray, m.config.MaxThreads, func(ctx context.Context, one types.Chunk, number int) error {
 		batchStartTime := time.Now()
 		err := processChunk(backfillCtx, one, number)
 		if err != nil {

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -63,6 +63,10 @@ func (m *Mongo) Setup() error {
 		// add 1 for first run
 		m.config.RetryCount += 1
 	}
+
+	// Initialize the global reader pool with the configured max threads
+	utils.InitReaderPool(m.config.MaxThreads)
+
 	return nil
 }
 

--- a/utils/concurrent_reader.go
+++ b/utils/concurrent_reader.go
@@ -11,12 +11,12 @@ import (
 
 // Global pool for controlling total concurrent database operations
 var ReaderPool struct {
-	semaphore chan struct{}
-	once      sync.Once
-	mutex     sync.Mutex
-	active    atomic.Int64
-	waiting   atomic.Int64
-	total     atomic.Int64
+	semaphore chan struct{} // Limits concurrent operations across all streams
+	once      sync.Once     // Ensures one-time initialization of the pool
+	mutex     sync.Mutex    // Protects access during initialization
+	active    atomic.Int64  // Tracks currently running operations
+	waiting   atomic.Int64  // Tracks operations waiting in queue
+	total     atomic.Int64  // Counts total completed operations
 }
 
 // InitReaderPool initializes the global reader pool with the specified concurrency limit.

--- a/utils/concurrent_reader.go
+++ b/utils/concurrent_reader.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/datazip-inc/olake/logger"
+	"golang.org/x/sync/errgroup"
+)
+
+// Global pool for controlling total concurrent database operations
+var ReaderPool struct {
+	semaphore chan struct{}
+	once      sync.Once
+	mutex     sync.Mutex
+	active    atomic.Int64
+	waiting   atomic.Int64
+	total     atomic.Int64
+}
+
+// InitReaderPool initializes the global reader pool with the specified concurrency limit
+func InitReaderPool(maxConcurrent int) {
+	ReaderPool.once.Do(func() {
+		ReaderPool.semaphore = make(chan struct{}, maxConcurrent)
+		logger.Infof("Initialized global reader pool with max concurrent: %d", maxConcurrent)
+	})
+}
+
+// ConcurrentReader executes database read operations with a global concurrency limit
+// to prevent database connection overload across multiple streams
+func ConcurrentReader[T any](ctx context.Context, array []T, concurrency int,
+	execute func(ctx context.Context, one T, executionNumber int) error) error {
+
+	// Initialize global pool if needed
+	ReaderPool.mutex.Lock()
+	if ReaderPool.semaphore == nil {
+		ReaderPool.semaphore = make(chan struct{}, concurrency)
+		logger.Infof("Initialized global reader pool with max concurrent: %d", concurrency)
+	}
+	ReaderPool.mutex.Unlock()
+
+	executor, ctx := errgroup.WithContext(ctx)
+
+	for idx, one := range array {
+		idx, one := idx, one // capture
+		executor.Go(func() error {
+			// TODO: Consider removing or reducing these debug logs before production release
+			// They are useful for development but may generate excessive log volume in production
+
+			// Increment waiting counter
+			waiting := ReaderPool.waiting.Add(1)
+			logger.Debugf("Chunk waiting for queue slot. Active: %d, Waiting: %d, Total: %d",
+				ReaderPool.active.Load(), waiting, ReaderPool.total.Load())
+
+			// Acquire global semaphore
+			select {
+			case ReaderPool.semaphore <- struct{}{}:
+				// Decrement waiting, increment active
+				ReaderPool.waiting.Add(-1)
+				active := ReaderPool.active.Add(1)
+				logger.Debugf("Chunk started execution. Active: %d, Waiting: %d, Total: %d",
+					active, ReaderPool.waiting.Load(), ReaderPool.total.Load())
+
+				defer func() {
+					<-ReaderPool.semaphore
+					active := ReaderPool.active.Add(-1)
+					total := ReaderPool.total.Add(1)
+					logger.Debugf("Chunk completed execution. Active: %d, Waiting: %d, Total: %d",
+						active, ReaderPool.waiting.Load(), total)
+				}()
+			case <-ctx.Done():
+				ReaderPool.waiting.Add(-1)
+				return ctx.Err()
+			}
+
+			// Execute with global limit enforced
+			return execute(ctx, one, idx+1)
+		})
+	}
+
+	return executor.Wait()
+}

--- a/utils/concurrent_reader.go
+++ b/utils/concurrent_reader.go
@@ -13,7 +13,6 @@ import (
 var ReaderPool struct {
 	semaphore chan struct{} // Limits concurrent operations across all streams
 	once      sync.Once     // Ensures one-time initialization of the pool
-	mutex     sync.Mutex    // Protects access during initialization
 
 	// The following counters are maintained for monitoring purposes only.
 	// They can be exposed via metrics collectors or debugging tools without


### PR DESCRIPTION
# Description

Currently if we sync 10 new streams/tables in CDC mode and num_thread is configured to be 50 in config, it will create 500 go-routines for backfill. Which will have two major bad effects :
- Source database will be overwhelmed.
- It will consume RAM where Olake is running.

Fixes: [[Bug] Concurrency overall control based on number of threads defined](https://github.com/datazip-inc/olake/issues/88)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The global reader pool implementation has been tested through the following scenarios:

- [x] Load Testing with Multiple Streams: Verified that the total number of concurrent database operations never exceeds the configured limit, even when multiple streams are running simultaneously.
- [x] Resource Utilization Monitoring: Monitored system resources (CPU, memory, database connections) during high-load operations to confirm the concurrency control prevents resource exhaustion.
- [x] Initialization Consistency: Tested that the pool is properly initialized during MongoDB driver setup and maintains consistent behavior across application restarts.
- [x] Counter Accuracy: Verified that the atomic counters (active, waiting, total) accurately reflect the current state of operations through logging and monitoring.
- [x] Context Cancellation: Confirmed that operations properly release resources and update counters when their context is canceled.
- [x] Performance Impact: Measured throughput with various max_threads count settings to check if the said number of threads are utilised on OS side.
- [x] Error Handling: Tested error propagation when database operations fail to ensure the semaphore slots are properly released.

Test environment included MongoDB instances with varying connection limits to validate behavior under different database configurations.

# Screenshots or Recordings
[test_issue_88.log.zip](https://github.com/user-attachments/files/18970680/test_issue_88.log.zip)

Note: This log file contains logs of a fresh sync run on the [sample training](https://www.mongodb.com/docs/atlas/sample-data/sample-training/) dataset. These logs were attained with the verbose logging enabled on the concurrentReader function. Check this [commit](https://github.com/datazip-inc/olake/pull/115/commits/620ecc1155bbaed3384ebaa7133c62ab5685d8dc) to view the logging code logic.


## Related PR's (If Any):
NA
