### PR TITLE
[Chore] Added a test releaser

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: []

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -8,11 +8,6 @@ on:
       version:
         description: "Version to release"
         required: true
-      dev_mode:
-        description: "Build development image"
-        type: boolean
-        default: true
-        required: false
 
 jobs:
   publish_drivers:
@@ -26,7 +21,7 @@ jobs:
       DHID: ${{ secrets.DOCKER_REPO || 'olakego' }}
       DRIVER: ${{ github.event.inputs.driver || 'mongodb' }}
       VERSION: ${{ github.event.inputs.version || 'v0.0.0.dev' }}
-      DEV_MODE: ${{ github.event.inputs.dev_mode || 'true' }}
+      BRANCH_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,11 +29,11 @@ jobs:
         run: echo "DRIVER=${{ env.DRIVER }}" >> $GITHUB_ENV
       - name: Set VERSION
         run: echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
-      - name: Set DEV_MODE
-        run: echo "DEV_MODE=${{ env.DEV_MODE }}" >> $GITHUB_ENV
+      - name: Set BRANCH_NAME
+        run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}" >> $GITHUB_ENV
       - name: Show VERSION
         run: |
-          echo "Building driver $DRIVER with version $VERSION (Dev mode: $DEV_MODE)"
+          echo "Building driver $DRIVER with version $VERSION on branch $BRANCH_NAME"
       - name: Run Release tool
         run: |
           chmod +x ./release-tool.sh

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -8,6 +8,11 @@ on:
       version:
         description: "Version to release"
         required: true
+      test_mode:
+        description: "Build test image"
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   publish_drivers:
@@ -21,6 +26,7 @@ jobs:
       DHID: ${{ secrets.DOCKER_REPO || 'olakego' }}
       DRIVER: ${{ github.event.inputs.driver || 'mongodb' }}
       VERSION: ${{ github.event.inputs.version || 'v0.0.0.dev' }}
+      TEST_MODE: ${{ github.event.inputs.test_mode || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -28,8 +34,11 @@ jobs:
         run: echo "DRIVER=${{ env.DRIVER }}" >> $GITHUB_ENV
       - name: Set VERSION
         run: echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
+      - name: Set TEST_MODE
+        run: echo "TEST_MODE=${{ env.TEST_MODE }}" >> $GITHUB_ENV
       - name: Show VERSION
-        run: echo "Building driver $DRIVER with version $VERSION"
+        run: |
+          echo "Building driver $DRIVER with version $VERSION (Test mode: $TEST_MODE)"
       - name: Run Release tool
         run: |
           chmod +x ./release-tool.sh

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Set VERSION
         run: echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
       - name: Show VERSION
-        run: |
-          echo "Building driver $DRIVER with version $VERSION"
+        run: echo "Building driver $DRIVER with version $VERSION"
       - name: Run Release tool
         run: |
           chmod +x ./release-tool.sh

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -8,8 +8,8 @@ on:
       version:
         description: "Version to release"
         required: true
-      test_mode:
-        description: "Build test image"
+      dev_mode:
+        description: "Build development image"
         type: boolean
         default: false
         required: false
@@ -26,7 +26,7 @@ jobs:
       DHID: ${{ secrets.DOCKER_REPO || 'olakego' }}
       DRIVER: ${{ github.event.inputs.driver || 'mongodb' }}
       VERSION: ${{ github.event.inputs.version || 'v0.0.0.dev' }}
-      TEST_MODE: ${{ github.event.inputs.test_mode || 'false' }}
+      DEV_MODE: ${{ github.event.inputs.dev_mode || 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,11 +34,11 @@ jobs:
         run: echo "DRIVER=${{ env.DRIVER }}" >> $GITHUB_ENV
       - name: Set VERSION
         run: echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
-      - name: Set TEST_MODE
-        run: echo "TEST_MODE=${{ env.TEST_MODE }}" >> $GITHUB_ENV
+      - name: Set DEV_MODE
+        run: echo "DEV_MODE=${{ env.DEV_MODE }}" >> $GITHUB_ENV
       - name: Show VERSION
         run: |
-          echo "Building driver $DRIVER with version $VERSION (Test mode: $TEST_MODE)"
+          echo "Building driver $DRIVER with version $VERSION (Dev mode: $DEV_MODE)"
       - name: Run Release tool
         run: |
           chmod +x ./release-tool.sh

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -11,7 +11,7 @@ on:
       dev_mode:
         description: "Build development image"
         type: boolean
-        default: false
+        default: true
         required: false
 
 jobs:

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   publish_drivers:
-    if: github.ref == 'refs/heads/master' # Restrict to master branch
+    # if: github.ref == 'refs/heads/master' # Restrict to master branch
     name: Publish driver ${{ github.event.inputs.driver }} [manual]
     environment: Publish Driver
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -21,7 +21,6 @@ jobs:
       DHID: ${{ secrets.DOCKER_REPO || 'olakego' }}
       DRIVER: ${{ github.event.inputs.driver || 'mongodb' }}
       VERSION: ${{ github.event.inputs.version || 'v0.0.0.dev' }}
-      BRANCH_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -29,11 +28,9 @@ jobs:
         run: echo "DRIVER=${{ env.DRIVER }}" >> $GITHUB_ENV
       - name: Set VERSION
         run: echo "VERSION=${{ env.VERSION }}" >> $GITHUB_ENV
-      - name: Set BRANCH_NAME
-        run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}" >> $GITHUB_ENV
       - name: Show VERSION
         run: |
-          echo "Building driver $DRIVER with version $VERSION on branch $BRANCH_NAME"
+          echo "Building driver $DRIVER with version $VERSION"
       - name: Run Release tool
         run: |
           chmod +x ./release-tool.sh

--- a/.github/workflows/build-and-release-driver.yml
+++ b/.github/workflows/build-and-release-driver.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   publish_drivers:
-    # if: github.ref == 'refs/heads/master' # Restrict to master branch
     name: Publish driver ${{ github.event.inputs.driver }} [manual]
     environment: Publish Driver
     runs-on: ubuntu-latest

--- a/release-tool.sh
+++ b/release-tool.sh
@@ -71,7 +71,7 @@ SEMVER_EXPRESSION='v([0-9]+\.[0-9]+\.[0-9]+)$'
 STAGING_VERSION_EXPRESSION='v([0-9]+\.[0-9]+\.[0-9]+)-[a-zA-Z0-9_.-]+'
 
 echo "Release tool running..."
-CURRENT_BRANCH="${BRANCH_NAME:-master}"  # Use BRANCH_NAME from environment
+CURRENT_BRANCH=$(git branch --show-current)
 echo "Building on branch: $CURRENT_BRANCH"
 echo "Fetching remote changes from git with git fetch"
 git fetch origin "$CURRENT_BRANCH" >/dev/null 2>&1

--- a/release-tool.sh
+++ b/release-tool.sh
@@ -52,19 +52,16 @@ function release() {
     echo "Attempting multi-platform build..."
     
     # For dev images, only tag with the specified version, not 'latest'
+    local latest_tag="${image_name}:latest"
     if [[ "$is_dev" == "true" ]]; then
-        docker buildx build --platform "$platform" --push \
-            -t "${image_name}:${tag_version}" \
-            -t "${image_name}:dev-latest" \
-            --build-arg DRIVER_NAME="$connector" \
-            --build-arg DRIVER_VERSION="$VERSION" . || fail "Multi-platform build failed. Exiting..."
-    else
-        docker buildx build --platform "$platform" --push \
-            -t "${image_name}:${tag_version}" \
-            -t "${image_name}:latest" \
-            --build-arg DRIVER_NAME="$connector" \
-            --build-arg DRIVER_VERSION="$VERSION" . || fail "Multi-platform build failed. Exiting..."
+        latest_tag="${image_name}:dev-latest"
     fi
+    
+    docker buildx build --platform "$platform" --push \
+        -t "${image_name}:${tag_version}" \
+        -t "${latest_tag}" \
+        --build-arg DRIVER_NAME="$connector" \
+        --build-arg DRIVER_VERSION="$VERSION" . || fail "Multi-platform build failed. Exiting..."
     
     echo "$(chalk green "Release successful for $image_name version $tag_version")"
 }

--- a/release-tool.sh
+++ b/release-tool.sh
@@ -73,6 +73,8 @@ STAGING_VERSION_EXPRESSION='v([0-9]+\.[0-9]+\.[0-9]+)-[a-zA-Z0-9_.-]+'
 echo "Release tool running..."
 CURRENT_BRANCH="${BRANCH_NAME:-master}"  # Use BRANCH_NAME from environment
 echo "Building on branch: $CURRENT_BRANCH"
+echo "Fetching remote changes from git with git fetch"
+git fetch origin "$CURRENT_BRANCH" >/dev/null 2>&1
 GIT_COMMITSHA=$(git rev-parse HEAD | cut -c 1-8)
 echo "Latest commit SHA: $GIT_COMMITSHA"
 


### PR DESCRIPTION
# Description

This PR adds support for building test images by adding a new "test_mode" option to the driver release workflow. When enabled, it prefixes the image tag with "testing-" and bypasses semantic versioning requirements for the tag. This allows developers to build and test images with more flexible versioning schemes during development while maintaining strict semantic versioning for production releases.

The main changes include:
1. Added a new "test_mode" boolean input parameter to the GitHub workflow
2. Modified the release script to support test mode with "testing-" tag prefix
3. Implemented conditional version validation that skips semantic version checking for test images

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Build regular image with semantic versioning (e.g., v1.0.0)
  - Verify image is tagged as `olakego/source-mongodb:v1.0.0` and `olakego/source-mongodb:latest`
  - Confirm semantic version validation is enforced

- [x] Build test image with non-semantic versioning (e.g., dev-123)
  - Verify image is tagged as `olakego/source-mongodb:testing-dev-123`
  - Confirm semantic version validation is bypassed
  - Verify no "latest" tag is created for test images

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

**Example output when building test image:**
```
Test mode: true
✅ Test mode active - skipping semantic version validation for version: dev-123
...
**** Releasing olakego/source-mongodb for platforms [linux/amd64,linux/arm64] with version [testing-dev-123] ****
...
Release successful for olakego/source-mongodb version testing-dev-123
```

## Related PR's (If Any):
None
