### PR TITLE
Fix: Username required in config.json while is optional while creating a Mongo cluster

### DIFF
--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -46,9 +46,16 @@ func (c *Config) URI() string {
 		options = fmt.Sprintf("%s&replicaSet=%s&readPreference=%s", options, c.ReplicaSet, c.ReadPreference)
 	}
 
+	//  Handle auth credentials
+	auth := ""
+	if c.Username != "" {
+		auth = utils.Ternary(c.Password != "", fmt.Sprintf("%s:%s@", c.Username, c.Password), fmt.Sprintf("%s@", c.Username))
+	}
+
+	// Final MongoDB URI
 	return fmt.Sprintf(
-		"%s://%s:%s@%s/?%s", connectionPrefix,
-		c.Username, c.Password, strings.Join(c.Hosts, ","), options,
+		"%s://%s%s/%s",
+		connectionPrefix, auth, strings.Join(c.Hosts, ","), options,
 	)
 }
 


### PR DESCRIPTION
# Description

This pull request includes an important change to the `drivers/mongodb/internal/config.go` file, specifically to the `func (c *Config) URI() string {` function. The change ensures that the MongoDB URI only includes the username and password if they are set. This helps to avoid potential security issues and simplifies the connection string when authentication is not required.

Improvements to MongoDB URI construction:

* `drivers/mongodb/internal/config.go`: Modified the `URI` method to conditionally include the username and password in the MongoDB connection string only if they are set. This prevents the inclusion of empty credentials in the URI.

Fixes #107 

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Use the following `config.json` without username/password:
   ```json
   {
      "hosts": ["localhost:27017", "localhost:27018", "localhost:27019"],
      "replica_set": "rs0",
      "read_preference": "secondaryPreferred",
      "srv": false,
      "server_ram": 16,
      "database": "reddit",
      "max_threads": 50,
      "default_mode": "cdc",
      "backoff_retry_count": 2
   }
   ```
2. Attempt to generate the catalog file using the command:
   https://olake.io/docs/getting-started/mongodb#step-2-generate-a-catalog-file
  Mentioned here

3. Previously, it would throw an error requiring a username. After this fix, the connection should work as expected without authentication.
