### PR TITLE
fix: Added CMD_NOT_ALLOWED as splitVector fallback in Mongodb

### DIFF
--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -273,11 +273,9 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 	default:
 		chunks, err := splitVectorStrategy()
 		// check if authorization error occurs
-		if err != nil && strings.Contains(err.Error(), "not authorized") {
+		if err != nil && (strings.Contains(err.Error(), "not authorized") ||
+			strings.Contains(err.Error(), "CMD_NOT_ALLOWED")) {
 			logger.Warnf("failed to get chunks via split vector strategy: %s", err)
-			return bucketAutoStrategy()
-		}else if err != nil && strings.Contains(err.Error(), "CMD_NOT_ALLOWED") {
-			logger.Warnf("command is not allowed on MongoAtlas: %s", err.Error())
 			return bucketAutoStrategy()
 		}
 		return chunks, err

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -276,6 +276,9 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		if err != nil && strings.Contains(err.Error(), "not authorized") {
 			logger.Warnf("failed to get chunks via split vector strategy: %s", err)
 			return bucketAutoStrategy()
+		}else if err != nil && strings.Contains(err.Error(), "CMD_NOT_ALLOWED") {
+			logger.Warnf("command is not allowed on MongoAtlas: %s", err.Error())
+			return bucketAutoStrategy()
 		}
 		return chunks, err
 	}


### PR DESCRIPTION
# Description

Added a fallback to bucketAutoStrategy in the MongoDB backfill logic when the splitVector command is not allowed (common in MongoDB Atlas environments). 

Fixes: Compatibility issue with MongoDB Atlas where splitVector is not permitted (CMD_NOT_ALLOWED error).

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran full backfill on MongoDB Atlas replica set where splitVector is not allowed. Verified chunk generation falls back to bucketAutoStrategy and data loads successfully.


