### PR TITLE
fix: Fixing the logging color format for Iceberg sync failures

### DIFF
--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         run: $(go env GOPATH)/bin/gosec -exclude=G115 -severity=high -confidence=medium ./...
   trivy:
     name: trivy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect

--- a/writers/iceberg/iceberg.go
+++ b/writers/iceberg/iceberg.go
@@ -69,7 +69,7 @@ func (i *Iceberg) Write(_ context.Context, record types.RawRecord) error {
 func (i *Iceberg) Close() error {
 	err := flushBatch(i.configHash, i.client)
 	if err != nil {
-		logger.Infof("Error flushing batch on close: %v", err)
+		logger.Errorf("Error flushing batch on close: %v", err)
 		return err
 	}
 

--- a/writers/iceberg/iceberg_utils.go
+++ b/writers/iceberg/iceberg_utils.go
@@ -634,7 +634,8 @@ func sendRecords(records []string, client proto.RecordIngestServiceClient) error
 	// Send the batch to the server
 	res, err := client.SendRecords(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to send batch: %v", err)
+		logger.Errorf("failed to send batch: %v", err)
+		return err
 	}
 
 	logger.Infof("Sent batch to Iceberg server: %d records, response: %s",


### PR DESCRIPTION
# Description

The java error logs were not formatted properly in red color before. 

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Running the sync and intentionally breaking it because of unsupported data type changes in Iceberg.
