### PR TITLE
Add validation for key field IDs in schema

### DIFF
--- a/writers/iceberg/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/RecordConverter.java
+++ b/writers/iceberg/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/RecordConverter.java
@@ -425,7 +425,17 @@ public class RecordConverter {
         throw new RuntimeException("Failed to get schema from debezium event, event schema has no fields!");
       }
 
-      // @TODO validate key fields are correctly set!?
+      // Validate key fields
+      if (createIdentifierFields && !schemaData.identifierFieldIds().isEmpty()) {
+        LOGGER.debug("Validating key fields in schema: {}", schemaData.identifierFieldIds());
+        for (int keyFieldId : schemaData.identifierFieldIds()) {
+            boolean fieldExists = schemaData.fields().stream()
+                .anyMatch(field -> field.fieldId() == keyFieldId);
+            if (!fieldExists) {
+                throw new RuntimeException("Key field with ID " + keyFieldId + " is not present in the schema fields!");
+            }
+        }
+      }
       return new Schema(schemaData.fields(), schemaData.identifierFieldIds());
 
     }


### PR DESCRIPTION
# Description

This change addresses the validation of key fields within the schema before inserting records into the database. Specifically, the validation checks if the key fields are correctly set in the schema and if they match the current table schema. If a key field is missing, a RuntimeException is thrown to prevent any invalid record insertions.

Fixes: Issue with checking if the key fields are set correctly before insertion into the table schema.

Fixes #185 

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
