### PR TITLE
[WIP] feat: incremental mongodb sync

### DIFF
--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -10,19 +10,22 @@ import (
 )
 
 type Config struct {
-	Hosts             []string       `json:"hosts"`
-	Username          string         `json:"username"`
-	Password          string         `json:"password"`
-	AuthDB            string         `json:"authdb"`
-	ReplicaSet        string         `json:"replica_set"`
-	ReadPreference    string         `json:"read_preference"`
-	Srv               bool           `json:"srv"`
-	ServerRAM         uint           `json:"server_ram"`
-	MaxThreads        int            `json:"max_threads"`
-	Database          string         `json:"database"`
-	DefaultMode       types.SyncMode `json:"default_mode"`
-	RetryCount        int            `json:"backoff_retry_count"`
-	PartitionStrategy string         `json:"partition_strategy"`
+	Hosts             []string            `json:"hosts"`
+	Username          string              `json:"username"`
+	Password          string              `json:"password"`
+	AuthDB            string              `json:"authdb"`
+	ReplicaSet        string              `json:"replica_set"`
+	ReadPreference    string              `json:"read_preference"`
+	Srv               bool                `json:"srv"`
+	ServerRAM         uint                `json:"server_ram"`
+	MaxThreads        int                 `json:"max_threads"`
+	Database          string              `json:"database"`
+	DefaultMode       types.SyncMode      `json:"default_mode"`
+	RetryCount        int                 `json:"backoff_retry_count"`
+	PartitionStrategy string              `json:"partition_strategy"`
+	Incremental       IncrementalStrategy `json:"incremental_strategy,omitempty" mapstructure:"incremental_strategy"`
+	TrackingField     string              `json:"tracking_field,omitempty"       mapstructure:"tracking_field"`
+	BatchSize         int32               `json:"batch_size,omitempty"           mapstructure:"batch_size"`
 }
 
 func (c *Config) URI() string {
@@ -45,7 +48,6 @@ func (c *Config) URI() string {
 		}
 		options = fmt.Sprintf("%s&replicaSet=%s&readPreference=%s", options, c.ReplicaSet, c.ReadPreference)
 	}
-
 	//  Handle auth credentials
 	auth := ""
 	if c.Username != "" {
@@ -61,5 +63,11 @@ func (c *Config) URI() string {
 
 // TODO: Add go struct validation in Config
 func (c *Config) Validate() error {
+	if c.Incremental == "" {
+		c.Incremental = StrategyChangeStream // preserve current behaviour
+	}
+	if c.BatchSize == 0 {
+		c.BatchSize = 5000
+	}
 	return utils.Validate(c)
 }

--- a/drivers/mongodb/internal/constants.go
+++ b/drivers/mongodb/internal/constants.go
@@ -1,0 +1,15 @@
+package driver
+
+const (
+	cursorLastTS = "last_ts"
+	cursorLastID = "last_id"
+)
+
+type IncrementalStrategy string
+
+const (
+	StrategyChangeStream IncrementalStrategy = "change_stream" // default – existing behaviour
+	StrategyTimestamp    IncrementalStrategy = "timestamp"     // new
+	StrategyObjectID     IncrementalStrategy = "objectid"      // new
+	StrategySoftDelete   IncrementalStrategy = "soft_delete"   // new
+)

--- a/drivers/mongodb/internal/incremental.go
+++ b/drivers/mongodb/internal/incremental.go
@@ -1,0 +1,156 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/datazip-inc/olake/constants"
+	"github.com/datazip-inc/olake/logger"
+	"github.com/datazip-inc/olake/protocol"
+	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func (m *Mongo) incrementalSync(stream protocol.Stream, pool *protocol.WriterPool) error {
+	cfg := m.config
+	db, collName := stream.Namespace(), stream.Name()
+	coll := m.client.Database(db).Collection(collName)
+
+	// ---- hydrated checkpoint from State ------------
+	cstream := stream.Self() // *types.ConfiguredStream
+	var lastTS primitive.DateTime
+	var lastID primitive.ObjectID
+
+	if raw := m.State.GetCursor(cstream, cursorLastTS); raw != nil {
+		switch t := raw.(type) {
+		case primitive.DateTime:
+			lastTS = t
+		case string:
+			if parsed, err := time.Parse(time.RFC3339Nano, t); err == nil {
+				lastTS = primitive.NewDateTimeFromTime(parsed)
+			} else {
+				logger.Warnf("could not parse saved last_ts %q: %s", t, err)
+			}
+		default:
+			logger.Warnf("unexpected type for last_ts in state: %T", raw)
+		}
+	}
+	if raw := m.State.GetCursor(cstream, cursorLastID); raw != nil {
+		switch v := raw.(type) {
+		case primitive.ObjectID:
+			lastID = v
+		case string:
+			if oid, err := primitive.ObjectIDFromHex(v); err == nil {
+				lastID = oid
+			} else {
+				logger.Warnf("could not parse saved last_id %q: %s", v, err)
+			}
+		default:
+			logger.Warnf("unexpected type for last_id in state: %T", raw)
+		}
+	}
+
+	batch := cfg.BatchSize
+	if batch == 0 {
+		batch = 5000
+	}
+	trk := cfg.TrackingField
+	if trk == "" {
+		ac := stream.GetStream().AvailableCursorFields.Array()
+		if len(ac) == 1 {
+			trk = ac[0]
+		} else {
+			trk = "_id"
+		}
+	}
+
+	logger.Infof("incremental sync started on %s.%s (strategy=%s, batch=%d)", db, collName, cfg.Incremental, batch)
+
+	for {
+		var filter bson.M
+		findOpts := options.Find().SetBatchSize(batch)
+
+		switch cfg.Incremental {
+		case StrategyTimestamp:
+			filter = bson.M{trk: bson.M{"$gt": lastTS}}
+			findOpts.SetSort(bson.D{{Key: trk, Value: 1}})
+
+		case StrategyObjectID:
+			filter = bson.M{"_id": bson.M{"$gt": lastID}}
+			findOpts.SetSort(bson.D{{Key: "_id", Value: 1}})
+
+		case StrategySoftDelete:
+			filter = bson.M{
+				"$or": []bson.M{
+					{trk: bson.M{"$gt": lastTS}},
+					{"deleted": true, "deletedAt": bson.M{"$gt": lastTS}},
+				}}
+			findOpts.SetSort(bson.D{{Key: trk, Value: 1}})
+
+		default:
+			return fmt.Errorf("unknown incremental strategy %q", cfg.Incremental)
+		}
+
+		cur, err := coll.Find(context.TODO(), filter, findOpts)
+		if err != nil {
+			return err
+		}
+
+		thread, err := pool.NewThread(context.TODO(), stream)
+		if err != nil {
+			cur.Close(context.TODO())
+			return err
+		}
+
+		var processed int
+		for cur.Next(context.TODO()) {
+			var doc bson.M
+			_ = cur.Decode(&doc)
+			handleMongoObject(doc)
+
+			hash := utils.GetKeysHash(doc, constants.MongoPrimaryID)
+			if err := thread.Insert(types.CreateRawRecord(hash, doc, "r", time.Unix(0, 0))); err != nil {
+				cur.Close(context.TODO())
+				return err
+			}
+
+			// ---- advance in-memory checkpoint safely ----
+			switch cfg.Incremental {
+			case StrategyObjectID:
+				if hex, ok := doc["_id"].(string); ok {
+					if oid, err := primitive.ObjectIDFromHex(hex); err == nil {
+						lastID = oid
+					}
+				}
+			default: // timestamp & soft_delete
+				// handleMongoObject lower-cases keys → use trk in lower case
+				if tsRaw, ok := doc[strings.ToLower(trk)]; ok {
+					switch v := tsRaw.(type) {
+					case primitive.DateTime:
+						lastTS = v
+					case time.Time:
+						lastTS = primitive.NewDateTimeFromTime(v)
+					}
+				}
+			}
+			processed++
+		}
+		cur.Close(context.TODO())
+		thread.Close()
+
+		if processed > 0 {
+			m.State.SetCursor(cstream, cursorLastTS, lastTS)
+			if cfg.Incremental == StrategyObjectID || cfg.Incremental == StrategySoftDelete {
+				m.State.SetCursor(cstream, cursorLastID, lastID)
+			}
+			m.State.LogState()
+		} else {
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
# Description
Implemented query-based incremental sync for the MongoDB driver so that users without Change Streams (e.g. shared Atlas tiers or standalone servers) can still perform efficient incremental reads. This addresses the requirements in issue #161 by adding three sync strategies—timestamp, ObjectID, and soft-delete—and wiring up checkpointing in state.

Fixes #161 
Thing Implemented : 

- [X] Timestamp-based incremental sync (uses updatedAt > last_ts)
- [ ]  ObjectID-based incremental sync (uses _id > last_id)
- [ ]  Soft-delete support (tracks deleted: true / deletedAt > last_ts)
- [ ]  Configurable strategy, tracking field, and batch size in config.json
- [ ]  Batched, indexed queries with pagination
- [ ]  Checkpointing: persists and hydrates last_ts and last_id in state.json
- [ ]  Fallback full-refresh when tracking field is missing or invalid
- [ ]  Schema evolution detection (new or removed cursor fields)
- [ ]  Automated tests for all sync strategies
- [ ] Documentation