### PR TITLE
feat: added flatten, resolver and catalog tests

### DIFF
--- a/types/catalog_test.go
+++ b/types/catalog_test.go
@@ -1,0 +1,208 @@
+package types
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWrappedCatalog(t *testing.T) {
+	testCases := []struct {
+		name     string
+		streams  []*Stream
+		expected *Catalog
+	}{
+		{
+			name:    "empty streams",
+			streams: []*Stream{},
+			expected: &Catalog{
+				Streams:         []*ConfiguredStream{},
+				SelectedStreams: make(map[string][]StreamMetadata),
+			},
+		},
+		{
+			name: "single stream",
+			streams: []*Stream{
+				{
+					Name:      "test_stream",
+					Namespace: "test_namespace",
+				},
+			},
+			expected: &Catalog{
+				Streams: []*ConfiguredStream{
+					{
+						Stream: &Stream{
+							Name:      "test_stream",
+							Namespace: "test_namespace",
+						},
+					},
+				},
+				SelectedStreams: map[string][]StreamMetadata{
+					"test_namespace": {
+						{
+							StreamName:     "test_stream",
+							PartitionRegex: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple streams same namespace",
+			streams: []*Stream{
+				{
+					Name:      "stream1",
+					Namespace: "namespace1",
+				},
+				{
+					Name:      "stream2",
+					Namespace: "namespace1",
+				},
+			},
+			expected: &Catalog{
+				Streams: []*ConfiguredStream{
+					{
+						Stream: &Stream{
+							Name:      "stream1",
+							Namespace: "namespace1",
+						},
+					},
+					{
+						Stream: &Stream{
+							Name:      "stream2",
+							Namespace: "namespace1",
+						},
+					},
+				},
+				SelectedStreams: map[string][]StreamMetadata{
+					"namespace1": {
+						{
+							StreamName:     "stream1",
+							PartitionRegex: "",
+						},
+						{
+							StreamName:     "stream2",
+							PartitionRegex: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple streams different namespaces",
+			streams: []*Stream{
+				{
+					Name:      "stream1",
+					Namespace: "namespace1",
+				},
+				{
+					Name:      "stream2",
+					Namespace: "namespace2",
+				},
+			},
+			expected: &Catalog{
+				Streams: []*ConfiguredStream{
+					{
+						Stream: &Stream{
+							Name:      "stream1",
+							Namespace: "namespace1",
+						},
+					},
+					{
+						Stream: &Stream{
+							Name:      "stream2",
+							Namespace: "namespace2",
+						},
+					},
+				},
+				SelectedStreams: map[string][]StreamMetadata{
+					"namespace1": {
+						{
+							StreamName:     "stream1",
+							PartitionRegex: "",
+						},
+					},
+					"namespace2": {
+						{
+							StreamName:     "stream2",
+							PartitionRegex: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "stream with full properties",
+			streams: []*Stream{
+				{
+					Name:      "users",
+					Namespace: "public",
+					Schema: &TypeSchema{
+						Properties: sync.Map{},
+					},
+					SupportedSyncModes:      NewSet[SyncMode]("incremental", "full_refresh"),
+					SourceDefinedPrimaryKey: NewSet("id"),
+					AvailableCursorFields:   NewSet("updated_at"),
+					AdditionalProperties:    `{"replication_method": "incremental"}`,
+					SyncMode:                "incremental",
+				},
+			},
+			expected: &Catalog{
+				Streams: []*ConfiguredStream{
+					{
+						Stream: &Stream{
+							Name:      "users",
+							Namespace: "public",
+							Schema: &TypeSchema{
+								Properties: sync.Map{},
+							},
+							SupportedSyncModes:      NewSet[SyncMode]("incremental", "full_refresh"),
+							SourceDefinedPrimaryKey: NewSet("id"),
+							AvailableCursorFields:   NewSet("updated_at"),
+							AdditionalProperties:    `{"replication_method": "incremental"}`,
+							SyncMode:                "incremental",
+						},
+					},
+				},
+				SelectedStreams: map[string][]StreamMetadata{
+					"public": {
+						{
+							StreamName:     "users",
+							PartitionRegex: "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetWrappedCatalog(tc.streams)
+
+			// Verify the number of streams
+			assert.Equal(t, len(tc.expected.Streams), len(result.Streams), "Number of streams should match")
+
+			// Verify each stream
+			for i, expectedStream := range tc.expected.Streams {
+				assert.Equal(t, expectedStream.Stream.Name, result.Streams[i].Stream.Name, "Stream name should match")
+				assert.Equal(t, expectedStream.Stream.Namespace, result.Streams[i].Stream.Namespace, "Stream namespace should match")
+			}
+
+			// Verify selected streams
+			assert.Equal(t, len(tc.expected.SelectedStreams), len(result.SelectedStreams), "Number of namespaces should match")
+
+			for namespace, expectedMetadata := range tc.expected.SelectedStreams {
+				resultMetadata, exists := result.SelectedStreams[namespace]
+				assert.True(t, exists, "Namespace should exist in result")
+				assert.Equal(t, len(expectedMetadata), len(resultMetadata), "Number of streams in namespace should match")
+
+				for i, expected := range expectedMetadata {
+					assert.Equal(t, expected.StreamName, resultMetadata[i].StreamName, "Stream name in metadata should match")
+					assert.Equal(t, expected.PartitionRegex, resultMetadata[i].PartitionRegex, "Partition regex should match")
+				}
+			}
+		})
+	}
+}

--- a/typeutils/flatten_test.go
+++ b/typeutils/flatten_test.go
@@ -1,0 +1,289 @@
+package typeutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/datazip-inc/olake/types"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testUserID  = 12345
+	testName    = "John Doe"
+	testAge     = 30
+	testEnabled = true
+	testScore   = 92.5
+)
+
+var testTimestamp = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// TestFlattenerFlatten tests the Flatten method of Flattener interface
+func TestFlattenerFlatten(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       types.Record
+		expected    types.Record
+		expectError bool
+	}{
+		{
+			name: "flatten nested map",
+			input: types.Record{
+				"user": map[string]interface{}{
+					"name":  testName,
+					"age":   testAge,
+					"admin": testEnabled,
+				},
+				"stats": []int{1, 2, 3, 4, 5},
+				"metadata": map[string]interface{}{
+					"created_at": testTimestamp,
+				},
+			},
+			expected: types.Record{
+				"user":     `{"admin":true,"age":30,"name":"John Doe"}`,
+				"stats":    `[1,2,3,4,5]`,
+				"metadata": `{"created_at":"2023-01-01T00:00:00Z"}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "flatten simple values",
+			input: types.Record{
+				"name":    testName,
+				"age":     testAge,
+				"enabled": testEnabled,
+				"score":   testScore,
+			},
+			expected: types.Record{
+				"name":    testName,
+				"age":     testAge,
+				"enabled": testEnabled,
+				"score":   testScore,
+			},
+			expectError: false,
+		},
+		{
+			name: "flatten with special characters in keys",
+			input: types.Record{
+				"User@Name": testName,
+				"user-id":   testUserID,
+				"is.admin":  testEnabled,
+			},
+			expected: types.Record{
+				"user_name": testName,
+				"user_id":   testUserID,
+				"is_admin":  testEnabled,
+			},
+			expectError: false,
+		},
+		{
+			name: "flatten with time value",
+			input: types.Record{
+				"timestamp": testTimestamp,
+			},
+			expected: types.Record{
+				"timestamp": testTimestamp,
+			},
+			expectError: false,
+		},
+		{
+			name: "flatten with nil value",
+			input: types.Record{
+				"nullable": nil,
+			},
+			expected:    types.Record{},
+			expectError: false,
+		},
+		{
+			name: "flatten deeply nested maps with mixed types",
+			input: types.Record{
+				"user": map[string]interface{}{
+					"profile": map[string]interface{}{
+						"personal": map[string]interface{}{
+							"name": testName,
+							"age":  testAge,
+							"address": map[string]interface{}{
+								"city":    "New York",
+								"zipcode": 10001,
+								"details": map[string]interface{}{
+									"street": "test street",
+									"apt":    "5B",
+								},
+							},
+						},
+						"preferences": map[string]interface{}{
+							"notifications": true,
+							"theme":         "dark",
+						},
+					},
+					"stats": map[string]interface{}{
+						"visits": []int{1, 2, 3},
+						"score":  testScore,
+					},
+				},
+			},
+			expected: types.Record{
+				"user": `{"profile":{"personal":{"address":{"city":"New York","details":{"apt":"5B","street":"test street"},"zipcode":10001},"age":30,"name":"John Doe"},"preferences":{"notifications":true,"theme":"dark"}},"stats":{"score":92.5,"visits":[1,2,3]}}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "flatten nested maps with arrays and timestamps",
+			input: types.Record{
+				"data": map[string]interface{}{
+					"events": []map[string]interface{}{
+						{
+							"timestamp": testTimestamp,
+							"type":      "login",
+							"details": map[string]interface{}{
+								"ip":      "192.168.1.1",
+								"success": true,
+							},
+						},
+						{
+							"timestamp": testTimestamp.Add(time.Hour),
+							"type":      "logout",
+							"details": map[string]interface{}{
+								"duration": 3600,
+							},
+						},
+					},
+					"metadata": map[string]interface{}{
+						"version": "1.0",
+						"tags":    []string{"test", "nested"},
+					},
+				},
+			},
+			expected: types.Record{
+				"data": `{"events":[{"details":{"ip":"192.168.1.1","success":true},"timestamp":"2023-01-01T00:00:00Z","type":"login"},{"details":{"duration":3600},"timestamp":"2023-01-01T01:00:00Z","type":"logout"}],"metadata":{"tags":["test","nested"],"version":"1.0"}}`,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flattener := NewFlattener()
+
+			result, err := flattener.Flatten(tc.input)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+// TestFlattenerImplFlatten tests the internal flatten method
+func TestFlattenerImplFlatten(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		value       any
+		expected    types.Record
+		expectError bool
+	}{
+		{
+			name:  "test slice flattening",
+			key:   "testArray",
+			value: []string{"a", "b", "c"},
+			expected: types.Record{
+				"testarray": `["a","b","c"]`,
+			},
+			expectError: false,
+		},
+		{
+			name: "test map flattening",
+			key:  "testMap",
+			value: map[string]interface{}{
+				"nested_1": "value",
+				"nested_2": "value2",
+			},
+			expected: types.Record{
+				"testmap": `{"nested_1":"value","nested_2":"value2"}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "test primitive types",
+			key:  "testPrimitive",
+			value: map[string]interface{}{
+				"string":  "hello",
+				"int":     42,
+				"float":   3.14,
+				"boolean": true,
+			},
+			expected: types.Record{
+				"testprimitive": `{"boolean":true,"float":3.14,"int":42,"string":"hello"}`,
+			},
+			expectError: false,
+		},
+		{
+			name:  "test time value",
+			key:   "testTime",
+			value: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected: types.Record{
+				"testtime": time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			expectError: false,
+		},
+		{
+			name:        "test nil value with omitNilValues true",
+			key:         "testNil",
+			value:       nil,
+			expected:    types.Record{},
+			expectError: false,
+		},
+		{
+			name:  "test special characters in key",
+			key:   "Test@K-e_y#123",
+			value: "value",
+			expected: types.Record{
+				"test_k_e_y_123": "value",
+			},
+			expectError: false,
+		},
+		{
+			name: "test deeply nested map with multiple levels",
+			key:  "deeplyNested",
+			value: map[string]interface{}{
+				"level1": map[string]interface{}{
+					"level2": map[string]interface{}{
+						"level3": map[string]interface{}{
+							"level4": map[string]interface{}{
+								"final": "value",
+								"array": []int{1, 2, 3},
+								"nested": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: types.Record{
+				"deeplynested": `{"level1":{"level2":{"level3":{"level4":{"array":[1,2,3],"final":"value","nested":{"key":"value"}}}}}}`,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flattener := NewFlattener()
+			destination := make(types.Record)
+
+			err := flattener.(*FlattenerImpl).flatten(tc.key, tc.value, destination)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, destination)
+			}
+		})
+	}
+}

--- a/typeutils/resolver_test.go
+++ b/typeutils/resolver_test.go
@@ -1,0 +1,134 @@
+package typeutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/datazip-inc/olake/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolve(t *testing.T) {
+	testCases := []struct {
+		name     string
+		objects  []map[string]interface{}
+		expected map[string]struct {
+			dataType types.DataType
+			nullable bool
+		}
+	}{
+		{
+			name: "basic types",
+			objects: []map[string]interface{}{
+				{
+					"string_field": "test string",
+					"int_field":    int32(42),
+					"float_field":  float64(3.14),
+					"bool_field":   true,
+				},
+			},
+			expected: map[string]struct {
+				dataType types.DataType
+				nullable bool
+			}{
+				"string_field": {dataType: types.String, nullable: false},
+				"int_field":    {dataType: types.Int32, nullable: false},
+				"float_field":  {dataType: types.Float64, nullable: false},
+				"bool_field":   {dataType: types.Bool, nullable: false},
+			},
+		},
+		{
+			name: "nullable fields",
+			objects: []map[string]interface{}{
+				{
+					"field1": "value1",
+					"field2": int32(123),
+				},
+				{
+					"field1": "value2",
+					// field2 is missing, should be marked as nullable
+				},
+			},
+			expected: map[string]struct {
+				dataType types.DataType
+				nullable bool
+			}{
+				"field1": {dataType: types.String, nullable: false},
+				"field2": {dataType: types.Int32, nullable: true},
+			},
+		},
+		{
+			name: "complex types",
+			objects: []map[string]interface{}{
+				{
+					"array_field":  []int{1, 2, 3},
+					"object_field": map[string]interface{}{"key": "value"},
+					"time_field":   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expected: map[string]struct {
+				dataType types.DataType
+				nullable bool
+			}{
+				"array_field":  {dataType: types.Array, nullable: false},
+				"object_field": {dataType: types.Object, nullable: false},
+				"time_field":   {dataType: types.Timestamp, nullable: false},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a new stream for testing
+			stream := types.NewStream("test_stream", "test_namespace")
+
+			err := Resolve(stream, tc.objects...)
+
+			require.NoError(t, err)
+
+			for fieldName, expected := range tc.expected {
+				// Check if the field exists in the stream's schema
+				property, found := stream.Schema.Properties.Load(fieldName)
+				assert.True(t, found, "Field %s should exist in schema", fieldName)
+
+				if found {
+					prop := property.(*types.Property)
+					typeSet := *(prop.Type)
+
+					// Check field type
+					assert.True(t, typeSet.Exists(expected.dataType),
+						"Field %s should have type %s, got %v",
+						fieldName, expected.dataType, typeSet)
+
+					// Check nullability
+					if expected.nullable {
+						assert.True(t, typeSet.Exists(types.Null),
+							"Field %s should be nullable", fieldName)
+					} else {
+						assert.False(t, typeSet.Exists(types.Null),
+							"Field %s should not be nullable", fieldName)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestResolveWithEmptyInput tests the edge case of resolving with no objects
+func TestResolveWithEmptyInput(t *testing.T) {
+	stream := types.NewStream("empty_stream", "test_namespace")
+
+	err := Resolve(stream, []map[string]interface{}{}...)
+
+	assert.NoError(t, err)
+
+	assert.NotNil(t, stream.Schema)
+
+	count := 0
+	stream.Schema.Properties.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count, "Expected empty schema")
+}


### PR DESCRIPTION
# Description

This PR adds unit tests for the flatten, resolver and the catalog file logic. The tests cover various scenarios.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Running tests added for flatten, resolver and catalog file, using the command 
` go test -v -run <test_name>`
- Verified coverage increase using 
`go test -coverprofile`
