### PR TITLE
fix: support MySQL RDS v8.4 for CDC

### DIFF
--- a/drivers/mysql/internal/cdc.go
+++ b/drivers/mysql/internal/cdc.go
@@ -192,15 +192,15 @@ func parseMySQLVersion(version string) (int, int, error) {
 	if len(parts) < 2 {
 		return 0, 0, fmt.Errorf("invalid version format")
 	}
-	major, err := strconv.Atoi(parts[0])
+	majorVersion, err := strconv.Atoi(parts[0])
 	if err != nil {
 		return 0, 0, fmt.Errorf("invalid major version: %s", err)
 	}
 
-	minor, err := strconv.Atoi(parts[1])
+	minorVersion, err := strconv.Atoi(parts[1])
 	if err != nil {
 		return 0, 0, fmt.Errorf("invalid minor version: %s", err)
 	}
 
-	return major, minor, nil
+	return majorVersion, minorVersion, nil
 }

--- a/drivers/mysql/internal/cdc.go
+++ b/drivers/mysql/internal/cdc.go
@@ -149,9 +149,14 @@ func (m *MySQL) RunChangeStream(pool *protocol.WriterPool, streams ...protocol.S
 
 // getCurrentBinlogPosition retrieves the current binlog position from MySQL.
 func (m *MySQL) getCurrentBinlogPosition() (mysql.Position, error) {
+	// MySQL v8.1 and below
 	rows, err := m.client.Query(jdbc.MySQLMasterStatusQuery())
 	if err != nil {
-		return mysql.Position{}, fmt.Errorf("failed to get master status: %s", err)
+		// MySQL v8.2 and above
+		rows, err = m.client.Query(jdbc.MySQLMasterStatusQueryNew())
+		if err != nil {
+			return mysql.Position{}, fmt.Errorf("failed to get master status: %s", err)
+		}
 	}
 	defer rows.Close()
 

--- a/drivers/mysql/internal/cdc.go
+++ b/drivers/mysql/internal/cdc.go
@@ -160,12 +160,12 @@ func (m *MySQL) getCurrentBinlogPosition() (mysql.Position, error) {
 		return mysql.Position{}, fmt.Errorf("failed to get MySQL version: %s", err)
 	}
 	// Parse MySQL version to get major and minor version
-	major, minor, err := parseMySQLVersion(version)
+	majorVersion, minorVersion, err := parseMySQLVersion(version)
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("failed to parse MySQL version: %s", err)
 	}
 	// Use the appropriate query based on the MySQL version
-	query := utils.Ternary(major > 8 || (major == 8 && minor >= 4), jdbc.MySQLMasterStatusQueryNew(), jdbc.MySQLMasterStatusQuery()).(string)
+	query := utils.Ternary(majorVersion > 8 || (majorVersion == 8 && minorVersion >= 4), jdbc.MySQLMasterStatusQueryNew(), jdbc.MySQLMasterStatusQuery()).(string)
 
 	rows, err := m.client.Query(query)
 	if err != nil {

--- a/drivers/mysql/internal/cdc.go
+++ b/drivers/mysql/internal/cdc.go
@@ -157,7 +157,7 @@ func (m *MySQL) getCurrentBinlogPosition() (mysql.Position, error) {
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("failed to get MySQL version: %s", err)
 	}
-	// Compare MySQL version
+	// Compare current MySQL version with version 8.4
 	versionCompare, err := jdbc.CompareMySQLVersion(version, "8.4")
 	if err != nil {
 		return mysql.Position{}, fmt.Errorf("failed to compare MySQL version: %s", err)

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -181,7 +181,6 @@ func MySQLVersion(client *sql.DB) (int, int, error) {
 	}
 
 	return majorVersion, minorVersion, nil
-
 }
 
 func WithIsolation(ctx context.Context, client *sql.DB, fn func(tx *sql.Tx) error) error {

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/datazip-inc/olake/protocol"
 	"github.com/datazip-inc/olake/types"
@@ -137,12 +135,12 @@ func MySQLTableRowsQuery() string {
 	`
 }
 
-// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL: mysql v8.1 and below
+// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL: mysql v8.3 and below
 func MySQLMasterStatusQuery() string {
 	return "SHOW MASTER STATUS"
 }
 
-// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL: mysql v8.2 and above
+// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL: mysql v8.4 and above
 func MySQLMasterStatusQueryNew() string {
 	return "SHOW BINARY LOG STATUS"
 }
@@ -160,57 +158,12 @@ func MySQLTableColumnsQuery() string {
 // MySQLVersion returns the version of the MySQL server
 func MySQLVersion(client *sql.DB) (string, error) {
 	var version string
-	err := client.QueryRow("SELECT SUBSTRING_INDEX(VERSION(), '-', 1)").Scan(&version)
+	err := client.QueryRow("SELECT @@version").Scan(&version)
 	if err != nil {
 		return "", fmt.Errorf("failed to get MySQL version: %w", err)
 	}
 
 	return version, nil
-}
-
-// CompareMySQLVersion compares the MySQL version with the minimum version
-// Returns 0 if the v1 is equal to the v2
-// Returns 1 if the v1 is greater than the v2
-// Returns -1 if the v1 is less than the v2
-func CompareMySQLVersion(v1 string, v2 string) (int, error) {
-	v1Parts := strings.Split(v1, ".")
-	v2Parts := strings.Split(v2, ".")
-
-	if len(v1Parts) < 2 || len(v2Parts) < 2 {
-		return 0, fmt.Errorf("invalid version format")
-	}
-
-	major1, err := strconv.Atoi(v1Parts[0])
-	if err != nil {
-		return 0, fmt.Errorf("invalid major version: %w", err)
-	}
-	minor1, err := strconv.Atoi(v1Parts[1])
-	if err != nil {
-		return 0, fmt.Errorf("invalid minor version: %w", err)
-	}
-
-	major2, err := strconv.Atoi(v2Parts[0])
-	if err != nil {
-		return 0, fmt.Errorf("invalid major version: %w", err)
-	}
-	minor2, err := strconv.Atoi(v2Parts[1])
-	if err != nil {
-		return 0, fmt.Errorf("invalid minor version: %w", err)
-	}
-
-	if major1 > major2 {
-		return 1, nil
-	}
-	if major1 < major2 {
-		return -1, nil
-	}
-	if minor1 > minor2 {
-		return 1, nil
-	}
-	if minor1 < minor2 {
-		return -1, nil
-	}
-	return 0, nil
 }
 
 func WithIsolation(ctx context.Context, client *sql.DB, fn func(tx *sql.Tx) error) error {

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -135,9 +135,14 @@ func MySQLTableRowsQuery() string {
 	`
 }
 
-// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL
+// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL: mysql v8.1 and below
 func MySQLMasterStatusQuery() string {
 	return "SHOW MASTER STATUS"
+}
+
+// MySQLMasterStatusQuery returns the query to fetch the current binlog position in MySQL: mysql v8.2 and above
+func MySQLMasterStatusQueryNew() string {
+	return "SHOW BINARY LOG STATUS"
 }
 
 // MySQLTableColumnsQuery returns the query to fetch column names of a table in MySQL


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
"SHOW MASTER STATUS" mysql command has been deprecated (https://dev.mysql.com/doc/refman/8.4/en/show-master-status.html). Instead "SHOW BINARY LOG STATUS" is used in mysql v8.2.0 and newer versions.

Fixes #243 

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

This has been tested with CDC and full_refresh modes using MySQL versions both above and below v8.2.0 as the source.
