### PR TITLE
fix: add tls_skip_verify support in mysql

### DIFF
--- a/drivers/mysql/internal/config.go
+++ b/drivers/mysql/internal/config.go
@@ -39,14 +39,21 @@ func (c *Config) URI() string {
 		hostStr = "localhost"
 	}
 
+	// Add TLS parameters
+	tlsParam := "tls=true"
+	if c.TLSSkipVerify {
+		tlsParam = "tls=skip-verify"
+	}
+
 	// Construct full connection string
 	return fmt.Sprintf(
-		"%s:%s@tcp(%s:%d)/%s",
+		"%s:%s@tcp(%s:%d)/%s?%s",
 		url.QueryEscape(c.Username),
 		url.QueryEscape(c.Password),
 		hostStr,
 		c.Port,
 		url.QueryEscape(c.Database),
+		tlsParam,
 	)
 }
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
## Fix TLS Configuration for Database Connections
Added proper TLS parameters to the database connection string to ensure secure connections. The fix enables skipping verification when `tls_skip_verify` is set to true.


Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

