### PR TITLE
feat: add timestamp-based CDC resume for MongoDB

### DIFF
--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	DefaultMode       types.SyncMode `json:"default_mode"`
 	RetryCount        int            `json:"backoff_retry_count"`
 	PartitionStrategy string         `json:"partition_strategy"`
+	StategenTimestamp string         `json:"stategen_timestamp"`
 }
 
 func (c *Config) URI() string {


### PR DESCRIPTION
# Description

This PR adds the ability to resume CDC (Change Data Capture) operations from a specific timestamp in MongoDB. This is particularly useful when:
- You need to start CDC from a known point in time
- You want to skip the initial backfill process
- You need to recover from a specific point after a failure or deletion of state file

## Type of change

<!--
Please delete options that are not relevant. -->

- [] New feature (non-breaking change which adds functionality)
- [] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested with MongoDB Atlas:
  - CDC sync with fresh state (no state file)
  - CDC sync with existing state file
  - CDC sync with timestamp flag and fresh state
  - CDC sync with timestamp flag and existing state

- [x] Tested with Local Replica Set:
  - CDC sync with fresh state (no state file)
  - CDC sync with existing state file
  - CDC sync with timestamp flag and fresh state
  - CDC sync with timestamp flag and existing state

- [x] Additional Test Cases:
  - Verified that backfill is skipped when using timestamp
  - Verified proper cursor handling
  - Verified that no resume tokens are skipped during CDC sync