### PR TITLE
feat: added chunking strategies for no primary key tables, and enhanced existing strategy to support composite primary keys.

### DIFF
--- a/drivers/mysql/internal/backfill.go
+++ b/drivers/mysql/internal/backfill.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/datazip-inc/olake/logger"
@@ -28,12 +29,64 @@ func (m *MySQL) backfill(pool *protocol.WriterPool, stream protocol.Stream) erro
 	}
 	pool.AddRecordsToSync(approxRowCount)
 	// Get primary key column
-	pkColumns := stream.GetStream().SourceDefinedPrimaryKey
-	if pkColumns.Len() == 0 {
-		return fmt.Errorf("no primary key defined for stream %s", stream.Name())
+	pkColumns := stream.GetStream().SourceDefinedPrimaryKey.Array()
+	sort.Strings(pkColumns)
+
+	if len(pkColumns) == 0 && m.config.SelectAll {
+		logger.Infof("Chunking without primary key for stream %s, running SELECT ALL Strategy", stream.ID())
+		// Handle tables without primary keys using select all strategy
+		batchStartTime := time.Now()
+		waitChannel := make(chan error, 1)
+		insert, err := pool.NewThread(backfillCtx, stream, protocol.WithErrorChannel(waitChannel), protocol.WithBackfill(true))
+		if err != nil {
+			return fmt.Errorf("failed to create writer thread: %s", err)
+		}
+		defer func() {
+			insert.Close()
+			if err == nil {
+				// Wait for completion
+				err = <-waitChannel
+			}
+			// Log completion
+			if err == nil {
+				logger.Infof("Select all completed in %0.2f seconds", time.Since(batchStartTime).Seconds())
+			}
+		}()
+
+		return jdbc.WithIsolation(backfillCtx, m.client, func(tx *sql.Tx) error {
+
+			stmt := jdbc.SelectAllQuery(stream)
+			logger.Debugf("Select All Query for stream %s: %s", stream.ID(), stmt)
+			setter := jdbc.NewReader(backfillCtx, stmt, 0, func(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+				return tx.QueryContext(ctx, query, args...)
+			})
+			// Capture and process rows
+			return setter.Capture(func(rows *sql.Rows) error {
+				//create a map to hold column names and values
+				record := make(types.Record)
+				//scan the row into map
+				err := jdbc.MapScan(rows, record, m.dataTypeConverter)
+				if err != nil {
+					return fmt.Errorf("failed to mapScan record data: %s", err)
+				}
+
+				// Generate olake id using all columns since no primary key exists
+				allColumns := make([]string, 0, len(record))
+				for k := range record {
+					allColumns = append(allColumns, k)
+				}
+				olakeID := utils.GetKeysHash(record, allColumns...)
+
+				//insert record
+				err = insert.Insert(types.CreateRawRecord(olakeID, record, "r", time.Unix(0, 0)))
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+		})
 	}
-	// currently only support single primary key chunking
-	pkColumn := pkColumns.Array()[0]
+
 	// Get chunks from state or calculate new ones
 	stateChunks := m.State.GetChunks(stream.Self())
 	var splitChunks []types.Chunk
@@ -57,115 +110,234 @@ func (m *MySQL) backfill(pool *protocol.WriterPool, stream protocol.Stream) erro
 
 	// Process chunks concurrently
 	processChunk := func(ctx context.Context, chunk types.Chunk, number int) (err error) {
-		// Track batch start time for logging
-		batchStartTime := time.Now()
-		waitChannel := make(chan error, 1)
-		insert, err := pool.NewThread(backfillCtx, stream, protocol.WithErrorChannel(waitChannel), protocol.WithBackfill(true))
-		if err != nil {
-			return fmt.Errorf("failed to create writer thread: %s", err)
+
+		if stream.GetStream().SourceDefinedPrimaryKey.Len() == 0 {
+
+			// Track batch start time for logging
+			batchStartTime := time.Now()
+			waitChannel := make(chan error, 1)
+			insert, err := pool.NewThread(backfillCtx, stream, protocol.WithErrorChannel(waitChannel), protocol.WithBackfill(true))
+			if err != nil {
+				return fmt.Errorf("failed to create writer thread: %s", err)
+			}
+
+			defer func() {
+				insert.Close()
+				if err == nil {
+					// Wait for chunk completion
+					err = <-waitChannel
+				}
+
+				// Log completion and update state if successful
+				if err == nil {
+					logger.Infof("rows from %s to %s completed in %0.2f seconds", chunk.Min, chunk.Max, time.Since(batchStartTime).Seconds())
+					m.State.RemoveChunk(stream.Self(), chunk)
+				}
+			}()
+			// Begin transaction with repeatable read isolation
+			return jdbc.WithIsolation(backfillCtx, m.client, func(tx *sql.Tx) error {
+				// Build query for the chunk
+				stmt := jdbc.MysqlLimitOffsetScanQuery(stream, pkColumns, chunk)
+				setter := jdbc.NewReader(backfillCtx, stmt, 0, func(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+					return tx.QueryContext(ctx, query, args...)
+				})
+				// Capture and process rows
+				return setter.Capture(func(rows *sql.Rows) error {
+					//create a map to hold column names and values
+					record := make(types.Record)
+					//scan the row into map
+					err := jdbc.MapScan(rows, record, m.dataTypeConverter)
+					if err != nil {
+						return fmt.Errorf("failed to mapScan record data: %s", err)
+					}
+					// TODO : create hash from all keys if primary key not present
+					//generate olake id
+					olakeID := utils.GetKeysHash(record, stream.GetStream().SourceDefinedPrimaryKey.Array()...)
+					//insert record
+					err = insert.Insert(types.CreateRawRecord(olakeID, record, "r", time.Unix(0, 0)))
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+			})
+
+		} else {
+			// Track batch start time for logging
+			batchStartTime := time.Now()
+			waitChannel := make(chan error, 1)
+			insert, err := pool.NewThread(backfillCtx, stream, protocol.WithErrorChannel(waitChannel), protocol.WithBackfill(true))
+			if err != nil {
+				return fmt.Errorf("failed to create writer thread: %s", err)
+			}
+			defer func() {
+				insert.Close()
+				if err == nil {
+					// Wait for chunk completion
+					err = <-waitChannel
+				}
+				// Log completion and update state if successful
+				if err == nil {
+					logger.Infof("chunk[%d] with min[%v]-max[%v] completed in %0.2f seconds", number, chunk.Min, chunk.Max, time.Since(batchStartTime).Seconds())
+					m.State.RemoveChunk(stream.Self(), chunk)
+				}
+			}()
+			// Begin transaction with repeatable read isolation
+			return jdbc.WithIsolation(backfillCtx, m.client, func(tx *sql.Tx) error {
+				// Build query for the chunk
+				stmt := jdbc.MysqlChunkScanQuery(stream, pkColumns, chunk)
+				setter := jdbc.NewReader(backfillCtx, stmt, 0, func(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+					return tx.QueryContext(ctx, query, args...)
+				})
+				// Capture and process rows
+				return setter.Capture(func(rows *sql.Rows) error {
+					//create a map to hold column names and values
+					record := make(types.Record)
+					//scan the row into map
+					err := jdbc.MapScan(rows, record, m.dataTypeConverter)
+					if err != nil {
+						return fmt.Errorf("failed to mapScan record data: %s", err)
+					}
+					// TODO : create hash from all keys if primary key not present
+					//generate olake id
+					olakeID := utils.GetKeysHash(record, stream.GetStream().SourceDefinedPrimaryKey.Array()...)
+					//insert record
+					err = insert.Insert(types.CreateRawRecord(olakeID, record, "r", time.Unix(0, 0)))
+					if err != nil {
+						return err
+					}
+					return nil
+				})
+			})
 		}
-		defer func() {
-			insert.Close()
-			if err == nil {
-				// Wait for chunk completion
-				err = <-waitChannel
-			}
-			// Log completion and update state if successful
-			if err == nil {
-				logger.Infof("chunk[%d] with min[%v]-max[%v] completed in %0.2f seconds", number, chunk.Min, chunk.Max, time.Since(batchStartTime).Seconds())
-				m.State.RemoveChunk(stream.Self(), chunk)
-			}
-		}()
-		// Begin transaction with repeatable read isolation
-		return jdbc.WithIsolation(backfillCtx, m.client, func(tx *sql.Tx) error {
-			// Build query for the chunk
-			stmt := jdbc.MysqlChunkScanQuery(stream, pkColumn, chunk)
-			setter := jdbc.NewReader(backfillCtx, stmt, 0, func(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-				return tx.QueryContext(ctx, query, args...)
-			})
-			// Capture and process rows
-			return setter.Capture(func(rows *sql.Rows) error {
-				//crrate a map to hold column names and values
-				record := make(types.Record)
-				//scan the row into map
-				err := jdbc.MapScan(rows, record, m.dataTypeConverter)
-				if err != nil {
-					return fmt.Errorf("failed to mapScan record data: %s", err)
-				}
-				// TODO : create hash from all keys if primary key not present
-				//genrate olake id
-				olakeID := utils.GetKeysHash(record, stream.GetStream().SourceDefinedPrimaryKey.Array()...)
-				//insert record
-				err = insert.Insert(types.CreateRawRecord(olakeID, record, "r", time.Unix(0, 0)))
-				if err != nil {
-					return err
-				}
-				return nil
-			})
-		})
 	}
 
 	return utils.Concurrent(backfillCtx, splitChunks, m.config.MaxThreads, processChunk)
 }
 
 func (m *MySQL) splitChunks(stream protocol.Stream, chunks *types.Set[types.Chunk]) error {
-	return jdbc.WithIsolation(context.Background(), m.client, func(tx *sql.Tx) error {
-		// Get primary key column using the provided function
-		pkColumn := stream.GetStream().SourceDefinedPrimaryKey.Array()[0]
-		// Get table extremes
-		minVal, maxVal, err := m.getTableExtremes(stream, pkColumn, tx)
-		if err != nil {
-			return err
-		}
-		if minVal == nil {
-			return nil
-		}
-		chunks.Insert(types.Chunk{
-			Min: nil,
-			Max: utils.ConvertToString(minVal),
-		})
 
-		logger.Infof("Stream %s extremes - min: %v, max: %v", stream.ID(), utils.ConvertToString(minVal), utils.ConvertToString(maxVal))
+	splitViaPrimaryKey := func(stream protocol.Stream, chunks *types.Set[types.Chunk]) error {
+		return jdbc.WithIsolation(context.Background(), m.client, func(tx *sql.Tx) error {
+			// Get primary key columns
+			pkColumns := stream.GetStream().SourceDefinedPrimaryKey.Array()
+			sort.Strings(pkColumns)
+			// Get table extremes
+			minVal, maxVal, err := m.getTableExtremes(stream, pkColumns, tx)
 
-		// Calculate optimal chunk size based on table statistics
-		chunkSize, err := m.calculateChunkSize(stream)
-		if err != nil {
-			return fmt.Errorf("failed to calculate chunk size: %w", err)
-		}
-
-		// Generate chunks based on range
-		query := jdbc.NextChunkEndQuery(stream, pkColumn, chunkSize)
-
-		currentVal := minVal
-		for {
-			var nextValRaw interface{}
-			err := tx.QueryRow(query, currentVal).Scan(&nextValRaw)
-			if err != nil && err == sql.ErrNoRows || nextValRaw == nil {
-				break
-			} else if err != nil {
-				return fmt.Errorf("failed to get next chunk end: %w", err)
+			if err != nil {
+				return err
 			}
-			if currentVal != nil && nextValRaw != nil {
+			if minVal == nil {
+				return nil
+			}
+			chunks.Insert(types.Chunk{
+				Min: nil,
+				Max: utils.ConvertToString(minVal),
+			})
+
+			logger.Infof("Stream %s extremes - min: %v, max: %v", stream.ID(), utils.ConvertToString(minVal), utils.ConvertToString(maxVal))
+
+			// Calculate optimal chunk size based on table statistics
+			chunkSize, err := m.calculateChunkSize(stream)
+			if err != nil {
+				return fmt.Errorf("failed to calculate chunk size: %w", err)
+			}
+
+			// Generate chunks based on range
+			query := jdbc.NextChunkEndQuery(stream, pkColumns, chunkSize)
+
+			currentVal := minVal
+
+			for {
+				// Split the current value into parts
+				parts := strings.Split(utils.ConvertToString(currentVal), ",")
+
+				// Create args array with the correct number of arguments for the query
+				args := make([]interface{}, 0)
+				for i := 0; i < len(pkColumns); i++ {
+					// For each column combination in the WHERE clause, we need to add the necessary parts
+					for j := 0; j <= i; j++ {
+						if j < len(parts) {
+							args = append(args, parts[j])
+						}
+					}
+				}
+
+				var nextValRaw interface{}
+				err := tx.QueryRow(query, args...).Scan(&nextValRaw)
+				if err != nil && err == sql.ErrNoRows || nextValRaw == nil {
+					break
+				} else if err != nil {
+					return fmt.Errorf("failed to get next chunk end: %w", err)
+				}
+				if currentVal != nil && nextValRaw != nil {
+					chunks.Insert(types.Chunk{
+						Min: utils.ConvertToString(currentVal),
+						Max: utils.ConvertToString(nextValRaw),
+					})
+				}
+
+				currentVal = nextValRaw
+			}
+			if currentVal != nil {
 				chunks.Insert(types.Chunk{
 					Min: utils.ConvertToString(currentVal),
-					Max: utils.ConvertToString(nextValRaw),
+					Max: nil,
 				})
 			}
-			currentVal = nextValRaw
-		}
-		if currentVal != nil {
+
+			return nil
+		})
+	}
+
+	limitOffsetChunking := func(stream protocol.Stream, chunks *types.Set[types.Chunk]) error {
+		return jdbc.WithIsolation(context.Background(), m.client, func(tx *sql.Tx) error {
+
+			chunkSize, err := m.calculateChunkSize(stream)
+			if err != nil {
+				return fmt.Errorf("failed to calculate chunk size: %w", err)
+			}
+
+			query := jdbc.CalculateTotalRows(stream)
+			var totalRows int
+			logger.Infof("Query for total rows: %s", query)
+			err = m.client.QueryRow(query).Scan(&totalRows)
+			if err != nil {
+				return fmt.Errorf("failed to calculate total Rows: %w", err)
+			}
+
 			chunks.Insert(types.Chunk{
-				Min: utils.ConvertToString(currentVal),
+				Min: nil,
+				Max: utils.ConvertToString(chunkSize),
+			})
+			lastChunk := chunkSize
+			for lastChunk < totalRows {
+				chunks.Insert(types.Chunk{
+					Min: utils.ConvertToString(lastChunk),
+					Max: utils.ConvertToString(lastChunk + chunkSize),
+				})
+				lastChunk += chunkSize
+			}
+			chunks.Insert(types.Chunk{
+				Min: utils.ConvertToString(lastChunk),
 				Max: nil,
 			})
-		}
+			return nil
+		})
+	}
 
-		return nil
-	})
+	if stream.GetStream().SourceDefinedPrimaryKey.Len() > 0 {
+		logger.Infof("Chunking with primary key for stream %s, running Primary Key Chunking", stream.ID())
+		return splitViaPrimaryKey(stream, chunks)
+	} else {
+		logger.Infof("Chunking without primary key for stream %s, running Limit Offset Chunking Strategy", stream.ID())
+		return limitOffsetChunking(stream, chunks)
+	}
 }
 
-func (m *MySQL) getTableExtremes(stream protocol.Stream, pkColumn string, tx *sql.Tx) (min, max any, err error) {
-	query := jdbc.MinMaxQuery(stream, pkColumn)
+func (m *MySQL) getTableExtremes(stream protocol.Stream, pkColumns []string, tx *sql.Tx) (min, max any, err error) {
+	query := jdbc.MinMaxQueryMySQL(stream, pkColumns)
 	err = tx.QueryRow(query).Scan(&min, &max)
 	if err != nil {
 		return "", "", err
@@ -180,5 +352,6 @@ func (m *MySQL) calculateChunkSize(stream protocol.Stream) (int, error) {
 		return 0, fmt.Errorf("failed to get estimated records count:%v", err)
 	}
 	// number of chunks based on max threads
-	return totalRecords / (m.config.MaxThreads * 8), nil
+	chunkSize := totalRecords / (m.config.MaxThreads * 8)
+	return utils.Ternary(chunkSize>0, chunkSize, 1).(int), nil
 }

--- a/drivers/mysql/internal/config.go
+++ b/drivers/mysql/internal/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	DefaultMode   types.SyncMode `json:"default_mode"`
 	MaxThreads    int            `json:"max_threads"`
 	RetryCount    int            `json:"backoff_retry_count"`
+	SelectAll      bool         `json:"select_all"`
 }
 type CDC struct {
 	InitialWaitTime int `json:"intial_wait_time"`


### PR DESCRIPTION
# Description

This PR enhances Olake's table synchronization capabilities in two key ways:

1. **Enhanced Primary Key Support**
   - Improved existing strategy to handle composite primary keys
   - Added sorting of primary key columns for consistent ordering
   - Optimized chunk size calculation based on table size and thread count

2. **New Strategies for Tables Without Primary Keys**
   - Implemented `Limit Offset` and `Select All` strategy
   - Added configuration option to choose between strategies
## Type of change

<!--
Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Running the sync using all the strategies available and ensuring that all the data has been synced properly without missing any row or having a duplicate row.

