### PR TITLE
support for s3 table bucket with aws signing V4

### DIFF
--- a/writers/iceberg/config.go
+++ b/writers/iceberg/config.go
@@ -57,6 +57,11 @@ type Config struct {
 	JarPath         string `json:"sink_jar_path,omitempty"`        // Path to the Iceberg sink JAR
 	ServerHost      string `json:"sink_rpc_server_host,omitempty"` // gRPC server host
 
+	// S3 Table Bucket Config
+	RestSigningName   string `json:"rest_signing_name,omitempty"`
+	RestSigningRegion string `json:"rest_signing_region,omitempty"`
+	RestSigningV4     string `json:"rest_signing_v_4,omitempty"`
+
 	Normalization bool `json:"normalization,omitempty"`
 }
 

--- a/writers/iceberg/iceberg_utils.go
+++ b/writers/iceberg/iceberg_utils.go
@@ -222,6 +222,9 @@ func (i *Iceberg) getServerConfigJSON(port int, upsert bool) ([]byte, error) {
 	case RestCatalog:
 		serverConfig["catalog-impl"] = "org.apache.iceberg.rest.RESTCatalog"
 		serverConfig["uri"] = i.config.RestCatalogURL
+		serverConfig["rest.signing-name"] = i.config.RestSigningName
+		serverConfig["rest.signing-region"] = i.config.RestSigningRegion
+		serverConfig["rest.sigv4-enabled"] = i.config.RestSigningV4
 
 	default:
 		return nil, fmt.Errorf("unsupported catalog type: %s", i.config.CatalogType)


### PR DESCRIPTION
# Description

support for s3 table bucket with aws signing V4

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

-
- [ x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

after these changes I have ran a sync using postgres driver

here is the destination.json file content

`{
  "type": "ICEBERG",
  "writer": {
    "catalog_type": "rest",
    "rest_catalog_url": "https://s3tables.us-east-1.amazonaws.com/iceberg",
    "iceberg_s3_path": "arn:aws:s3tables:us-east-1:<account_id>:bucket/<table_bucket_name>",
    "iceberg_db": "<namespace>",
    "aws_access_key": "",
    "aws_secret_key": "",
    "aws_region": "us-east-1",
    "rest_signing_name": "s3tables",
    "rest_signing_region": "us-east-1",
    "rest_signing_v_4": "true"
  }
}`


change <account_id> and <table_bucket_name>" with actual values and pass the destination namespace.

# Screenshots or Recordings

![image](https://github.com/user-attachments/assets/78ddd9de-1aa1-4a7c-8410-e68502dc145a)


