### PR TITLE
feat: support for s3 table bucket with aws signing V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We have additionally planned the following sources -  [AWS S3](https://github.co
 | Glue Catalog               | Supported                                                                                                      |
 | Hive Meta Store            | Supported                                                                                                 |
 | JDBC Catalogue             | Supported                                                                                                 |
-| REST Catalogue             | Supported                                                                                                 |
+| REST Catalogue             | Supported (with AWS S3 table)                                                                                                |
 | Azure Purview              | Not Planned, [submit a request](https://github.com/datazip-inc/olake/issues/new?template=new-feature.md) |
 | BigLake Metastore          | Not Planned, [submit a request](https://github.com/datazip-inc/olake/issues/new?template=new-feature.md) |
 

--- a/destination/iceberg/README.md
+++ b/destination/iceberg/README.md
@@ -114,6 +114,32 @@ Create a json for writer config (writer.json)
 }
 ```
 
+### S3 Table Bucket
+Create a json for writer config (writer.json)
+```json
+{
+  "type": "ICEBERG",
+  "writer": {
+    "catalog_type": "rest",
+    "rest_catalog_url": "https://s3tables.us-east-1.amazonaws.com/iceberg",
+    "iceberg_s3_path": "arn:aws:s3tables:<REGION>:<ACCOUNT_ID>:bucket/<BUCKET_NAME>",
+    "iceberg_db": "<NAMESPACE>",
+    "aws_access_key": "",
+    "aws_secret_key": "",
+    "aws_region": "<REGION>",
+    "rest_signing_name": "s3tables",
+    "rest_signing_region": "<REGION>",
+    "rest_signing_v_4": "true"
+  }
+}
+```
+
+change the placeholders with actual values
+* `REGION` -> Region for AWS bucket and catalog
+* `NAMESPACE` -> This will be your s3 table bucket namespace
+* `ACCOUNT_ID` -> AWS account identifier
+* `BUCKET_NAME` -> Table Bucket Name
+
 ### Hive Catalog
 Create a json for writer config (writer.json)
 ```json

--- a/destination/iceberg/README.md
+++ b/destination/iceberg/README.md
@@ -129,7 +129,7 @@ Create a json for writer config (writer.json)
     "aws_region": "<REGION>",
     "rest_signing_name": "s3tables",
     "rest_signing_region": "<REGION>",
-    "rest_signing_v_4": "true"
+    "rest_signing_v_4": true
   }
 }
 ```

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -61,7 +61,7 @@ type Config struct {
 
 	RestSigningName   string `json:"rest_signing_name,omitempty"`
 	RestSigningRegion string `json:"rest_signing_region,omitempty"`
-	RestSigningV4     string `json:"rest_signing_v_4,omitempty"`
+	RestSigningV4     bool   `json:"rest_signing_v_4,omitempty"`
 }
 
 func (c *Config) Validate() error {

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -58,6 +58,10 @@ type Config struct {
 	ServerHost      string `json:"sink_rpc_server_host,omitempty"` // gRPC server host
 
 	DebugMode bool `json:"debug_mode,omitempty"`
+
+	RestSigningName   string `json:"rest_signing_name,omitempty"`
+	RestSigningRegion string `json:"rest_signing_region,omitempty"`
+	RestSigningV4     string `json:"rest_signing_v_4,omitempty"`
 }
 
 func (c *Config) Validate() error {

--- a/destination/iceberg/iceberg_utils.go
+++ b/destination/iceberg/iceberg_utils.go
@@ -222,6 +222,9 @@ func (i *Iceberg) getServerConfigJSON(port int, upsert bool) ([]byte, error) {
 	case RestCatalog:
 		serverConfig["catalog-impl"] = "org.apache.iceberg.rest.RESTCatalog"
 		serverConfig["uri"] = i.config.RestCatalogURL
+		serverConfig["rest.signing-name"] = i.config.RestSigningName
+		serverConfig["rest.signing-region"] = i.config.RestSigningRegion
+		serverConfig["rest.sigv4-enabled"] = i.config.RestSigningV4
 
 	default:
 		return nil, fmt.Errorf("unsupported catalog type: %s", i.config.CatalogType)

--- a/destination/iceberg/iceberg_utils.go
+++ b/destination/iceberg/iceberg_utils.go
@@ -183,7 +183,7 @@ func (i *Iceberg) parsePartitionRegex(pattern string) error {
 // getServerConfigJSON generates the JSON configuration for the Iceberg server
 func (i *Iceberg) getServerConfigJSON(port int, upsert bool) ([]byte, error) {
 	// Create the server configuration map
-	serverConfig := map[string]string{
+	serverConfig := map[string]interface{}{
 		"port":                 fmt.Sprintf("%d", port),
 		"warehouse":            i.config.IcebergS3Path,
 		"table-namespace":      i.config.IcebergDatabase,


### PR DESCRIPTION
# Description

support for s3 table bucket with aws signing V4

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

-
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

after these changes I have ran a sync using postgres driver

here is the destination.json file content

`{
  "type": "ICEBERG",
  "writer": {
    "catalog_type": "rest",
    "rest_catalog_url": "https://s3tables.us-east-1.amazonaws.com/iceberg",
    "iceberg_s3_path": "arn:aws:s3tables:us-east-1:<account_id>:bucket/<table_bucket_name>",
    "iceberg_db": "<namespace>",
    "aws_access_key": "",
    "aws_secret_key": "",
    "aws_region": "us-east-1",
    "rest_signing_name": "s3tables",
    "rest_signing_region": "us-east-1",
    "rest_signing_v_4": "true"
  }
}`


change <account_id> and <table_bucket_name>" with actual values and pass the destination namespace.

# Screenshots or Recordings

![image](https://github.com/user-attachments/assets/78ddd9de-1aa1-4a7c-8410-e68502dc145a)


