### PR TITLE
fix: trivy pom postgres dependency vulnerability fix

### DIFF
--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -501,7 +501,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.4</version>
+            <version>42.7.7</version>
         </dependency>
         <dependency>
             <groupId>io.minio</groupId>


### PR DESCRIPTION
# Description

Trivy build is failing with recommendation to update pg version in java writer from 42.7.4 to 42.7.7.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing can be skipped as its a patch upgrade.
