### PR TITLE
feat: mysql new chunking strategies

### DIFF
--- a/drivers/mysql/README.md
+++ b/drivers/mysql/README.md
@@ -35,6 +35,7 @@ Add MySql credentials in following format in `config.json` file. [More details.]
     "tls_skip_verify": true,
     "default_mode":"cdc",
     "max_threads":10,
+    "reader_batch_size": 100000,
     "backoff_retry_count": 2
   }
 ```

--- a/drivers/mysql/internal/backfill.go
+++ b/drivers/mysql/internal/backfill.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/drivers/abstract"
@@ -17,10 +19,11 @@ func (m *MySQL) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 	// Begin transaction with repeatable read isolation
 	return jdbc.WithIsolation(ctx, m.client, func(tx *sql.Tx) error {
 		// Build query for the chunk
-		pkColumns := stream.GetStream().SourceDefinedPrimaryKey
-		pkColumn := pkColumns.Array()[0]
+		pkColumns := stream.GetStream().SourceDefinedPrimaryKey.Array()
+		chunkColumn := stream.Self().StreamMetadata.ChunkColumn
 		// Get chunks from state or calculate new ones
-		stmt := jdbc.MysqlChunkScanQuery(stream, pkColumn, chunk)
+		stmt := utils.Ternary(chunkColumn != "", jdbc.MysqlChunkScanQuery(stream, []string{chunkColumn}, chunk), utils.Ternary(len(pkColumns) > 0, jdbc.MysqlChunkScanQuery(stream, pkColumns, chunk), jdbc.MysqlLimitOffsetScanQuery(stream, chunk))).(string)
+
 		setter := jdbc.NewReader(ctx, stmt, 0, func(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 			return tx.QueryContext(ctx, query, args...)
 		})
@@ -46,77 +49,123 @@ func (m *MySQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 	pool.AddRecordsToSync(approxRowCount)
 
 	chunks := types.NewSet[types.Chunk]()
-	err = jdbc.WithIsolation(ctx, m.client, func(tx *sql.Tx) error {
-		// Get primary key column using the provided function
-		pkColumn := stream.GetStream().SourceDefinedPrimaryKey.Array()[0]
-		// Get table extremes
-		minVal, maxVal, err := m.getTableExtremes(stream, pkColumn, tx)
-		if err != nil {
-			return err
-		}
-		if minVal == nil {
-			return nil
-		}
-		chunks.Insert(types.Chunk{
-			Min: nil,
-			Max: utils.ConvertToString(minVal),
-		})
+	chunkColumn := stream.Self().StreamMetadata.ChunkColumn
 
-		logger.Infof("Stream %s extremes - min: %v, max: %v", stream.ID(), utils.ConvertToString(minVal), utils.ConvertToString(maxVal))
+	// Takes the user defined batch size as chunkSize
+	chunkSize := m.config.BatchSize
 
-		// Calculate optimal chunk size based on table statistics
-		chunkSize, err := m.calculateChunkSize(stream)
-		if err != nil {
-			return fmt.Errorf("failed to calculate chunk size: %s", err)
-		}
+	splitViaPrimaryKey := func(stream types.StreamInterface, chunks *types.Set[types.Chunk]) error {
+		return jdbc.WithIsolation(ctx, m.client, func(tx *sql.Tx) error {
+			// Get primary key column using the provided function
 
-		// Generate chunks based on range
-		query := jdbc.NextChunkEndQuery(stream, pkColumn, chunkSize)
-
-		currentVal := minVal
-		for {
-			var nextValRaw interface{}
-			err := tx.QueryRow(query, currentVal).Scan(&nextValRaw)
-			if err != nil && err == sql.ErrNoRows || nextValRaw == nil {
-				break
-			} else if err != nil {
-				return fmt.Errorf("failed to get next chunk end: %s", err)
+			pkColumns := []string{chunkColumn}
+			if chunkColumn == "" {
+				pkColumns = stream.GetStream().SourceDefinedPrimaryKey.Array()
+				sort.Strings(pkColumns)
 			}
-			if currentVal != nil && nextValRaw != nil {
+			// Get table extremes
+			minVal, maxVal, err := m.getTableExtremes(stream, pkColumns, tx)
+			if err != nil {
+				return err
+			}
+			if minVal == nil {
+				return nil
+			}
+			chunks.Insert(types.Chunk{
+				Min: nil,
+				Max: utils.ConvertToString(minVal),
+			})
+
+			logger.Infof("Stream %s extremes - min: %v, max: %v", stream.ID(), utils.ConvertToString(minVal), utils.ConvertToString(maxVal))
+
+			// Generate chunks based on range
+			query := jdbc.NextChunkEndQuery(stream, pkColumns, chunkSize)
+
+			currentVal := minVal
+
+			for {
+				// Split the current value into parts
+				parts := strings.Split(utils.ConvertToString(currentVal), ",")
+
+				// Create args array with the correct number of arguments for the query
+				args := make([]interface{}, 0)
+				for i := 0; i < len(pkColumns); i++ {
+					// For each column combination in the WHERE clause, we need to add the necessary parts
+					for j := 0; j <= i && j < len(parts); j++ {
+						args = append(args, parts[j])
+					}
+				}
+
+				var nextValRaw interface{}
+				err := tx.QueryRow(query, args...).Scan(&nextValRaw)
+				if err != nil && err == sql.ErrNoRows || nextValRaw == nil {
+					break
+				} else if err != nil {
+					return fmt.Errorf("failed to get next chunk end: %w", err)
+				}
+				if currentVal != nil && nextValRaw != nil {
+					chunks.Insert(types.Chunk{
+						Min: utils.ConvertToString(currentVal),
+						Max: utils.ConvertToString(nextValRaw),
+					})
+				}
+				currentVal = nextValRaw
+			}
+			if currentVal != nil {
 				chunks.Insert(types.Chunk{
 					Min: utils.ConvertToString(currentVal),
-					Max: utils.ConvertToString(nextValRaw),
+					Max: nil,
 				})
 			}
-			currentVal = nextValRaw
-		}
-		if currentVal != nil {
+
+			return nil
+		})
+	}
+
+	limitOffsetChunking := func(stream types.StreamInterface, chunks *types.Set[types.Chunk]) error {
+		return jdbc.WithIsolation(context.Background(), m.client, func(tx *sql.Tx) error {
+
+			if err != nil {
+				return fmt.Errorf("failed to calculate chunk size: %w", err)
+			}
+
+			query := jdbc.CalculateTotalRows(stream)
+			var totalRows uint64
+			logger.Infof("Query for total rows: %s", query)
+			err = m.client.QueryRow(query).Scan(&totalRows)
+			if err != nil {
+				return fmt.Errorf("failed to calculate total Rows: %w", err)
+			}
+
 			chunks.Insert(types.Chunk{
-				Min: utils.ConvertToString(currentVal),
+				Min: nil,
+				Max: uint64(chunkSize),
+			})
+			lastChunk := uint64(chunkSize)
+			for lastChunk < totalRows {
+				chunks.Insert(types.Chunk{
+					Min: lastChunk,
+					Max: lastChunk + uint64(chunkSize),
+				})
+				lastChunk += uint64(chunkSize)
+			}
+			chunks.Insert(types.Chunk{
+				Min: lastChunk,
 				Max: nil,
 			})
-		}
+			return nil
+		})
+	}
 
-		return nil
-	})
+	err = utils.Ternary(stream.GetStream().SourceDefinedPrimaryKey.Len() > 0 || chunkColumn != "", splitViaPrimaryKey(stream, chunks), limitOffsetChunking(stream, chunks)).(error)
 	return chunks, err
 }
 
-func (m *MySQL) getTableExtremes(stream types.StreamInterface, pkColumn string, tx *sql.Tx) (min, max any, err error) {
-	query := jdbc.MinMaxQuery(stream, pkColumn)
+func (m *MySQL) getTableExtremes(stream types.StreamInterface, pkColumns []string, tx *sql.Tx) (min, max any, err error) {
+	query := jdbc.MinMaxQueryMySQL(stream, pkColumns)
 	err = tx.QueryRow(query).Scan(&min, &max)
 	if err != nil {
 		return "", "", err
 	}
 	return min, max, err
-}
-func (m *MySQL) calculateChunkSize(stream types.StreamInterface) (int, error) {
-	var totalRecords int
-	query := jdbc.MySQLTableRowsQuery()
-	err := m.client.QueryRow(query, stream.Name()).Scan(&totalRecords)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get estimated records count: %s", err)
-	}
-	// number of chunks based on max threads
-	return totalRecords / (m.config.MaxThreads * 8), nil
 }

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -11,14 +11,41 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// MinMaxQuery returns the query to fetch MIN and MAX values of a column in a table
+// MinMaxQuery returns the query to fetch MIN and MAX values of a column in a Postgres table
 func MinMaxQuery(stream types.StreamInterface, column string) string {
 	return fmt.Sprintf(`SELECT MIN(%[1]s) AS min_value, MAX(%[1]s) AS max_value FROM %[2]s.%[3]s`, column, stream.Namespace(), stream.Name())
 }
 
 // NextChunkEndQuery returns the query to calculate the next chunk boundary
-func NextChunkEndQuery(stream types.StreamInterface, column string, chunkSize int) string {
-	return fmt.Sprintf(`SELECT MAX(%[1]s) FROM (SELECT %[1]s FROM %[2]s.%[3]s WHERE %[1]s > ? ORDER BY %[1]s LIMIT %[4]d) AS subquery`, column, stream.Namespace(), stream.Name(), chunkSize)
+func NextChunkEndQuery(stream types.StreamInterface, columns []string, chunkSize int) string {
+	var query strings.Builder
+
+	// SELECT with quoted and concatenated values
+	fmt.Fprintf(&query, "SELECT MAX(key_str) FROM (SELECT CONCAT_WS(',', %s) AS key_str FROM `%s`.`%s`",
+		strings.Join(columns, ", "),
+		stream.Namespace(),
+		stream.Name(),
+	)
+
+	// WHERE clause for lexicographic "greater than"
+	fmt.Fprintf(&query, " WHERE ")
+	for i := 0; i < len(columns); i++ {
+		if i > 0 {
+			query.WriteString(" OR ")
+		}
+		query.WriteString("(")
+		for j := 0; j < i; j++ {
+			fmt.Fprintf(&query, "`%s` = ? AND ", columns[j])
+		}
+		fmt.Fprintf(&query, "`%s` > ?", columns[i])
+		query.WriteString(")")
+	}
+
+	// ORDER + LIMIT
+	fmt.Fprintf(&query, " ORDER BY %s", strings.Join(columns, ", "))
+	fmt.Fprintf(&query, " LIMIT %d) AS subquery", chunkSize)
+
+	return query.String()
 }
 
 // buildChunkCondition builds the condition for a chunk
@@ -77,10 +104,83 @@ func PostgresChunkScanQuery(stream types.StreamInterface, filterColumn string, c
 
 // MySQL-Specific Queries
 
+// Calculates total number of rows in a table
+func CalculateTotalRows(stream types.StreamInterface) string {
+	return fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`%s`", stream.Namespace(), stream.Name())
+}
+
+func buildTuple(chunkBase string) string {
+
+	chunkBaseParts := strings.Split(chunkBase, ",")
+	for i, part := range chunkBaseParts {
+		chunkBaseParts[i] = fmt.Sprintf("'%s'", strings.TrimSpace(part))
+	}
+	return strings.Join(chunkBaseParts, ", ")
+}
+
+// buildChunkConditionMySQL builds the condition for a chunk in MySQL
+func buildChunkConditionMySQL(filterColumns []string, chunk types.Chunk) string {
+	colTuple := "(" + strings.Join(filterColumns, ", ") + ")"
+
+	if chunk.Min != nil && chunk.Max != nil {
+		chunkMinTuple := buildTuple(chunk.Min.(string))
+		chunkMaxTuple := buildTuple(chunk.Max.(string))
+
+		return fmt.Sprintf("%s >= (%s) AND %s < (%s)", colTuple, chunkMinTuple, colTuple, chunkMaxTuple)
+	} else if chunk.Min != nil {
+		chunkMinTuple := buildTuple(chunk.Min.(string))
+		return fmt.Sprintf("%s >= (%s)", colTuple, chunkMinTuple)
+	} else if chunk.Max != nil {
+		chunkMaxTuple := buildTuple(chunk.Max.(string))
+		return fmt.Sprintf("%s < (%s)", colTuple, chunkMaxTuple)
+	}
+	return ""
+}
+
+// MysqlLimitOffsetScanQuery is used to get the rows
+func MysqlLimitOffsetScanQuery(stream types.StreamInterface, chunk types.Chunk) string {
+	if chunk.Min == nil {
+		return fmt.Sprintf("SELECT * FROM `%s`.`%s` LIMIT %d", stream.Namespace(), stream.Name(), chunk.Max)
+	} else if chunk.Min != nil && chunk.Max != nil {
+		return fmt.Sprintf("SELECT * FROM `%s`.`%s` LIMIT %d OFFSET %d",
+			stream.Namespace(),
+			stream.Name(),
+			chunk.Max.(uint64)-chunk.Min.(uint64),
+			chunk.Min)
+	}
+	maxNum := ^uint64(0)
+	return fmt.Sprintf("SELECT * FROM `%s`.`%s` LIMIT %d OFFSET %d",
+		stream.Namespace(),
+		stream.Name(),
+		maxNum,
+		chunk.Min)
+}
+
 // MySQLWithoutState builds a chunk scan query for MySql
-func MysqlChunkScanQuery(stream types.StreamInterface, filterColumn string, chunk types.Chunk) string {
-	condition := buildChunkCondition(filterColumn, chunk)
+func MysqlChunkScanQuery(stream types.StreamInterface, filterColumns []string, chunk types.Chunk) string {
+	condition := buildChunkConditionMySQL(filterColumns, chunk)
 	return fmt.Sprintf("SELECT * FROM `%s`.`%s` WHERE %s", stream.Namespace(), stream.Name(), condition)
+}
+
+// MinMaxQueryMySQL returns the query to fetch MIN and MAX values of a column in a MySQL table
+func MinMaxQueryMySQL(stream types.StreamInterface, columns []string) string {
+	concatCols := fmt.Sprintf("CONCAT_WS(',', %s)", strings.Join(columns, ", "))
+
+	orderAsc := strings.Join(columns, ", ")
+	descCols := make([]string, len(columns))
+	for i, col := range columns {
+		descCols[i] = col + " DESC"
+	}
+	orderDesc := strings.Join(descCols, ", ")
+
+	return fmt.Sprintf(`
+		SELECT
+			(SELECT %s FROM %s.%s ORDER BY %s LIMIT 1) AS min_value,
+			(SELECT %s FROM %s.%s ORDER BY %s LIMIT 1) AS max_value
+	`,
+		concatCols, stream.Namespace(), stream.Name(), orderAsc,
+		concatCols, stream.Namespace(), stream.Name(), orderDesc,
+	)
 }
 
 // MySQLDiscoverTablesQuery returns the query to discover tables in a MySQL database


### PR DESCRIPTION
# Description

This PR enhances Olake's table synchronization capabilities in two key ways:

## Key Improvements:

Extended support for all key configurations:

Single primary key
Composite primary keys
User-defined chunk column (configured via chunk_column)
New Strategies for Tables Without Primary Keys:

Implemented Limit Offset strategy
Efficient for large datasets with no primary keys.
Type of change

## New feature (non-breaking change which adds functionality)
 This change requires a documentation update
## How Has This Been Tested?

 Sync with single primary key
 Sync with composite primary key
 Sync using user-defined chunk column
 Sync using no-primary-key strategy
 Verified no row loss or duplication across multiple chunking runs
## Related PR's (If Any):

Draft version of this PR : #310
Previous Version with comments : #313 