### PR TITLE
feat: strict_cdc sync mode for all drivers

### DIFF
--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -90,7 +90,7 @@ func (a *AbstractDriver) Discover(ctx context.Context) ([]*types.Stream, error) 
 			for column, typ := range DefaultColumns {
 				convStream.UpsertField(column, typ, true)
 			}
-			convStream.WithSyncMode(types.CDC)
+			convStream.WithSyncMode(types.CDC, types.STRICTCDC)
 		}
 		finalStreams = append(finalStreams, convStream)
 		return true

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -21,7 +21,7 @@ func (a *AbstractDriver) RunChangeStream(ctx context.Context, pool *destination.
 	defer close(backfillWaitChannel)
 	err := utils.ForEach(streams, func(stream types.StreamInterface) error {
 		if stream.GetStream().SyncMode == types.STRICTCDC {
-			logger.Infof("strict cdc mode, skipping backfill for stream[%s]", stream.ID())
+			logger.Infof("Strict CDC mode, skipping backfill for stream[%s]", stream.ID())
 			backfillWaitChannel <- stream.ID()
 			return nil
 		}

--- a/drivers/mongodb/README.md
+++ b/drivers/mongodb/README.md
@@ -8,6 +8,8 @@ The MongoDB Driver enables data synchronization from MongoDB to your desired des
    Fetches the complete dataset from MongoDB.
 2. **CDC (Change Data Capture)**
    Tracks and syncs incremental changes from MongoDB in real time.
+3. **Strict CDC (Change Data Capture)**
+   Tracks only new changes from the current position in the MongoDB change stream, without performing an initial backfill.
 
 ---
 

--- a/drivers/mysql/README.md
+++ b/drivers/mysql/README.md
@@ -8,6 +8,8 @@ The MySql Driver enables data synchronization from MySql to your desired destina
    Fetches the complete dataset from MySql.
 2. **CDC (Change Data Capture)**
    Tracks and syncs incremental changes from MySql in real time.
+3. **Strict CDC (Change Data Capture)**
+   Tracks only new changes from the current position in the MySQL binlog, without performing an initial backfill.
 
 ---
 

--- a/drivers/postgres/README.md
+++ b/drivers/postgres/README.md
@@ -8,6 +8,8 @@ The Postgres Driver enables data synchronization from Postgres to your desired d
    Fetches the complete dataset from Postgres.
 2. **CDC (Change Data Capture)**
    Tracks and syncs incremental changes from Postgres in real time.
+3. **Strict CDC (Change Data Capture)**
+   Tracks only new changes from the current position in the PostgreSQL WAL, without performing an initial backfill.
 
 ---
 

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -116,7 +116,7 @@ var syncCmd = &cobra.Command{
 			elem.StreamMetadata = sMetadata
 			selectedStreams = append(selectedStreams, elem.ID())
 
-			if elem.Stream.SyncMode == types.CDC {
+			if elem.Stream.SyncMode == types.CDC || elem.Stream.SyncMode == types.STRICTCDC {
 				cdcStreams = append(cdcStreams, elem)
 				streamState, exists := stateStreamMap[fmt.Sprintf("%s.%s", elem.Namespace(), elem.Name())]
 				if exists {

--- a/types/sync_mode.go
+++ b/types/sync_mode.go
@@ -6,4 +6,5 @@ const (
 	FULLREFRESH SyncMode = "full_refresh"
 	INCREMENTAL SyncMode = "incremental"
 	CDC         SyncMode = "cdc"
+	STRICTCDC   SyncMode = "strict_cdc"
 )


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Strict CDC sync mode ensures that during sync mode no backfill (full refresh) happens.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

This has been tested by performing CDC, STRICTCDC with multiple streams in all the drivers.

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

**MongoDB**
<img width="1303" alt="mongodb" src="https://github.com/user-attachments/assets/cce18e00-471a-45ef-8b58-27553fe38c75" />
<br/>

**Postgresql**
<img width="1312" alt="postgres" src="https://github.com/user-attachments/assets/f7485e88-1023-4fce-9d9d-4bdfa5f2099b" />
<br/>

**MySQL**
<img width="1306" alt="mysql" src="https://github.com/user-attachments/assets/f6eb2007-7d3b-4ff2-984a-251a1a42e691" />

