### PR TITLE
chore: Add datatype integration tests for Postgres and MySQL drivers.

### DIFF
--- a/drivers/abstract/test_schema.go
+++ b/drivers/abstract/test_schema.go
@@ -1,0 +1,201 @@
+package abstract
+
+// GlobalTypeToDataType maps database-specific types (Postgres/MySQL) to internal standard types
+var GlobalTypeMapping = map[string]string{
+	// Integer Types
+	"tinyint":            "int",
+	"smallint":           "int",
+	"mediumint":          "int",
+	"int":                "int",
+	"integer":            "int",
+	"unsigned int":       "int",
+	"unsigned smallint":  "int",
+	"unsigned tinyint":   "int",
+	"unsigned mediumint": "int",
+	"int2":               "int",
+	"int4":               "int",
+	"smallserial":        "int",
+	"serial":             "int",
+	"serial2":            "int",
+	"serial4":            "int",
+
+	"bigint":    "bigint",
+	"int8":      "bigint",
+	"serial8":   "bigint",
+	"bigserial": "bigint",
+	"year":      "bigint",
+
+	// Floating Point Types
+	"float":   "float",
+	"real":    "float",
+	"decimal": "float",
+	"numeric": "float",
+	"float4":  "float",
+	"money":   "float",
+
+	"double":           "double",
+	"float8":           "double",
+	"double precision": "double",
+
+	// Boolean Types
+	"bool":    "boolean",
+	"boolean": "boolean",
+
+	// String Types
+	"char":              "string",
+	"varchar":           "string",
+	"tinytext":          "string",
+	"text":              "string",
+	"mediumtext":        "string",
+	"longtext":          "string",
+	"character":         "string",
+	"character varying": "string",
+	"longvarchar":       "string",
+	"bpchar":            "string",
+	"name":              "string",
+
+	// Binary Types
+	"binary":     "string",
+	"varbinary":  "string",
+	"tinyblob":   "string",
+	"blob":       "string",
+	"mediumblob": "string",
+	"longblob":   "string",
+	"bytea":      "string",
+
+	// JSON and Document Types
+	"json":   "string",
+	"jsonb":  "string",
+	"xml":    "string",
+	"hstore": "string",
+
+	// Network Types
+	"cidr":     "string",
+	"inet":     "string",
+	"macaddr":  "string",
+	"macaddr8": "string",
+
+	// Spatial Types
+	"geometry":           "string",
+	"point":              "string",
+	"linestring":         "string",
+	"polygon":            "string",
+	"multipoint":         "string",
+	"multilinestring":    "string",
+	"multipolygon":       "string",
+	"geometrycollection": "string",
+	"circle":             "string",
+	"path":               "string",
+	"box":                "string",
+	"line":               "string",
+	"lseg":               "string",
+
+	// Full Text Search Types
+	"tsvector": "string",
+	"tsquery":  "string",
+
+	// UUID
+	"uuid": "string",
+
+	// Range Types
+	"tsrange":   "string",
+	"tstzrange": "string",
+	"int4range": "string",
+	"numrange":  "string",
+	"daterange": "string",
+
+	// Array
+	"array":      "string",
+	"ARRAY":      "string",
+	"int2vector": "string",
+
+	// Enum and Set
+	"enum": "string",
+	"set":  "string",
+
+	// Date/Time
+	"date":                        "timestamp",
+	"timestamp":                   "timestamp",
+	"datetime":                    "timestamp",
+	"timestampz":                  "timestamp",
+	"timestamp with time zone":    "timestamp",
+	"timestamp without time zone": "timestamp",
+
+	"time":     "string",
+	"timez":    "string",
+	"interval": "string",
+
+	// Misc
+	"pg_lsn":      "string",
+	"bit varying": "string",
+	"varbit":      "string",
+	"bit(n)":      "string",
+	"varying(n)":  "string",
+}
+
+var PostgresSchema = map[string]string{
+	"col_bigint":            "bigint",
+	"col_bigserial":         "bigserial",
+	"col_bool":              "boolean",
+	"col_char":              "char",
+	"col_character":         "character",
+	"col_character_varying": "varchar",
+	"col_date":              "date",
+	"col_daterange":         "daterange",
+	"col_decimal":           "numeric",
+	"col_double_precision":  "double precision",
+	"col_float4":            "real",
+	"col_int":               "int",
+	"col_int2":              "smallint",
+	"col_integer":           "integer",
+	"col_interval":          "interval",
+	"col_json":              "json",
+	"col_jsonb":             "jsonb",
+	"col_jsonpath":          "jsonpath",
+	"col_name":              "name",
+	"col_numeric":           "numeric",
+	"col_real":              "real",
+	"col_text":              "text",
+	"col_time":              "time",
+	"col_timestamp":         "timestamp",
+	"col_timestamptz":       "timestamptz",
+	"col_timetz":            "timetz",
+	"col_uuid":              "uuid",
+	"col_varbit":            "varbit",
+	"col_xml":               "xml",
+}
+
+var MySQLSchema = map[string]string{
+	"id":                     "unsigned int",
+	"id_bigint":              "bigint",
+	"id_int":                 "int",
+	"id_int_unsigned":        "unsigned int",
+	"id_integer":             "int",
+	"id_integer_unsigned":    "unsigned int",
+	"id_mediumint":           "mediumint",
+	"id_mediumint_unsigned":  "unsigned mediumint",
+	"id_smallint":            "smallint",
+	"id_smallint_unsigned":   "unsigned smallint",
+	"id_tinyint":             "tinyint",
+	"id_tinyint_unsigned":    "unsigned tinyint",
+	"price_decimal":          "decimal",
+	"price_double":           "double",
+	"price_double_precision": "double",
+	"price_float":            "float",
+	"price_numeric":          "decimal",
+	"price_real":             "double",
+	"name_char":              "char",
+	"name_varchar":           "varchar",
+	"name_text":              "text",
+	"name_tinytext":          "tinytext",
+	"name_mediumtext":        "mediumtext",
+	"name_longtext":          "longtext",
+	"name_enum":              "enum",
+	"created_date":           "datetime",
+	"created_time":           "time",
+	"created_timestamp":      "timestamp",
+	"is_active":              "tinyint",
+	"json_data":              "json",
+	"long_varchar":           "mediumtext",
+	"name_bool":              "tinyint",
+}

--- a/drivers/abstract/test_utils.go
+++ b/drivers/abstract/test_utils.go
@@ -12,7 +12,6 @@ import (
 	"github.com/datazip-inc/olake/destination/iceberg"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
-	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -238,7 +237,6 @@ func verifyIcebergSync(t *testing.T, tableName string, expectedCount string, sch
 	for _, row := range describeRows {
 		colName := row.Value("col_name").(string)
 		dataType := row.Value("data_type").(string)
-		logger.Infof("Column: %s, Data Type: %s", colName, dataType)
 		if !strings.HasPrefix(colName, "#") {
 			icebergSchema[colName] = dataType
 		}

--- a/drivers/mysql/internal/mysql_test.go
+++ b/drivers/mysql/internal/mysql_test.go
@@ -2,6 +2,8 @@ package driver
 
 import (
 	"testing"
+
+	"github.com/datazip-inc/olake/drivers/abstract"
 )
 
 // Test functions using base utilities
@@ -18,5 +20,5 @@ func TestMySQLDiscover(t *testing.T) {
 
 func TestMySQLRead(t *testing.T) {
 	conn, abstractDriver := testAndBuildAbstractDriver(t)
-	abstractDriver.TestRead(t, conn, ExecuteQuery)
+	abstractDriver.TestRead(t, conn, ExecuteQuery, abstract.MySQLSchema)
 }

--- a/drivers/mysql/internal/mysql_test_util.go
+++ b/drivers/mysql/internal/mysql_test_util.go
@@ -41,9 +41,40 @@ func ExecuteQuery(ctx context.Context, t *testing.T, conn interface{}, tableName
 	case "create":
 		query = fmt.Sprintf(`
 			CREATE TABLE IF NOT EXISTS %s (
-				id INTEGER PRIMARY KEY,
-				col1 VARCHAR(255),
-				col2 VARCHAR(255)
+				id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+				id_bigint BIGINT,
+				id_bigint_unsigned BIGINT UNSIGNED,
+				id_int INT,
+				id_int_unsigned INT UNSIGNED,
+				id_integer INT,
+				id_integer_unsigned INT UNSIGNED,
+				id_mediumint MEDIUMINT,
+				id_mediumint_unsigned MEDIUMINT UNSIGNED,
+				id_smallint SMALLINT,
+				id_smallint_unsigned SMALLINT UNSIGNED,
+				id_tinyint TINYINT,
+				id_tinyint_unsigned TINYINT UNSIGNED,
+				price_decimal DECIMAL(10,2),
+				price_double DOUBLE,
+				price_double_precision DOUBLE,
+				price_float FLOAT,
+				price_numeric DECIMAL(10,2),
+				price_real DOUBLE,
+				name_char CHAR(50),
+				name_varchar VARCHAR(100),
+				name_text TEXT,
+				name_tinytext TINYTEXT,
+				name_mediumtext MEDIUMTEXT,
+				name_longtext LONGTEXT,
+				name_enum ENUM('Small','Medium','Large'),
+				created_date DATETIME,
+				created_time TIME,
+				created_timestamp TIMESTAMP NULL,
+				is_active TINYINT(1),
+				json_data JSON,
+				long_varchar MEDIUMTEXT,
+				name_bool TINYINT(1) DEFAULT '1',
+				PRIMARY KEY (id)
 			)`, tableName)
 
 	case "drop":
@@ -57,19 +88,22 @@ func ExecuteQuery(ctx context.Context, t *testing.T, conn interface{}, tableName
 		return // Early return since we handle all inserts in the helper function
 
 	case "insert":
-		query = fmt.Sprintf(`
-			INSERT INTO %s (id, col1, col2) 
-			VALUES (10, 'new val', 'new val')`, tableName)
+		query = fmt.Sprintf(
+			"INSERT INTO %s (id, name_varchar, name_text) VALUES (10, 'new val', 'new val')",
+			tableName,
+		)
 
 	case "update":
-		query = fmt.Sprintf(`
-			UPDATE %s 
-			SET col1 = 'updated val' 
-			WHERE id = (
+		query = fmt.Sprintf(
+			`UPDATE %s
+			 SET name_varchar = 'updated val'
+			 WHERE id = (
 				SELECT id FROM (
 					SELECT id FROM %s ORDER BY RAND() LIMIT 1
 				) AS subquery
-			)`, tableName, tableName)
+			)`,
+			tableName, tableName,
+		)
 
 	case "delete":
 		query = fmt.Sprintf(`
@@ -94,9 +128,28 @@ func insertTestData(t *testing.T, ctx context.Context, db *sqlx.DB, tableName st
 
 	for i := 1; i <= 5; i++ {
 		query := fmt.Sprintf(`
-			INSERT INTO %s (id, col1, col2) 
-			VALUES (%d, 'value%d_col1', 'value%d_col2')`,
-			tableName, i, i, i)
+		INSERT INTO %s (
+			id, id_bigint, id_bigint_unsigned,
+			id_int, id_int_unsigned, id_integer, id_integer_unsigned,
+			id_mediumint, id_mediumint_unsigned, id_smallint, id_smallint_unsigned,
+			id_tinyint, id_tinyint_unsigned, price_decimal, price_double,
+			price_double_precision, price_float, price_numeric, price_real,
+			name_char, name_varchar, name_text, name_tinytext,
+			name_mediumtext, name_longtext, name_enum, created_date,
+			created_time, created_timestamp, is_active, json_data,
+			long_varchar, name_bool
+		) VALUES (
+			%d, 1234567890, 1234567891,
+			100, 101, 102, 103,
+			5001, 5002, 101, 102,
+			50, 51,
+			%.2f, %.3f,
+			%.3f, %.2f, %.2f, %.3f,
+			'char_val_1', 'varchar_val_2', 'text_val_1', 'tinytext_val_2',
+			'mediumtext_val_1', 'longtext_val_2', 'Medium', '2023-01-01 12:00:00',
+			'12:00:00', '2023-01-01 12:00:00', 1, '{"key": "value_1"}',
+			'long_varchar_val_2', 1
+		)`, tableName, i, 123.45, 123.456, 123.456, 123.45, 123.45, 123.456)
 
 		_, err := db.ExecContext(ctx, query)
 		require.NoError(t, err, "Failed to insert test data row %d", i)

--- a/drivers/mysql/internal/mysql_test_util.go
+++ b/drivers/mysql/internal/mysql_test_util.go
@@ -143,13 +143,13 @@ func insertTestData(t *testing.T, ctx context.Context, db *sqlx.DB, tableName st
 			100, 101, 102, 103,
 			5001, 5002, 101, 102,
 			50, 51,
-			%.2f, %.3f,
-			%.3f, %.2f, %.2f, %.3f,
+			123.45, 123.456,
+			123.456,  123.45, 123.45, 123.456,
 			'char_val_1', 'varchar_val_2', 'text_val_1', 'tinytext_val_2',
 			'mediumtext_val_1', 'longtext_val_2', 'Medium', '2023-01-01 12:00:00',
 			'12:00:00', '2023-01-01 12:00:00', 1, '{"key": "value_1"}',
 			'long_varchar_val_2', 1
-		)`, tableName, i, 123.45, 123.456, 123.456, 123.45, 123.45, 123.456)
+		)`, tableName, i)
 
 		_, err := db.ExecContext(ctx, query)
 		require.NoError(t, err, "Failed to insert test data row %d", i)

--- a/drivers/postgres/internal/postgres_test.go
+++ b/drivers/postgres/internal/postgres_test.go
@@ -2,6 +2,8 @@ package driver
 
 import (
 	"testing"
+
+	"github.com/datazip-inc/olake/drivers/abstract"
 )
 
 // Test functions using base utilities
@@ -17,5 +19,5 @@ func TestPostgresDiscover(t *testing.T) {
 
 func TestPostgresRead(t *testing.T) {
 	client, absDriver := testPostgresClient(t)
-	absDriver.TestRead(t, client, ExecuteQuery)
+	absDriver.TestRead(t, client, ExecuteQuery, abstract.PostgresSchema)
 }

--- a/drivers/postgres/internal/postgres_test_util.go
+++ b/drivers/postgres/internal/postgres_test_util.go
@@ -41,9 +41,36 @@ func ExecuteQuery(ctx context.Context, t *testing.T, conn interface{}, tableName
 	case "create":
 		query = fmt.Sprintf(`
 			CREATE TABLE IF NOT EXISTS %s (
-				id INTEGER PRIMARY KEY,
-				col1 VARCHAR(255),
-				col2 VARCHAR(255)
+				col_bigint BIGINT,
+				col_bigserial BIGSERIAL PRIMARY KEY,
+				col_bool BOOLEAN,
+				col_char CHAR(1),
+				col_character CHAR(10),
+				col_character_varying VARCHAR(50),
+				col_date DATE,
+				col_daterange DATERANGE,
+				col_decimal NUMERIC,
+				col_double_precision DOUBLE PRECISION,
+				col_float4 REAL,
+				col_int INT,
+				col_int2 SMALLINT,
+				col_integer INTEGER,
+				col_interval INTERVAL,
+				col_json JSON,
+				col_jsonb JSONB,
+				col_jsonpath JSONPATH,
+				col_name NAME,
+				col_numeric NUMERIC,
+				col_real REAL,
+				col_text TEXT,
+				col_time TIME,
+				col_timestamp TIMESTAMP,
+				col_timestamptz TIMESTAMPTZ,
+				col_timetz TIMETZ,
+				col_uuid UUID,
+				col_varbit VARBIT(20),
+				col_xml XML,
+				CONSTRAINT unique_custom_key_3 UNIQUE (col_bigserial)
 			)`, tableName)
 
 	case "drop":
@@ -58,25 +85,25 @@ func ExecuteQuery(ctx context.Context, t *testing.T, conn interface{}, tableName
 
 	case "insert":
 		query = fmt.Sprintf(`
-			INSERT INTO %s (id, col1, col2) 
+			INSERT INTO %s (col_int, col_character_varying, col_text) 
 			VALUES (10, 'new val', 'new val')`, tableName)
 
 	case "update":
 		query = fmt.Sprintf(`
 			UPDATE %s 
-			SET col1 = 'updated val' 
-			WHERE id = (
-				SELECT id FROM (
-					SELECT id FROM %s ORDER BY RANDOM() LIMIT 1
+			SET col_character_varying = 'updated val' 
+			WHERE col_bigserial = (
+				SELECT col_bigserial FROM (
+					SELECT col_bigserial FROM %s ORDER BY RANDOM() LIMIT 1
 				) AS subquery
 			)`, tableName, tableName)
 
 	case "delete":
 		query = fmt.Sprintf(`
 			DELETE FROM %s 
-			WHERE id = (
-				SELECT id FROM (
-					SELECT id FROM %s ORDER BY RANDOM() LIMIT 1
+			WHERE col_bigserial = (
+				SELECT col_bigserial FROM (
+					SELECT col_bigserial FROM %s ORDER BY RANDOM() LIMIT 1
 				) AS subquery
 			)`, tableName, tableName)
 
@@ -94,12 +121,26 @@ func insertTestData(t *testing.T, ctx context.Context, db *sqlx.DB, tableName st
 
 	for i := 1; i <= 5; i++ {
 		query := fmt.Sprintf(`
-			INSERT INTO %s (id, col1, col2) 
-			VALUES (%d, 'value%d_col1', 'value%d_col2')`,
-			tableName, i, i, i)
+		INSERT INTO %s (
+			col_bigint, col_bigserial, col_bool, col_char, col_character,
+			col_character_varying, col_date, col_daterange, col_decimal,
+			col_double_precision, col_float4, col_int, col_int2, col_integer,
+			col_interval, col_json, col_jsonb, col_jsonpath, col_name, col_numeric,
+			col_real, col_text, col_time, col_timestamp, col_timestamptz, col_timetz,
+			col_uuid, col_varbit, col_xml
+		) VALUES (
+			1234567890123456789, DEFAULT, TRUE, 'c', 'char_val',
+			'varchar_val', '2023-01-01', '[2023-01-01,2023-01-02)', 123.45,
+			123.456789, 123.45, 123, 123, 12345, '1 hour', '{"key": "value"}',
+			'{"key": "value"}', '$.key', 'test_name', 123.45, 123.45,
+			'sample text', '12:00:00', '2023-01-01 12:00:00',
+			'2023-01-01 12:00:00+00', '12:00:00+00',
+			'123e4567-e89b-12d3-a456-426614174000', B'101010',
+			'<tag>value</tag>'
+		)`, tableName)
 
 		_, err := db.ExecContext(ctx, query)
-		require.NoError(t, err, "Failed to insert test data row %d", i)
+		require.NoError(t, err, "Failed to insert test data")
 	}
 }
 


### PR DESCRIPTION
# Description
Integration tests for the datatypes of the Postgres and MySQL driver is done.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
This has been tested using different datatypes of Postgres and MySQL in full refresh mode as well as cdc mode.