### PR TITLE
fix: iceberg deduplication fix

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -8,7 +8,8 @@ const (
 	DefaultDiscoverTimeout = 5 * time.Minute
 	DefaultRetryTimeout    = 60 * time.Second
 	ParquetFileExt         = "parquet"
-	PartitionRegex         = `\{([^}]+)\}`
+	PartitionRegexIceberg  = `\{([^,]+),\s*([^}]+)\}`
+	PartitionRegexParquet  = `\{([^}]+)\}`
 	MongoPrimaryID         = "_id"
 	OlakeID                = "_olake_id"
 	OlakeTimestamp         = "_olake_timestamp"

--- a/destination/iceberg/README.md
+++ b/destination/iceberg/README.md
@@ -24,6 +24,21 @@ Important reason why we are using Java to write is, current Golang-iceberg proje
 
 Its based in the directory olake-iceberg-java-writer. Read more ./olake-iceberg-java-writer/README.md on how to run it in standalone mode and test.
 
+## Environment Variables
+
+### OLAKE_DEBUG_MODE
+
+Set this environment variable to enable debug mode for the Java Iceberg writer. When enabled, the Java process will start with remote debugging options, allowing you to attach a debugger on port 5005.
+
+**Note:** Debug mode is only enabled during sync operations (not during check operations) to avoid blocking the connection check process.
+
+```bash
+# Enable debug mode
+export OLAKE_DEBUG_MODE=1
+
+# Run your sync command
+olake sync --config source.json --destination destination.json --catalog catalog.json
+```
 
 ## How to run 
 

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -57,8 +57,6 @@ type Config struct {
 	JarPath         string `json:"sink_jar_path,omitempty"`        // Path to the Iceberg sink JAR
 	ServerHost      string `json:"sink_rpc_server_host,omitempty"` // gRPC server host
 
-	DebugMode bool `json:"debug_mode,omitempty"`
-
 	RestSigningName   string `json:"rest_signing_name,omitempty"`
 	RestSigningRegion string `json:"rest_signing_region,omitempty"`
 	RestSigningV4     bool   `json:"rest_signing_v_4,omitempty"`

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/IcebergUtil.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/IcebergUtil.java
@@ -37,6 +37,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -120,11 +121,11 @@ public class IcebergUtil {
 
   public static Table createIcebergTable(Catalog icebergCatalog, TableIdentifier tableIdentifier,
                                          Schema schema, String writeFormat) {
-    return createIcebergTable(icebergCatalog, tableIdentifier, schema, writeFormat, Collections.emptyMap());
+    return createIcebergTable(icebergCatalog, tableIdentifier, schema, writeFormat, Collections.emptyList());
   }
 
   public static Table createIcebergTable(Catalog icebergCatalog, TableIdentifier tableIdentifier,
-                                         Schema schema, String writeFormat, Map<String, String> partitionTransforms) {
+                                         Schema schema, String writeFormat, List<Map<String, String>> partitionTransforms) {
 
     LOGGER.warn("Creating table:'{}'\nschema:{}\nrowIdentifier:{}", tableIdentifier, schema,
         schema.identifierFieldNames());
@@ -149,10 +150,10 @@ public class IcebergUtil {
       // Start building the table
       PartitionSpec.Builder specBuilder = PartitionSpec.builderFor(schema);
       
-      // Apply each partition transform
-      for (Map.Entry<String, String> entry : partitionTransforms.entrySet()) {
-        String field = entry.getKey();
-        String transform = entry.getValue().toLowerCase(Locale.ENGLISH);
+      // Apply each partition transform in order
+      for (Map<String, String> partitionDef : partitionTransforms) {
+        String field = partitionDef.get("field");
+        String transform = partitionDef.get("transform").toLowerCase(Locale.ENGLISH);
         
         // Apply the appropriate transform based on the specified type
         switch (transform) {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -18,7 +18,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
 
 @Dependent
 public class OlakeRpcServer {
@@ -34,8 +37,8 @@ public class OlakeRpcServer {
     static Deserializer<JsonNode> keyDeserializer;
     static boolean upsert_records = true;
     static boolean createIdFields = true;
-    // Map to store partition fields and their transforms
-    static Map<String, String> partitionTransforms = new ConcurrentHashMap<>();
+    // List to store partition fields and their transforms - preserves order and allows duplicates
+    static List<Map<String, String>> partitionTransforms = new ArrayList<>();
 
 
     public static void main(String[] args) throws Exception {
@@ -48,36 +51,47 @@ public class OlakeRpcServer {
 
         String jsonConfig = args[0];
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, String> configMap = objectMapper.readValue(jsonConfig, new TypeReference<Map<String, String>>() {
+        Map<String, Object> configMap = objectMapper.readValue(jsonConfig, new TypeReference<Map<String, Object>>() {
         });
         
         // Simplified logging setup - console only
         LOGGER.info("Logs will be output to console only");
 
-        configMap.forEach(hadoopConf::set);
-        icebergProperties.putAll(configMap);
+        // Convert all config values to strings for hadoopConf
+        Map<String, String> stringConfigMap = new ConcurrentHashMap<>();
+        configMap.forEach((key, value) -> {
+            if (value != null && !"partition-fields".equals(key)) {
+                stringConfigMap.put(key, value.toString());
+            }
+        });
+        
+        stringConfigMap.forEach(hadoopConf::set);
+        icebergProperties.putAll(stringConfigMap);
         String catalogName = "iceberg";
-        if (configMap.get("catalog-name") != null) {
-            catalogName = configMap.get("catalog-name");
+        if (stringConfigMap.get("catalog-name") != null) {
+            catalogName = stringConfigMap.get("catalog-name");
         }
 
-        if (configMap.get("table-namespace") == null) {
+        if (stringConfigMap.get("table-namespace") == null) {
             throw new Exception("Iceberg table namespace not found");
         }
 
-        if (configMap.get("upsert") != null) {
-            upsert_records = Boolean.parseBoolean(configMap.get("upsert"));
+        if (stringConfigMap.get("upsert") != null) {
+            upsert_records = Boolean.parseBoolean(stringConfigMap.get("upsert"));
         }       
 
-        // Parse partition fields and their transforms
-        // Format: "partition.field.<fieldName>=<transform>"
-        // Example: "partition.field.ts_ms=day" or "partition.field.id=identity"
-        for (Map.Entry<String, String> entry : configMap.entrySet()) {
-            if (entry.getKey().startsWith("partition.field.")) {
-                String fieldName = entry.getKey().substring("partition.field.".length());
-                String transform = entry.getValue();
-                partitionTransforms.put(fieldName, transform);
-                LOGGER.info("Adding partition field: {} with transform: {}", fieldName, transform);
+        // Parse partition fields from array to preserve order
+        if (configMap.containsKey("partition-fields")) {
+            List<Map<String, String>> partitionFieldsList = (List<Map<String, String>>) configMap.get("partition-fields");
+            if (partitionFieldsList != null) {
+                for (Map<String, String> partitionField : partitionFieldsList) {
+                    String field = partitionField.get("field");
+                    String transform = partitionField.get("transform");
+                    if (field != null && transform != null) {
+                        partitionTransforms.add(partitionField);
+                        LOGGER.info("Adding partition field: {} with transform: {}", field, transform);
+                    }
+                }
             }
         }
 
@@ -95,7 +109,7 @@ public class OlakeRpcServer {
 
         // Retrieve a CDI-managed bean from the container
         ori = new OlakeRowsIngester(upsert_records);
-        ori.setIcebergNamespace(configMap.get("table-namespace"));
+        ori.setIcebergNamespace(stringConfigMap.get("table-namespace"));
         ori.setIcebergCatalog(icebergCatalog);
         // Pass partition transforms to the ingester
         ori.setPartitionTransforms(partitionTransforms);
@@ -103,14 +117,14 @@ public class OlakeRpcServer {
 
         // Build the server to listen on port 50051
         int port = 50051; // Default port
-        if (configMap.get("port") != null) {
-            port = Integer.parseInt(configMap.get("port"));
+        if (stringConfigMap.get("port") != null) {
+            port = Integer.parseInt(stringConfigMap.get("port"));
         }
         
         // Get max message size from config or use a reasonable default (500MB)
         int maxMessageSize = 2000 * 1024 * 1024; // 2GB default
-        if (configMap.get("max-message-size") != null) {
-            maxMessageSize = Integer.parseInt(configMap.get("max-message-size"));
+        if (stringConfigMap.get("max-message-size") != null) {
+            maxMessageSize = Integer.parseInt(stringConfigMap.get("max-message-size"));
         }
         
         Server server = ServerBuilder.forPort(port)

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.Map;
 import java.util.List;
-import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.ArrayList;
 
@@ -121,8 +120,8 @@ public class OlakeRpcServer {
             port = Integer.parseInt(stringConfigMap.get("port"));
         }
         
-        // Get max message size from config or use a reasonable default (500MB)
-        int maxMessageSize = 2000 * 1024 * 1024; // 2GB default
+        // Get max message size from config or use a reasonable default (1024MB)
+        int maxMessageSize = 1024 * 1024 * 1024; // 1GB default
         if (stringConfigMap.get("max-message-size") != null) {
             maxMessageSize = Integer.parseInt(stringConfigMap.get("max-message-size"));
         }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/RecordConverter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/RecordConverter.java
@@ -177,16 +177,12 @@ public class RecordConverter {
     // If not set during construction, try to extract from value data
     // This is a fallback and shouldn't normally be used since thread_id
     // is passed at the message level, not in the value data
-    try {
-      JsonNode valueNode = value();
-      if (valueNode != null && valueNode.has("thread_id")) {
-        return valueNode.get("thread_id").asText();
-      }
-    } catch (Exception e) {
-      LOGGER.debug("Failed to extract thread ID from value data", e);
+    JsonNode valueNode = value();
+    if (valueNode != null && valueNode.has("thread_id")) {
+      return valueNode.get("thread_id").asText();
+    } else {
+      throw new RuntimeException("Thread ID is required for all records");
     }
-    
-    return null;
   }
 
   public RecordWrapper convertAsAppend(Schema schema) {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/RecordConverter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/RecordConverter.java
@@ -52,11 +52,19 @@ public class RecordConverter {
   protected final byte[] keyData;
   private JsonNode value;
   private JsonNode key;
+  private String threadId; // Cache the thread ID
 
   public RecordConverter(String destination, byte[] valueData, byte[] keyData) {
     this.destination = destination;
     this.valueData = valueData;
     this.keyData = keyData;
+  }
+
+  public RecordConverter(String destination, byte[] valueData, byte[] keyData, String threadId) {
+    this.destination = destination;
+    this.valueData = valueData;
+    this.keyData = keyData;
+    this.threadId = threadId;
   }
 
   public JsonNode key() {
@@ -152,6 +160,33 @@ public class RecordConverter {
 
   public String destination() {
     return destination;
+  }
+
+  /**
+   * Extracts the thread ID from the record if present.
+   * The thread ID is expected to be at the top level of the JSON message.
+   * 
+   * @return The thread ID or null if not present
+   */
+  public String getThreadId() {
+    // Return cached value if already set
+    if (threadId != null) {
+      return threadId;
+    }
+    
+    // If not set during construction, try to extract from value data
+    // This is a fallback and shouldn't normally be used since thread_id
+    // is passed at the message level, not in the value data
+    try {
+      JsonNode valueNode = value();
+      if (valueNode != null && valueNode.has("thread_id")) {
+        return valueNode.get("thread_id").asText();
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Failed to extract thread ID from value data", e);
+    }
+    
+    return null;
   }
 
   public RecordWrapper convertAsAppend(Schema schema) {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
@@ -144,6 +144,7 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
     }
 
     public Table loadIcebergTable(TableIdentifier tableId, RecordConverter sampleEvent) {
+        // This is to prevent multiple writer threads from creating the same table at the same time.
         synchronized (tableCreationLock) {
             return IcebergUtil.loadIcebergTable(icebergCatalog, tableId).orElseGet(() -> {
                 try {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.HashMap;
+import java.util.ArrayList;
 
 // This class is used to receive rows from the Olake Golang project and dump it into iceberg using prebuilt code here.
 @Dependent
@@ -29,8 +29,10 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
     private final IcebergTableOperator icebergTableOperator;
     // Create a single reusable ObjectMapper instance
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    // Map to store partition fields and their transforms
-    private Map<String, String> partitionTransforms = new HashMap<>();
+    // List to store partition fields and their transforms - preserves order and allows duplicates
+    private List<Map<String, String>> partitionTransforms = new ArrayList<>();
+    // Lock object for table creation synchronization
+    private final Object tableCreationLock = new Object();
 
     public OlakeRowsIngester() {
         icebergTableOperator = new IcebergTableOperator();
@@ -48,7 +50,7 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
         this.icebergCatalog = icebergCatalog;
     }
 
-    public void setPartitionTransforms(Map<String, String> partitionTransforms) {
+    public void setPartitionTransforms(List<Map<String, String>> partitionTransforms) {
         this.partitionTransforms = partitionTransforms;
     }
 
@@ -60,6 +62,27 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
         List<String> messages = request.getMessagesList();
 
         try {
+            // First, check if this is a commit request
+            if (messages.size() == 1) {
+                String message = messages.get(0);
+                Map<String, Object> messageMap = objectMapper.readValue(message, new TypeReference<Map<String, Object>>() {});
+                if (messageMap.containsKey("commit") && messageMap.get("commit").equals(true) && messageMap.containsKey("thread_id")) {
+                    // This is a commit request
+                    String threadId = (String) messageMap.get("thread_id");
+                    LOGGER.info("{} Received commit request for thread: {}", requestId, threadId);
+                    icebergTableOperator.commitThread(threadId);
+                    
+                    RecordIngest.RecordIngestResponse response = RecordIngest.RecordIngestResponse.newBuilder()
+                            .setResult(requestId + " Successfully committed data for thread " + threadId)
+                            .build();
+                    responseObserver.onNext(response);
+                    responseObserver.onCompleted();
+                    LOGGER.info("{} Successfully committed data for thread: {}", requestId, threadId);
+                    return;
+                }
+            }
+            
+            // Normal record processing
             long parsingStartTime = System.currentTimeMillis();
             Map<String, List<RecordConverter>> result =
                     messages.parallelStream() // Use parallel stream for concurrent processing
@@ -70,6 +93,9 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
 
                                     // Get the destination table:
                                     String destinationTable = (String) messageMap.get("destination_table");
+                                    
+                                    // Extract thread_id if present
+                                    String threadId = (String) messageMap.get("thread_id");
 
                                     // Get key and value objects directly without re-serializing
                                     Object key = messageMap.get("key");
@@ -79,7 +105,7 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
                                     byte[] keyBytes = key != null ? objectMapper.writeValueAsBytes(key) : null;
                                     byte[] valueBytes = objectMapper.writeValueAsBytes(value);
 
-                                    return new RecordConverter(destinationTable, valueBytes, keyBytes);
+                                    return new RecordConverter(destinationTable, valueBytes, keyBytes, threadId);
                                 } catch (Exception e) {
                                     String errorMessage = String.format("%s Failed to parse message: %s", requestId, message);
                                     LOGGER.error(errorMessage, e);
@@ -118,15 +144,17 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
     }
 
     public Table loadIcebergTable(TableIdentifier tableId, RecordConverter sampleEvent) {
-        return IcebergUtil.loadIcebergTable(icebergCatalog, tableId).orElseGet(() -> {
-            try {
-                return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(true), "parquet", partitionTransforms);
-            } catch (Exception e) {
-                String errorMessage = String.format("Failed to create table from debezium event schema: %s Error: %s", tableId, e.getMessage());
-                LOGGER.error(errorMessage, e);
-                throw new DebeziumException(errorMessage, e);
-            }
-        });
+        synchronized (tableCreationLock) {
+            return IcebergUtil.loadIcebergTable(icebergCatalog, tableId).orElseGet(() -> {
+                try {
+                    return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(true), "parquet", partitionTransforms);
+                } catch (Exception e) {
+                    String errorMessage = String.format("Failed to create table from debezium event schema: %s Error: %s", tableId, e.getMessage());
+                    LOGGER.error(errorMessage, e);
+                    throw new DebeziumException(errorMessage, e);
+                }
+            });
+        }
     }
 }
 

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
@@ -50,13 +50,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
   public void write(Record row) throws IOException {
     RowDataDeltaWriter writer = route(row);
     Operation rowOperation = ((RecordWrapper) row).op();
-    if (rowOperation == Operation.INSERT) {
-      // new row
-      writer.write(row);
-    } else if (rowOperation == Operation.DELETE && !keepDeletes) {
+    if (rowOperation == Operation.DELETE && !keepDeletes) {
       // deletes. doing hard delete. when keepDeletes = FALSE we dont keep deleted record
       writer.deleteKey(keyProjection.wrap(row));
     } else {
+      // We are deleting key even for insert operations to avoid duplicate records for handling inserts happening while full-load
       writer.deleteKey(keyProjection.wrap(row));
       writer.write(row);
     }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -46,13 +46,13 @@ import java.util.HashMap;
 public class IcebergTableOperator {
 
   IcebergTableWriterFactory writerFactory2;
-  
+
   // Lock object for synchronizing commits
   private final Object commitLock = new Object();
-  
+
   // Map to track table references per thread
   private final Map<String, Table> threadTables = new ConcurrentHashMap<>();
-  
+
   // Map to store completed WriteResult per thread for later commit
   private final Map<String, List<WriteResult>> threadWriteResults = new ConcurrentHashMap<>();
 
@@ -78,7 +78,8 @@ public class IcebergTableOperator {
     cdcSourceTsMsField = "_cdc_timestamp";
   }
 
-  static final ImmutableMap<Operation, Integer> CDC_OPERATION_PRIORITY = ImmutableMap.of(Operation.INSERT, 1, Operation.READ, 2, Operation.UPDATE, 3, Operation.DELETE, 4);
+  static final ImmutableMap<Operation, Integer> CDC_OPERATION_PRIORITY = ImmutableMap.of(Operation.INSERT, 1,
+      Operation.READ, 2, Operation.UPDATE, 3, Operation.DELETE, 4);
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergTableOperator.class);
   @ConfigProperty(name = "debezium.sink.iceberg.upsert-dedup-column", defaultValue = "_cdc_timestamp")
   String cdcSourceTsMsField;
@@ -99,9 +100,10 @@ public class IcebergTableOperator {
     ConcurrentHashMap<JsonNode, RecordConverter> deduplicatedEvents = new ConcurrentHashMap<>();
 
     events.forEach(e -> {
-          if (e.key() == null || e.key().isNull()) {
-            throw new RuntimeException("Cannot deduplicate data with null key! destination:'" + e.destination() + "' event: '" + e.value().toString() + "'");
-          }
+      if (e.key() == null || e.key().isNull()) {
+        throw new RuntimeException("Cannot deduplicate data with null key! destination:'" + e.destination()
+            + "' event: '" + e.value().toString() + "'");
+      }
 
       try {
         // deduplicate using key(PK)
@@ -115,8 +117,7 @@ public class IcebergTableOperator {
       } catch (Exception ex) {
         throw new RuntimeException("Failed to deduplicate events", ex);
       }
-        }
-    );
+    });
 
     return new ArrayList<>(deduplicatedEvents.values());
   }
@@ -124,10 +125,12 @@ public class IcebergTableOperator {
   /**
    * This is used to deduplicate events within given batch.
    * <p>
-   * Forex ample a record can be updated multiple times in the source. for example insert followed by update and
+   * Forex ample a record can be updated multiple times in the source. for example
+   * insert followed by update and
    * delete. for this case we need to only pick last change event for the row.
    * <p>
-   * Its used when `upsert` feature enabled (when the consumer operating non append mode) which means it should not add
+   * Its used when `upsert` feature enabled (when the consumer operating non
+   * append mode) which means it should not add
    * duplicate records to target table.
    *
    * @param lhs
@@ -142,15 +145,15 @@ public class IcebergTableOperator {
       // return (x < y) ? -1 : ((x == y) ? 0 : 1);
       result = CDC_OPERATION_PRIORITY.getOrDefault(lhs.cdcOpValue(cdcOpField), -1)
           .compareTo(
-              CDC_OPERATION_PRIORITY.getOrDefault(rhs.cdcOpValue(cdcOpField), -1)
-          );
+              CDC_OPERATION_PRIORITY.getOrDefault(rhs.cdcOpValue(cdcOpField), -1));
     }
 
     return result;
   }
 
   /**
-   * If given schema contains new fields compared to target table schema then it adds new fields to target iceberg
+   * If given schema contains new fields compared to target table schema then it
+   * adds new fields to target iceberg
    * table.
    * <p>
    * Its used when allow field addition feature is enabled.
@@ -160,12 +163,12 @@ public class IcebergTableOperator {
    */
   private void applyFieldAddition(Table icebergTable, Schema newSchema) {
 
-    UpdateSchema us = icebergTable.updateSchema().
-        unionByNameWith(newSchema).
-        setIdentifierFields(newSchema.identifierFieldNames());
+    UpdateSchema us = icebergTable.updateSchema().unionByNameWith(newSchema)
+        .setIdentifierFields(newSchema.identifierFieldNames());
     Schema newSchemaCombined = us.apply();
 
-    // @NOTE avoid committing when there is no schema change. commit creates new commit even when there is no change!
+    // @NOTE avoid committing when there is no schema change. commit creates new
+    // commit even when there is no change!
     if (!icebergTable.schema().sameSchema(newSchemaCombined)) {
       LOGGER.warn("Extending schema of {}", icebergTable.name());
       us.commit();
@@ -175,10 +178,13 @@ public class IcebergTableOperator {
   /**
    * Adds list of events to iceberg table.
    * <p>
-   * If field addition enabled then it groups list of change events by their schema first. Then adds new fields to
-   * iceberg table if there is any. And then follows with adding data to the table.
+   * If field addition enabled then it groups list of change events by their
+   * schema first. Then adds new fields to
+   * iceberg table if there is any. And then follows with adding data to the
+   * table.
    * <p>
-   * New fields are detected using CDC event schema, since events are grouped by their schemas it uses single
+   * New fields are detected using CDC event schema, since events are grouped by
+   * their schemas it uses single
    * event to find-out schema for the whole list of events.
    *
    * @param icebergTable
@@ -186,7 +192,8 @@ public class IcebergTableOperator {
    */
   public void addToTable(Table icebergTable, List<RecordConverter> events) {
 
-    // when operation mode is not upsert deduplicate the events to avoid inserting duplicate row
+    // when operation mode is not upsert deduplicate the events to avoid inserting
+    // duplicate row
     if (upsert && !icebergTable.schema().identifierFieldIds().isEmpty()) {
       events = deduplicateBatch(events);
     }
@@ -195,14 +202,15 @@ public class IcebergTableOperator {
       // if field additions not enabled add set of events to table
       addToTablePerSchema(icebergTable, events);
     } else {
-      
-      Map<RecordConverter.SchemaConverter, List<RecordConverter>> eventsGroupedBySchema =
-          events.parallelStream()
-              .collect(Collectors.groupingBy(RecordConverter::schemaConverter));
-      
-      LOGGER.info("Batch got {} records with {} different schema!!", events.size(), eventsGroupedBySchema.keySet().size());
 
-      for (Map.Entry<RecordConverter.SchemaConverter, List<RecordConverter>> schemaEvents : eventsGroupedBySchema.entrySet()) {
+      Map<RecordConverter.SchemaConverter, List<RecordConverter>> eventsGroupedBySchema = events.parallelStream()
+          .collect(Collectors.groupingBy(RecordConverter::schemaConverter));
+
+      LOGGER.info("Batch got {} records with {} different schema!!", events.size(),
+          eventsGroupedBySchema.keySet().size());
+
+      for (Map.Entry<RecordConverter.SchemaConverter, List<RecordConverter>> schemaEvents : eventsGroupedBySchema
+          .entrySet()) {
         // extend table schema if new fields found
         applyFieldAddition(icebergTable, schemaEvents.getValue().get(0).icebergSchema(createIdentifierFields));
         // add set of events to table
@@ -218,43 +226,43 @@ public class IcebergTableOperator {
    * @param threadId The thread ID to commit
    * @throws RuntimeException if commit fails
    */
-  public void commitThread(String threadId) {    
+  public void commitThread(String threadId) {
     // Get the WriteResults for this thread
     List<WriteResult> writeResults = threadWriteResults.remove(threadId);
     Table table = threadTables.remove(threadId);
-    
+
     if (writeResults == null || writeResults.isEmpty()) {
       LOGGER.warn("No WriteResults found for thread: {}", threadId);
       return;
     }
-    
+
     if (table == null) {
       LOGGER.warn("No table found for thread: {}", threadId);
       return;
     }
-    
+
     // Calculate total files across all WriteResults
     int totalDataFiles = writeResults.stream().mapToInt(wr -> wr.dataFiles().length).sum();
     int totalDeleteFiles = writeResults.stream().mapToInt(wr -> wr.deleteFiles().length).sum();
-    
-    LOGGER.info("Committing {} data files and {} delete files across {} WriteResults for thread: {}", 
-               totalDataFiles, totalDeleteFiles, writeResults.size(), threadId);
-    
+
+    LOGGER.info("Committing {} data files and {} delete files across {} WriteResults for thread: {}",
+        totalDataFiles, totalDeleteFiles, writeResults.size(), threadId);
+
     // If no files were generated, nothing to commit
     if (totalDataFiles == 0 && totalDeleteFiles == 0) {
       LOGGER.info("No files to commit for thread: {}", threadId);
       return;
     }
-    
+
     // Commit the files
-    synchronized(commitLock) {
+    synchronized (commitLock) {
       try {
         // Refresh table before committing
         table.refresh();
-        
+
         // Check if any WriteResult has delete files
         boolean hasDeleteFiles = writeResults.stream().anyMatch(wr -> wr.deleteFiles().length > 0);
-        
+
         if (hasDeleteFiles) {
           RowDelta rowDelta = table.newRowDelta();
           // Add all data and delete files from all WriteResults
@@ -271,9 +279,9 @@ public class IcebergTableOperator {
           }
           appendFiles.commit();
         }
-        
-        LOGGER.info("Successfully committed {} data files and {} delete files across {} WriteResults for thread: {}", 
-                   totalDataFiles, totalDeleteFiles, writeResults.size(), threadId);
+
+        LOGGER.info("Successfully committed {} data files and {} delete files across {} WriteResults for thread: {}",
+            totalDataFiles, totalDeleteFiles, writeResults.size(), threadId);
       } catch (Exception e) {
         String errorMsg = String.format("Failed to commit data for thread %s: %s", threadId, e.getMessage());
         LOGGER.error(errorMsg, e);
@@ -283,124 +291,124 @@ public class IcebergTableOperator {
   }
 
   /**
-   * Adds list of change events to iceberg table. All the events are having same schema.
+   * Adds list of change events to iceberg table. All the events are having same
+   * schema.
    *
    * @param icebergTable
    * @param events
    */
   private void addToTablePerSchema(Table icebergTable, List<RecordConverter> events) {
 
-      String threadId = events.get(0).getThreadId();
-      if (threadId == null || threadId.isEmpty()) {
-        throw new RuntimeException("Thread ID is required for all records");
-      }
-      
-      // Create a new writer for this batch
-      LOGGER.info("Creating new writer for thread: {}", threadId);
-      threadTables.put(threadId, icebergTable);
-      BaseTaskWriter<Record> writer = writerFactory2.create(icebergTable);
-      
-      try {
-        // Convert and optionally sort records in a single stream operation
-        List<RecordWrapper> convertedRecords;
-        
-        if (!icebergTable.spec().isUnpartitioned() && events.size() > 1) {
-          // Create partition comparator for sorting
-          PartitionKey pk1 = new PartitionKey(icebergTable.spec(), icebergTable.schema());
-          PartitionKey pk2 = new PartitionKey(icebergTable.spec(), icebergTable.schema());
-          InternalRecordWrapper wrapper = new InternalRecordWrapper(icebergTable.schema().asStruct());
+    String threadId = events.get(0).getThreadId();
 
-          Comparator<RecordWrapper> partitionComparator = (r1, r2) -> {
-            pk1.partition(wrapper.wrap(r1));
-            pk2.partition(wrapper.wrap(r2));
+    // Create a new writer for this batch
+    LOGGER.info("Creating new writer for thread: {}", threadId);
+    threadTables.put(threadId, icebergTable);
+    BaseTaskWriter<Record> writer = writerFactory2.create(icebergTable);
 
-            int numFields = icebergTable.spec().fields().size();
-            for (int i = 0; i < numFields; i++) {
-              Object v1 = pk1.get(i, Object.class);
-              Object v2 = pk2.get(i, Object.class);
+    try {
+      // Convert and optionally sort records in a single stream operation
+      List<RecordWrapper> convertedRecords;
 
-              // Handle nulls explicitly
-              if (v1 == null && v2 == null) {
-                continue;
-              } else if (v1 == null) {
-                return -1;
-              } else if (v2 == null) {
-                return 1;
-              }
+      if (!icebergTable.spec().isUnpartitioned() && events.size() > 1) {
+        // Create partition comparator for sorting
+        PartitionKey pk1 = new PartitionKey(icebergTable.spec(), icebergTable.schema());
+        PartitionKey pk2 = new PartitionKey(icebergTable.spec(), icebergTable.schema());
+        InternalRecordWrapper wrapper = new InternalRecordWrapper(icebergTable.schema().asStruct());
 
-              @SuppressWarnings("unchecked")
-              int cmp = ((Comparable<Object>) v1).compareTo(v2);
-              if (cmp != 0) {
-                return cmp;
-              }
+        Comparator<RecordWrapper> partitionComparator = (r1, r2) -> {
+          pk1.partition(wrapper.wrap(r1));
+          pk2.partition(wrapper.wrap(r2));
+
+          int numFields = icebergTable.spec().fields().size();
+          for (int i = 0; i < numFields; i++) {
+            Object v1 = pk1.get(i, Object.class);
+            Object v2 = pk2.get(i, Object.class);
+
+            // Handle nulls explicitly
+            if (v1 == null && v2 == null) {
+              continue;
+            } else if (v1 == null) {
+              return -1;
+            } else if (v2 == null) {
+              return 1;
             }
-            return 0;
-          };
-          
-          // Convert and sort in single stream operation
-          convertedRecords = events.stream()
-              .map(e -> (upsert && !icebergTable.schema().identifierFieldIds().isEmpty())
-                  ? e.convert(icebergTable.schema(), cdcOpField)
-                  : e.convertAsAppend(icebergTable.schema()))
-              .sorted(partitionComparator)
-              .collect(Collectors.toList());
-        } else {
-          // Just convert without sorting for unpartitioned tables or single record
-          convertedRecords = events.stream()
-              .map(e -> (upsert && !icebergTable.schema().identifierFieldIds().isEmpty())
-                  ? e.convert(icebergTable.schema(), cdcOpField)
-                  : e.convertAsAppend(icebergTable.schema()))
-              .collect(Collectors.toList());
-        }
-        
-        // Write converted records sequentially to maintain thread safety with the writer
-        for (RecordWrapper record : convertedRecords) {
-            writer.write(record);
-        }
-        
-        LOGGER.info("Successfully wrote {} events for thread: {}", events.size(), threadId);
-        
-        // Complete the writer and store the WriteResult for later commit
-        try {
-          WriteResult writeResult = writer.complete();
-          threadWriteResults.computeIfAbsent(threadId, k -> new ArrayList<>()).add(writeResult);
-          
-          LOGGER.info("Writer for thread {} completed with {} data files and {} delete files", 
-                     threadId, writeResult.dataFiles().length, writeResult.deleteFiles().length);
-          
-        } catch (IOException e) {
-          LOGGER.error("Failed to complete writer for thread: {}", threadId, e);
-          throw new RuntimeException("Failed to complete writer for thread: " + threadId, e);
-        } finally {
-          // Close the writer
-          try {
-            writer.close();
-          } catch (IOException e) {
-            LOGGER.warn("Failed to close writer for thread: {}", threadId, e);
+
+            @SuppressWarnings("unchecked")
+            int cmp = ((Comparable<Object>) v1).compareTo(v2);
+            if (cmp != 0) {
+              return cmp;
+            }
           }
-        }
-        
-      } catch (Exception ex) {
-        LOGGER.error("Failed to write data to table: {} for thread: {}", icebergTable.name(), threadId, ex);
-        
-        // Clean up the writer
-        try {
-          writer.abort();
-        } catch (IOException abortEx) {
-          LOGGER.warn("Failed to abort writer", abortEx);
-        }
+          return 0;
+        };
+
+        // Convert and sort in single stream operation
+        // Sorting with partitions values to make sure Iceberg-java writes it without
+        // having too many files open. In a Clustered Writer way.
+        convertedRecords = events.stream()
+            .map(e -> (upsert && !icebergTable.schema().identifierFieldIds().isEmpty())
+                ? e.convert(icebergTable.schema(), cdcOpField)
+                : e.convertAsAppend(icebergTable.schema()))
+            .sorted(partitionComparator)
+            .collect(Collectors.toList());
+      } else {
+        // Just convert without sorting for unpartitioned tables or single record
+        convertedRecords = events.stream()
+            .map(e -> (upsert && !icebergTable.schema().identifierFieldIds().isEmpty())
+                ? e.convert(icebergTable.schema(), cdcOpField)
+                : e.convertAsAppend(icebergTable.schema()))
+            .collect(Collectors.toList());
+      }
+
+      // Write converted records sequentially to maintain thread safety with the
+      // writer
+      for (RecordWrapper record : convertedRecords) {
+        writer.write(record);
+      }
+
+      LOGGER.info("Successfully wrote {} events for thread: {}", events.size(), threadId);
+
+      // Complete the writer and store the WriteResult for later commit
+      try {
+        WriteResult writeResult = writer.complete();
+        threadWriteResults.computeIfAbsent(threadId, k -> new ArrayList<>()).add(writeResult);
+
+        LOGGER.info("Writer for thread {} completed with {} data files and {} delete files",
+            threadId, writeResult.dataFiles().length, writeResult.deleteFiles().length);
+
+      } catch (IOException e) {
+        LOGGER.error("Failed to complete writer for thread: {}", threadId, e);
+        throw new RuntimeException("Failed to complete writer for thread: " + threadId, e);
+      } finally {
+        // Close the writer
         try {
           writer.close();
         } catch (IOException e) {
-          LOGGER.warn("Failed to close writer", e);
+          LOGGER.warn("Failed to close writer for thread: {}", threadId, e);
         }
-        
-        // Also clean up any stored write results for this thread
-        threadWriteResults.remove(threadId);
-        threadTables.remove(threadId);
-        
-        throw new RuntimeException("Failed to write data to table: " + icebergTable.name(), ex);
       }
-    
+
+    } catch (Exception ex) {
+      LOGGER.error("Failed to write data to table: {} for thread: {}", icebergTable.name(), threadId, ex);
+
+      // Clean up the writer
+      try {
+        writer.abort();
+      } catch (IOException abortEx) {
+        LOGGER.warn("Failed to abort writer", abortEx);
+      }
+      try {
+        writer.close();
+      } catch (IOException e) {
+        LOGGER.warn("Failed to close writer", e);
+      }
+
+      // Also clean up any stored write results for this thread
+      threadWriteResults.remove(threadId);
+      threadTables.remove(threadId);
+
+      throw new RuntimeException("Failed to write data to table: " + icebergTable.name(), ex);
+    }
   }
 }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/resources/log4j2.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/resources/log4j2.xml
@@ -18,5 +18,8 @@
         <Logger name="io.grpc" level="error" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
+        <Logger name="org.apache.hadoop.io.compress.CodecPool" level="warn" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
     </Loggers>
 </Configuration> 

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -313,7 +313,7 @@ func (p *Parquet) getPartitionedFilePath(values map[string]any, olakeTimestamp t
 		return p.basePath
 	}
 	// path pattern example /{col_name, 'fallback', granularity}/random_string/{col_name, fallback, granularity}
-	patternRegex := regexp.MustCompile(constants.PartitionRegex)
+	patternRegex := regexp.MustCompile(constants.PartitionRegexParquet)
 
 	// Replace placeholders
 	result := patternRegex.ReplaceAllStringFunc(pattern, func(match string) string {

--- a/drivers/postgres/internal/backfill.go
+++ b/drivers/postgres/internal/backfill.go
@@ -34,6 +34,7 @@ func (p *Postgres) ChunkIterator(ctx context.Context, stream types.StreamInterfa
 		if err != nil {
 			return fmt.Errorf("failed to scan record data as map: %s", err)
 		}
+
 		return OnMessage(record)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/xitongsys/parquet-go-source v0.0.0-20241021075129-b732d2ac9c9b
 	go.mongodb.org/mongo-driver v1.17.3
 	golang.org/x/tools v0.30.0
-	google.golang.org/grpc v1.71.0
-	google.golang.org/protobuf v1.36.5
+	google.golang.org/grpc v1.71.3
+	google.golang.org/protobuf v1.36.6
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/pkg/waljs/waljs.go
+++ b/pkg/waljs/waljs.go
@@ -188,7 +188,6 @@ func (s *Socket) StreamMessages(ctx context.Context, callback abstract.CDCMsgFn)
 					if err != nil {
 						return fmt.Errorf("failed to ack lsn: %s", err)
 					}
-					s.ClientXLogPos = pkm.ServerWALEnd
 				}
 			case pglogrepl.XLogDataByteID:
 				// Reset the idle timer on receiving WAL data.

--- a/pkg/waljs/waljs.go
+++ b/pkg/waljs/waljs.go
@@ -189,6 +189,7 @@ func (s *Socket) StreamMessages(ctx context.Context, callback abstract.CDCMsgFn)
 						return fmt.Errorf("failed to ack lsn: %s", err)
 					}
 				}
+				s.ClientXLogPos = pkm.ServerWALEnd
 			case pglogrepl.XLogDataByteID:
 				// Reset the idle timer on receiving WAL data.
 				xld, err := pglogrepl.ParseXLogData(copyData.Data[1:])

--- a/pkg/waljs/waljs.go
+++ b/pkg/waljs/waljs.go
@@ -188,8 +188,8 @@ func (s *Socket) StreamMessages(ctx context.Context, callback abstract.CDCMsgFn)
 					if err != nil {
 						return fmt.Errorf("failed to ack lsn: %s", err)
 					}
+					s.ClientXLogPos = pkm.ServerWALEnd
 				}
-				s.ClientXLogPos = pkm.ServerWALEnd
 			case pglogrepl.XLogDataByteID:
 				// Reset the idle timer on receiving WAL data.
 				xld, err := pglogrepl.ParseXLogData(copyData.Data[1:])

--- a/types/data_types.go
+++ b/types/data_types.go
@@ -65,12 +65,6 @@ type RawRecord struct {
 	CdcTimestamp   time.Time      `parquet:"_cdc_timestamp"`
 }
 
-// PartitionInfo represents a Iceberg partition column with its transform, preserving order
-type PartitionInfo struct {
-	Field     string
-	Transform string
-}
-
 func CreateRawRecord(olakeID string, data map[string]any, operationType string, cdcTimestamp time.Time) RawRecord {
 	return RawRecord{
 		OlakeID:       olakeID,

--- a/types/data_types.go
+++ b/types/data_types.go
@@ -65,6 +65,12 @@ type RawRecord struct {
 	CdcTimestamp   time.Time      `parquet:"_cdc_timestamp"`
 }
 
+// PartitionInfo represents a Iceberg partition column with its transform, preserving order
+type PartitionInfo struct {
+	Field     string
+	Transform string
+}
+
 func CreateRawRecord(olakeID string, data map[string]any, operationType string, cdcTimestamp time.Time) RawRecord {
 	return RawRecord{
 		OlakeID:       olakeID,
@@ -74,7 +80,7 @@ func CreateRawRecord(olakeID string, data map[string]any, operationType string, 
 	}
 }
 
-func (r *RawRecord) ToDebeziumFormat(db string, stream string, normalization bool) (string, error) {
+func (r *RawRecord) ToDebeziumFormat(db string, stream string, normalization bool, threadID string) (string, error) {
 	// First create the schema and track field types
 	schema := r.createDebeziumSchema(db, stream, normalization)
 
@@ -126,6 +132,11 @@ func (r *RawRecord) ToDebeziumFormat(db string, stream string, normalization boo
 			"schema":  schema,
 			"payload": payload,
 		},
+	}
+
+	// Add thread_id if not empty
+	if threadID != "" {
+		debeziumRecord["thread_id"] = threadID
 	}
 
 	jsonBytes, err := json.Marshal(debeziumRecord)

--- a/utils/typeutils/compare.go
+++ b/utils/typeutils/compare.go
@@ -1,0 +1,24 @@
+package typeutils
+
+import "github.com/datazip-inc/olake/utils"
+
+func Compare(a, b any) int {
+	// Handle nil cases first
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	aTime, aOk := a.(Time)
+	bTime, bOk := b.(Time)
+
+	if aOk && bOk {
+		return aTime.Compare(bTime)
+	}
+	return utils.CompareInterfaceValue(a, b)
+}

--- a/utils/typeutils/time.go
+++ b/utils/typeutils/time.go
@@ -21,3 +21,30 @@ func (ct *Time) UnmarshalJSON(b []byte) error {
 	*ct = Time{time}
 	return nil
 }
+
+// Before reports whether the time instant ct is before u
+func (ct Time) Before(u Time) bool {
+	return ct.Time.Before(u.Time)
+}
+
+// After reports whether the time instant ct is after u
+func (ct Time) After(u Time) bool {
+	return ct.Time.After(u.Time)
+}
+
+// Equal reports whether ct and u represent the same time instant
+func (ct Time) Equal(u Time) bool {
+	return ct.Time.Equal(u.Time)
+}
+
+// Compare compares the time instant ct with u. If ct is before u, it returns -1;
+// if ct is after u, it returns +1; if they're the same, it returns 0.
+func (ct Time) Compare(u Time) int {
+	if ct.Before(u) {
+		return -1
+	}
+	if ct.After(u) {
+		return 1
+	}
+	return 0
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -288,29 +288,52 @@ func AddConstantToInterface(val interface{}, increment int) (interface{}, error)
 
 // return 0 for equal, -1 if a < b else 1 if a>b
 func CompareInterfaceValue(a, b interface{}) int {
-	switch a.(type) {
+	// Handle nil cases first
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	switch aVal := a.(type) {
 	case int, int64, float32, float64:
-		af := 0.0
-		if a != nil {
-			af = reflect.ValueOf(a).Convert(reflect.TypeOf(float64(0))).Float()
-		}
-		bf := 0.0
-		if b != nil {
-			bf = reflect.ValueOf(b).Convert(reflect.TypeOf(float64(0))).Float()
-		}
+		af := reflect.ValueOf(a).Convert(reflect.TypeOf(float64(0))).Float()
+		bf := reflect.ValueOf(b).Convert(reflect.TypeOf(float64(0))).Float()
 		if af < bf {
 			return -1
 		} else if af > bf {
 			return 1
 		}
+		return 0
 	case string:
-		if a != nil && b != nil {
-			return strings.Compare(a.(string), b.(string))
+		return strings.Compare(aVal, b.(string))
+	case time.Time:
+		bTime := b.(time.Time)
+		if aVal.Before(bTime) {
+			return -1
+		} else if aVal.After(bTime) {
+			return 1
 		}
-		return Ternary(a == nil, -1, 1).(int)
+		return 0
+	case bool:
+		bBool := b.(bool)
+		// false < true
+		if !aVal && bBool {
+			return -1
+		} else if aVal && !bBool {
+			return 1
+		}
+		return 0
+	default:
+		// For any other types, convert to string for comparison
+		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
 	}
-	return 0
 }
+
 func ConvertToString(value interface{}) string {
 	switch v := value.(type) {
 	case []byte:


### PR DESCRIPTION
# Description

Currently Iceberg writer can duplicate data as if chunk fails in between it can still take the commit the data. and when chunk gets processed again, then it can write the previously committed data again.

Fixes # (issue)

1. From going forward, we are committing only when the chunk is finished writing. We will not commit in between to avoid duplication.
2. for CDC or delta use case it will have deletes now for inserts as well (Because full-load & cdc running one after another can produce duplicates). 
3. fixed issue of random partitioning order
4. If one threads breaks, others should also fail and should not commit

## Type of change

<!--
Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Basic full load of postgres (small tables), getting committed successfully
- [X] Basic CDC workflow
- [ ] Failing one of the threads
- [ ] partitioning order test

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
