### PR TITLE
Add JDBC URL params and SSL config support to MySQL connector (#378)

### DIFF
--- a/drivers/mysql/README.md
+++ b/drivers/mysql/README.md
@@ -36,10 +36,48 @@ Add MySql credentials in following format in `config.json` file. [More details.]
      },
     "tls_skip_verify": true,
     "max_threads":10,
-    "backoff_retry_count": 2
+    "backoff_retry_count": 2,
+    "jdbc_url_params": {
+      "connectTimeout": "30000",
+      "socketTimeout": "30000",
+      "useSSL": "true"
+    },
+    "ssl_config": {
+      "mode": "verify-ca",
+      "server_ca": "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+      "client_cert": "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----",
+      "client_key": "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----"
+    }
   }
 ```
 
+#### JDBC URL Parameters
+
+The `jdbc_url_params` field allows you to specify custom connection parameters for the MySQL JDBC connection. These parameters will be appended to the connection string. Common parameters include:
+
+- `connectTimeout`: Connection timeout in milliseconds
+- `socketTimeout`: Socket timeout in milliseconds
+- `useSSL`: Whether to use SSL for the connection
+- `autoReconnect`: Whether to automatically reconnect if connection is lost
+- `characterEncoding`: Character encoding to use
+- `serverTimezone`: Server timezone to use
+
+#### SSL Configuration
+
+The `ssl_config` field provides advanced SSL configuration options:
+
+- `mode`: SSL mode to use. Options include:
+  - `disable`: No SSL
+  - `require`: Use SSL, but don't verify the server certificate
+  - `verify-ca`: Verify that the server certificate is signed by a trusted CA
+  - `verify-full`: Verify that the server certificate is signed by a trusted CA and the server hostname matches the certificate
+
+When using `verify-ca` or `verify-full` modes, you must provide:
+- `server_ca`: The CA certificate in PEM format
+- `client_cert`: The client certificate in PEM format
+- `client_key`: The client private key in PEM format
+
+For simple SSL connections without certificate verification, you can use the `tls_skip_verify` option instead of the full SSL configuration.
 
 ## Commands
 

--- a/drivers/mysql/internal/mysql_test.go
+++ b/drivers/mysql/internal/mysql_test.go
@@ -2,6 +2,9 @@ package driver
 
 import (
 	"testing"
+
+	"github.com/datazip-inc/olake/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 // Test functions using base utilities
@@ -19,4 +22,87 @@ func TestMySQLDiscover(t *testing.T) {
 func TestMySQLRead(t *testing.T) {
 	conn, abstractDriver := testAndBuildAbstractDriver(t)
 	abstractDriver.TestRead(t, conn, ExecuteQuery)
+}
+
+func TestURIWithJDBCParams(t *testing.T) {
+	config := &Config{
+		Host:     "localhost",
+		Port:     3306,
+		Username: "user",
+		Password: "pass",
+		Database: "testdb",
+		JDBCURLParams: map[string]string{
+			"connectTimeout": "30000",
+			"useSSL":         "true",
+		},
+	}
+
+	uri := config.URI()
+	assert.Contains(t, uri, "connectTimeout=30000")
+	assert.Contains(t, uri, "useSSL=true")
+}
+
+func TestURIWithSSLConfig(t *testing.T) {
+	// Test with SSLModeRequire
+	config := &Config{
+		Host:     "localhost",
+		Port:     3306,
+		Username: "user",
+		Password: "pass",
+		Database: "testdb",
+		SSLConfig: &utils.SSLConfig{
+			Mode: utils.SSLModeRequire,
+		},
+	}
+
+	uri := config.URI()
+	assert.Contains(t, uri, "tls=true")
+
+	// Test with SSLModeDisable
+	config.SSLConfig.Mode = utils.SSLModeDisable
+	uri = config.URI()
+	assert.Contains(t, uri, "tls=false")
+
+	// Test with TLSSkipVerify
+	config = &Config{
+		Host:          "localhost",
+		Port:          3306,
+		Username:      "user",
+		Password:      "pass",
+		Database:      "testdb",
+		TLSSkipVerify: true,
+	}
+
+	uri = config.URI()
+	assert.Contains(t, uri, "tls=skip-verify")
+}
+
+func TestConfigValidation(t *testing.T) {
+	// Test with valid SSL config
+	config := &Config{
+		Host:     "localhost",
+		Port:     3306,
+		Username: "user",
+		Password: "pass",
+		Database: "testdb",
+		SSLConfig: &utils.SSLConfig{
+			Mode:       utils.SSLModeVerifyCA,
+			ServerCA:   "ca-cert",
+			ClientCert: "client-cert",
+			ClientKey:  "client-key",
+		},
+	}
+
+	err := config.Validate()
+	assert.NoError(t, err)
+
+	// Test with invalid SSL config (missing required fields)
+	config.SSLConfig = &utils.SSLConfig{
+		Mode: utils.SSLModeVerifyCA,
+		// Missing ServerCA, ClientCert, ClientKey
+	}
+
+	err = config.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid SSL configuration")
 }


### PR DESCRIPTION
# Description

This PR adds JDBC URL parameters and SSL configuration support to the MySQL connector. Users can now specify custom connection parameters and configure secure SSL connections with certificate-based authentication.
Fixes #378

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update

# How Has This Been Tested?

[x] Added unit tests for JDBC URL parameters functionality
[x] Added unit tests for different SSL configuration modes
[x] Tested configuration validation with both valid and invalid SSL settings

# Screenshots or Recordings
NA

## Related PR's (If Any):
NA
