### PR TITLE
feat: unify Oracle config with connection_type replacing service_name and sid

### DIFF
--- a/drivers/oracle/README.md
+++ b/drivers/oracle/README.md
@@ -25,8 +25,9 @@ Add Oracle credentials in following format in `config.json` file. [More details.
     "host": "oracle-host",
     "username": "oracle-user",
     "password": "oracle-password",
-    "service_name": "oracle-service-name",
-    "sid": "ez",
+    "connection_type":{
+    "service_name": "oracle-service-name" //either service_name or sid can be entered here
+    },
     "port": 1521,
     "max_threads": 10,
     "retry_count": 0,

--- a/drivers/oracle/internal/config.go
+++ b/drivers/oracle/internal/config.go
@@ -21,8 +21,11 @@ type Config struct {
 	SSLConfiguration *utils.SSLConfig  `json:"ssl"`
 }
 
-type ConnectionType struct {
-	SID         string `json:"sid"`
+type SID struct {
+	SID string `json:"sid"`
+}
+
+type ServiceName struct {
 	ServiceName string `json:"service_name"`
 }
 
@@ -33,15 +36,20 @@ func (c *Config) connectionString() (string, error) {
 		urlOptions[k] = v
 	}
 
-	connectionType := &ConnectionType{}
-	if err := utils.Unmarshal(c.ConnectionType, &connectionType); err != nil {
-		return "", fmt.Errorf("failed to unmarshal connection type: %s", err)
-	}
 	serviceName := ""
-	if connectionType.SID != "" {
-		urlOptions["SID"] = connectionType.SID
+	found, _ := utils.IsOfType(c.ConnectionType, "sid")
+	if found {
+		unmarshalledSID := &SID{}
+		if err := utils.Unmarshal(c.ConnectionType, unmarshalledSID); err != nil {
+			return "", fmt.Errorf("failed to unmarshal sid: %s", err)
+		}
+		urlOptions["SID"] = unmarshalledSID.SID
 	} else {
-		serviceName = connectionType.ServiceName
+		unmarshalledServiceName := &ServiceName{}
+		if err := utils.Unmarshal(c.ConnectionType, unmarshalledServiceName); err != nil {
+			return "", fmt.Errorf("failed to unmarshal service name: %s", err)
+		}
+		serviceName = unmarshalledServiceName.ServiceName
 	}
 
 	// Add SSL params if provided

--- a/drivers/oracle/internal/oracle.go
+++ b/drivers/oracle/internal/oracle.go
@@ -31,7 +31,11 @@ func (o *Oracle) Setup(ctx context.Context) error {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 	// TODO: Add support for more encryption options provided in OracleDB
-	client, err := sqlx.Open("oracle", o.config.connectionString())
+	connectionString, err := o.config.connectionString()
+	if err != nil {
+		return fmt.Errorf("failed to get connection string: %s", err)
+	}
+	client, err := sqlx.Open("oracle",connectionString)
 	if err != nil {
 		return fmt.Errorf("failed to open database connection: %s", err)
 	}


### PR DESCRIPTION
# Description

Previously, Oracle configuration required directly specifying either `service_name` or `sid` as top-level fields.  
This PR introduces a new `connection_type` field, which encapsulates either a `service_name` or a `sid`, allowing for cleaner and more structured configuration input.

## Type of change

<!--Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Verified discover and sync using both `service_name` and `sid` as part of the new `connection_type` structure.