### PR TITLE
fix: oracle incremental fallback cursor deletion handled correctly

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/drivers/abstract/incremental.go
+++ b/drivers/abstract/incremental.go
@@ -27,6 +27,8 @@ func (a *AbstractDriver) Incremental(ctx context.Context, pool *destination.Writ
 			backfillWaitChannel <- stream.ID()
 			return nil
 		}
+		// Reset only mentioned cursor state while preserving other state values
+		a.state.ResetCursor(stream.Self())
 		return a.Backfill(ctx, backfillWaitChannel, pool, stream)
 	})
 	if err != nil {
@@ -95,11 +97,6 @@ func (a *AbstractDriver) Incremental(ctx context.Context, pool *destination.Writ
 func (a *AbstractDriver) getIncrementCursorFromState(primaryCursorField string, secondaryCursorField string, stream types.StreamInterface) (any, any, error) {
 	primaryStateCursorValue := a.state.GetCursor(stream.Self(), primaryCursorField)
 	secondaryStateCursorValue := a.state.GetCursor(stream.Self(), secondaryCursorField)
-
-	if primaryStateCursorValue == nil || (secondaryCursorField != "" && secondaryStateCursorValue == nil) {
-		// returning nil,nil,nil as there might be cases when primary state has some value but the secondary cursor value is nil, which might cause issue in while syncing in incremental mode
-		return nil, nil, nil
-	}
 
 	getCursorValue := func(cursorField string, cursorValue any) (any, error) {
 		if cursorField == "" {

--- a/drivers/abstract/incremental.go
+++ b/drivers/abstract/incremental.go
@@ -97,6 +97,7 @@ func (a *AbstractDriver) getIncrementCursorFromState(primaryCursorField string, 
 	secondaryStateCursorValue := a.state.GetCursor(stream.Self(), secondaryCursorField)
 
 	if primaryStateCursorValue == nil || (secondaryCursorField != "" && secondaryStateCursorValue == nil) {
+		// returning nil,nil,nil as there might be cases when primary state has some value but the secondary cursor value is nil, which might cause issue in while syncing in incremental mode
 		return nil, nil, nil
 	}
 

--- a/drivers/abstract/incremental.go
+++ b/drivers/abstract/incremental.go
@@ -97,7 +97,7 @@ func (a *AbstractDriver) getIncrementCursorFromState(primaryCursorField string, 
 	secondaryStateCursorValue := a.state.GetCursor(stream.Self(), secondaryCursorField)
 
 	if primaryStateCursorValue == nil || (secondaryCursorField != "" && secondaryStateCursorValue == nil) {
-		return primaryStateCursorValue, secondaryStateCursorValue, nil
+		return nil, nil, nil
 	}
 
 	getCursorValue := func(cursorField string, cursorValue any) (any, error) {

--- a/drivers/oracle/internal/backfill.go
+++ b/drivers/oracle/internal/backfill.go
@@ -69,8 +69,9 @@ func (o *Oracle) GetOrSplitChunks(ctx context.Context, pool *destination.WriterP
 		query = jdbc.OracleBlockSizeQuery()
 		var blockSize int64
 		err = o.client.QueryRow(query).Scan(&blockSize)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get block size: %s", err)
+		if err != nil || blockSize == 0 {
+			logger.Warnf("failed to get block size from query, switching to default block size value 8192")
+			blockSize = 8192
 		}
 		blocksPerChunk := int64(math.Ceil(float64(constants.EffectiveParquetSize) / float64(blockSize)))
 

--- a/drivers/oracle/internal/incremental.go
+++ b/drivers/oracle/internal/incremental.go
@@ -25,6 +25,12 @@ func (o *Oracle) StreamIncrementalChanges(ctx context.Context, stream types.Stre
 	primaryCursor, secondaryCursor := stream.Cursor()
 	lastPrimaryCursorValue := o.state.GetCursor(stream.Self(), primaryCursor)
 	lastSecondaryCursorValue := o.state.GetCursor(stream.Self(), secondaryCursor)
+	if lastPrimaryCursorValue == nil {
+		logger.Warnf("Stored primary cursor value is nil for the stream [%s]", stream.ID())
+	}
+	if secondaryCursor != "" && lastSecondaryCursorValue == nil {
+		logger.Warnf("Stored secondary cursor value is nil for the stream [%s]", stream.ID())
+	}
 
 	filter, err := jdbc.SQLFilter(stream, o.Type())
 	if err != nil {

--- a/drivers/oracle/internal/incremental.go
+++ b/drivers/oracle/internal/incremental.go
@@ -41,7 +41,7 @@ func (o *Oracle) StreamIncrementalChanges(ctx context.Context, stream types.Stre
 	if err != nil {
 		return fmt.Errorf("failed to format cursor condition: %s", err)
 	}
-	filter = utils.Ternary(filter != "", fmt.Sprintf("%s AND %s", filter, incrementalCondition), incrementalCondition).(string)
+	filter = utils.Ternary(filter != "", fmt.Sprintf("(%s) AND %s", filter, incrementalCondition), incrementalCondition).(string)
 
 	query := fmt.Sprintf("SELECT * FROM %q.%q WHERE %s",
 		stream.Namespace(), stream.Name(), filter)

--- a/drivers/oracle/internal/incremental.go
+++ b/drivers/oracle/internal/incremental.go
@@ -22,22 +22,12 @@ const (
 
 // StreamIncrementalChanges implements incremental sync for Oracle
 func (o *Oracle) StreamIncrementalChanges(ctx context.Context, stream types.StreamInterface, processFn abstract.BackfillMsgFn) error {
-	primaryCursor, secondaryCursor := stream.Cursor()
-	lastPrimaryCursorValue := o.state.GetCursor(stream.Self(), primaryCursor)
-	lastSecondaryCursorValue := o.state.GetCursor(stream.Self(), secondaryCursor)
-	if lastPrimaryCursorValue == nil {
-		logger.Warnf("Stored primary cursor value is nil for the stream [%s]", stream.ID())
-	}
-	if secondaryCursor != "" && lastSecondaryCursorValue == nil {
-		logger.Warnf("Stored secondary cursor value is nil for the stream [%s]", stream.ID())
-	}
-
 	filter, err := jdbc.SQLFilter(stream, o.Type())
 	if err != nil {
 		return fmt.Errorf("failed to create sql filter during incremental sync: %s", err)
 	}
 
-	incrementalCondition, err := o.buildIncrementalCondition(primaryCursor, secondaryCursor, stream, lastPrimaryCursorValue, lastSecondaryCursorValue)
+	incrementalCondition, err := o.buildIncrementalCondition(stream)
 	if err != nil {
 		return fmt.Errorf("failed to format cursor condition: %s", err)
 	}
@@ -68,7 +58,17 @@ func (o *Oracle) StreamIncrementalChanges(ctx context.Context, stream types.Stre
 }
 
 // buildIncrementalCondition generates the incremental condition SQL based on datatype and cursor value.
-func (o *Oracle) buildIncrementalCondition(primaryCursorField string, secondaryCursorField string, stream types.StreamInterface, lastPrimaryCursorValue any, lastSecondaryCursorValue any) (string, error) {
+func (o *Oracle) buildIncrementalCondition(stream types.StreamInterface) (string, error) {
+	primaryCursorField, secondaryCursorField := stream.Cursor()
+	lastPrimaryCursorValue := o.state.GetCursor(stream.Self(), primaryCursorField)
+	lastSecondaryCursorValue := o.state.GetCursor(stream.Self(), secondaryCursorField)
+	if lastPrimaryCursorValue == nil {
+		logger.Warnf("Stored primary cursor value is nil for the stream [%s]", stream.ID())
+	}
+	if secondaryCursorField != "" && lastSecondaryCursorValue == nil {
+		logger.Warnf("Stored secondary cursor value is nil for the stream [%s]", stream.ID())
+	}
+
 	formattedValue := func(cursorField string, lastCursorValue any) (string, error) {
 		// Get the datatype of the cursor field from streams
 		datatype, err := stream.Self().Stream.Schema.GetType(strings.ToLower(cursorField))

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -353,7 +353,7 @@ func OracleChunkScanQuery(stream types.StreamInterface, chunk types.Chunk, filte
 
 // OracleTableSizeQuery returns the query to fetch the size of a table in bytes in OracleDB
 func OracleBlockSizeQuery() string {
-	return `SELECT TO_NUMBER(value) FROM v$parameter WHERE name = 'db_block_size'`
+	return `SELECT CEIL(BYTES / NULLIF(BLOCKS, 0)) FROM user_segments WHERE BLOCKS IS NOT NULL AND ROWNUM =1`
 }
 
 // OracleCurrentSCNQuery returns the query to fetch the current SCN in OracleDB

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -342,7 +342,7 @@ func OracleChunkScanQuery(stream types.StreamInterface, chunk types.Chunk, filte
 	currentSCN := strings.Split(chunk.Min.(string), ",")[0]
 	chunkMin := strings.Split(chunk.Min.(string), ",")[1]
 
-	filterClause := utils.Ternary(filter == "", "", " AND "+filter).(string)
+	filterClause := utils.Ternary(filter == "", "", " AND ("+filter+")").(string)
 
 	if chunk.Max != nil {
 		chunkMax := chunk.Max.(string)

--- a/types/state.go
+++ b/types/state.go
@@ -97,14 +97,8 @@ func (s *State) ResetCursor(stream *ConfiguredStream) {
 		return elem.Namespace == stream.Namespace() && elem.Stream == stream.Name()
 	})
 	if contains {
-		s.Streams[index].State.Range(func(key, _ interface{}) bool {
-			if strKey, ok := key.(string); ok {
-				if strKey == primaryCursor || strKey == secondaryCursor {
-					s.Streams[index].State.Delete(key)
-				}
-			}
-			return true
-		})
+		s.Streams[index].State.Delete(primaryCursor)
+		s.Streams[index].State.Delete(secondaryCursor)
 	}
 	s.LogState()
 }

--- a/types/state.go
+++ b/types/state.go
@@ -87,6 +87,28 @@ func (s *State) ResetStreams() {
 	s.LogState()
 }
 
+func (s *State) ResetCursor(stream *ConfiguredStream) {
+	s.Lock()
+	defer s.Unlock()
+
+	primaryCursor, secondaryCursor := stream.Cursor()
+
+	index, contains := utils.ArrayContains(s.Streams, func(elem *StreamState) bool {
+		return elem.Namespace == stream.Namespace() && elem.Stream == stream.Name()
+	})
+	if contains {
+		s.Streams[index].State.Range(func(key, _ interface{}) bool {
+			if strKey, ok := key.(string); ok {
+				if strKey == primaryCursor || strKey == secondaryCursor {
+					s.Streams[index].State.Delete(key)
+				}
+			}
+			return true
+		})
+	}
+	s.LogState()
+}
+
 func (s *State) HasCompletedBackfill(stream *ConfiguredStream) bool {
 	if s.Type == GlobalType {
 		s.RLock()


### PR DESCRIPTION
# Description
Fixed a bug in Oracle incremental sync where removing a fallback cursor field after sync completion would cause errors when the primary cursor field was timestamp-based.

When running Oracle incremental sync with multiple cursor fields (primary + fallback), and then removing the fallback cursor field from the configuration, the system would throw typecasting errors if the primary cursor field contained timestamp data. This occurred because the `getIncrementCursorFromState` function was returning the raw cursor values instead of `nil` when cursor fields were missing, leading to improper type handling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran Oracle incremental sync with multiple cursor fields (primary timestamp + fallback)
- [x] Verified records sync correctly during full_refresh mode
- [x] Confirmed that after removing the secondary cursor field, the sync automatically switches to full_refresh mode without any typecasting errors
- [x] Tested with timestamp-based primary cursor fields to ensure proper type handling