### PR TITLE
fix: gcp using hive added

### DIFF
--- a/destination/iceberg/README.md
+++ b/destination/iceberg/README.md
@@ -210,6 +210,22 @@ Create a json for writer config (writer.json)
 }
 ```
 
+To use Iceberg with GCP, configure the writer to connect to a Hive Metastore hosted on Dataproc Metastore and write data to Dataproc generated bucket
+```json
+{
+  "type": "ICEBERG",
+  "writer": {
+      "catalog_type": "hive",
+      "hive_uri": "thrift://<hive-dataproc-metastore-ip>:9083",
+      "hive_clients": 10,
+      "hive_sasl_enabled": false,
+      "iceberg_db": "olake_iceberg",
+      "iceberg_s3_path": "gs://gcp-Dataproc-bucket/hive-warehouse",
+      "aws_region": "us-central1"
+  }
+}
+```
+
 Please change the above to real credentials to make it work.
 
 For detailed catalog configs and usage, refer [here.](https://olake.io/docs/category/catalogs)

--- a/destination/iceberg/iceberg_utils.go
+++ b/destination/iceberg/iceberg_utils.go
@@ -242,8 +242,8 @@ func (i *Iceberg) getServerConfigJSON(port int, upsert bool) ([]byte, error) {
 		return nil, fmt.Errorf("unsupported catalog type: %s", i.config.CatalogType)
 	}
 
-	// Configure S3 file IO
-	serverConfig["io-impl"] = "org.apache.iceberg.aws.s3.S3FileIO"
+	// Configure S3 or GCP file IO
+	serverConfig["io-impl"] = utils.Ternary(strings.HasPrefix(i.config.IcebergS3Path, "gs://"), "org.apache.iceberg.gcp.gcs.GCSFileIO", "org.apache.iceberg.aws.s3.S3FileIO")
 
 	// Only set access keys if explicitly provided, otherwise they'll be picked up from
 	// environment variables or AWS credential files


### PR DESCRIPTION
# Description
Added support of GCP when using Hive catalog for Iceberg.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- First logic on your GCP account, create a Project
- Search for Dataproc, go to Metastore services
- Create a Metastore service, provide service name, location, version, release channel, port (default: 9083), service tier etc
- Keep the endpoint protocol as Thrift
- Expose it to already running network
- Enable the Data catalog sync option
- Provide the database type and other options as per choice
- Click on submit. Creation of Dataproc metastore might take around 20 - 30 mins
- Now clone the Olake code in the same network where the Dataproc metastore is exposed to
- Follow the destination config format as given below and run the sync
- On successful sync, check the bucket which will have the desired parquet file with Iceberg data format

<img width="1750" height="869" alt="image" src="https://github.com/user-attachments/assets/4278cc49-4c33-4883-87ea-20ad33ac7d3a" />

On successful creation of Dataproc Metastore:
<img width="1796" height="831" alt="image" src="https://github.com/user-attachments/assets/816bac2c-5f97-48ce-be47-c72065fbc4b1" />

Example Destination Config:
```json
{
  "type": "ICEBERG",
  "writer": {
      "catalog_type": "hive",
      "hive_uri": "thrift://10.129.192.28:9083",
      "hive_clients": 10,
      "hive_sasl_enabled": false,
      "iceberg_db": "olake_iceberg",
      "iceberg_s3_path": "gs://gcs-bucket-duke-e2554901-54a5-43bb-ac9d-efc635918307/hive-warehouse",
      "aws_region": "us-central1"
  }
}
```