### PR TITLE
feat: Add an optional "target_name" to stream config to use as the Iceberg table name

### DIFF
--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -78,7 +78,7 @@ func (i *Iceberg) Setup(stream types.StreamInterface, options *destination.Optio
 func (i *Iceberg) Write(ctx context.Context, record types.RawRecord) error {
 	// Convert record to Debezium format with thread ID
 	// We are adding the thread ID to process the records from multiple threads in parallel and separately so that we can commit when each thread finishes.
-	debeziumRecord, err := record.ToDebeziumFormat(i.config.IcebergDatabase, i.stream.Name(), i.stream.NormalizationEnabled(), i.threadID)
+	debeziumRecord, err := record.ToDebeziumFormat(i.config.IcebergDatabase, i.stream.TargetName(), i.stream.NormalizationEnabled(), i.threadID)
 	if err != nil {
 		return fmt.Errorf("failed to convert record: %v", err)
 	}
@@ -92,7 +92,7 @@ func (i *Iceberg) Write(ctx context.Context, record types.RawRecord) error {
 		if err != nil {
 			return fmt.Errorf("thread id %s: failed to flush buffer: %s", i.threadID, err)
 		}
-		logger.Infof("thread id %s: Batch flushed to Iceberg server for stream %s", i.threadID, i.stream.Name())
+		logger.Infof("thread id %s: Batch flushed to Iceberg server for stream %s as %s", i.threadID, i.stream.Name(), i.stream.TargetName())
 	}
 
 	i.records.Add(1)

--- a/types/catalog.go
+++ b/types/catalog.go
@@ -42,6 +42,7 @@ type StreamMetadata struct {
 	ChunkColumn    string `json:"chunk_column,omitempty"`
 	PartitionRegex string `json:"partition_regex"`
 	StreamName     string `json:"stream_name"`
+	TargetName     string `json:"target_name,omitempty"`
 	AppendMode     bool   `json:"append_mode,omitempty"`
 	Normalization  bool   `json:"normalization"`
 	Filter         string `json:"filter,omitempty"`

--- a/types/interface.go
+++ b/types/interface.go
@@ -4,6 +4,7 @@ type StreamInterface interface {
 	ID() string
 	Self() *ConfiguredStream
 	Name() string
+	TargetName() string
 	Namespace() string
 	Schema() *TypeSchema
 	GetStream() *Stream

--- a/types/stream_configured.go
+++ b/types/stream_configured.go
@@ -37,6 +37,13 @@ func (s *ConfiguredStream) Name() string {
 	return s.Stream.Name
 }
 
+func (s *ConfiguredStream) TargetName() string {
+	if s.StreamMetadata.TargetName != "" {
+		return s.StreamMetadata.TargetName
+	}
+	return s.StreamMetadata.StreamName
+}
+
 func (s *ConfiguredStream) GetStream() *Stream {
 	return s.Stream
 }


### PR DESCRIPTION
# Description

Iceberg table names have more stringent requirements (lower-case, alphanum and underscore only) than some of our source tables/collections.

To handle this, we've added an optional "target_name" parameter to the streams.json's "selected_streams" entries. This `TargetName` is then used in the Debezium record (with the original stream name as default, if the override target is not set) that is sent to the Iceberg Java code.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested on our internal MongoDB to AWS S3Tables replication process.
