### PR TITLE
chore: override default timeout in Discover

### DIFF
--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -59,15 +59,12 @@ func (a *AbstractDriver) Type() string {
 }
 
 func (a *AbstractDriver) Discover(ctx context.Context) ([]*types.Stream, error) {
-	discoverCtx, cancel := context.WithTimeout(ctx, constants.DefaultDiscoverTimeout)
-	defer cancel()
-
 	// set max connections
 	if a.driver.MaxConnections() > 0 {
-		a.GlobalConnGroup = utils.NewCGroupWithLimit(discoverCtx, a.driver.MaxConnections())
+		a.GlobalConnGroup = utils.NewCGroupWithLimit(ctx, a.driver.MaxConnections())
 	}
 
-	streams, err := a.driver.GetStreamNames(discoverCtx)
+	streams, err := a.driver.GetStreamNames(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stream names: %s", err)
 	}

--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -40,11 +40,11 @@ var discoverCmd = &cobra.Command{
 		}
 
 		// build discover ctx
-		discvoerTimeout := utils.Ternary(timeout == -1, constants.DefaultDiscoverTimeout, time.Duration(timeout*int64(time.Second))).(time.Duration)
-		discvoerCtx, cancel := context.WithTimeout(cmd.Context(), discvoerTimeout)
+		discoverTimeout := utils.Ternary(timeout == -1, constants.DefaultDiscoverTimeout, time.Duration(timeout)*time.Second).(time.Duration)
+		discoverCtx, cancel := context.WithTimeout(cmd.Context(), discoverTimeout)
 		defer cancel()
 
-		streams, err := connector.Discover(discvoerCtx)
+		streams, err := connector.Discover(discoverCtx)
 		if err != nil {
 			return err
 		}

--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -1,10 +1,12 @@
 package protocol
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
@@ -36,7 +38,13 @@ var discoverCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		streams, err := connector.Discover(cmd.Context())
+
+		// build discover ctx
+		discvoerTimeout := utils.Ternary(timeout == -1, constants.DefaultDiscoverTimeout, time.Duration(timeout*int64(time.Second))).(time.Duration)
+		discvoerCtx, cancel := context.WithTimeout(cmd.Context(), discvoerTimeout)
+		defer cancel()
+
+		streams, err := connector.Discover(discvoerCtx)
 		if err != nil {
 			return err
 		}

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -26,6 +26,7 @@ var (
 	encryptionKey         string
 	catalog               *types.Catalog
 	state                 *types.State
+	timeout               int64 // timeout in seconds
 	destinationConfig     *types.WriterConfig
 
 	commands  = []*cobra.Command{}
@@ -81,6 +82,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&noSave, "no-save", "", false, "(Optional) Flag to skip logging artifacts in file")
 	RootCmd.PersistentFlags().BoolVarP(&clearDestinationFlag, "clear-destination", "", false, "(Optional) Flag to clear destination and reset sync state for selected streams to force full refresh. Note: Destination is automatically cleared for full refresh streams regardless of this flag.")
 	RootCmd.PersistentFlags().StringVarP(&encryptionKey, "encryption-key", "", "", "(Optional) Decryption key. Provide the ARN of a KMS key, a UUID, or a custom string based on your encryption configuration.")
+	RootCmd.PersistentFlags().Int64VarP(&timeout, "timeout", "", -1, "(Optional) Timeout to override default timeouts (in seconds)")
 	// Disable Cobra CLI's built-in usage and error handling
 	RootCmd.SilenceUsage = true
 	RootCmd.SilenceErrors = true


### PR DESCRIPTION
# Description
Closing Issue: https://github.com/datazip-inc/olake/issues/464
-> a flag `--timeout` need to be passed in command as argument to override.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
