### PR TITLE
fix: environment not passed to icerberg jar breaking IRSA in k8s

### DIFF
--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -155,9 +155,17 @@ func newIcebergClient(config *Config, partitionInfo []PartitionInfo, threadID st
 	serverCmd.Env = os.Environ()
 
 	addEnvIfSet := func(key, value string) {
-		if value != "" {
-			serverCmd.Env = append(serverCmd.Env, fmt.Sprintf("%s=%s", key, value))
+		if value == "" {
+			return
 		}
+		prefix := key + "="
+		for i := range serverCmd.Env {
+			if strings.HasPrefix(serverCmd.Env[i], prefix) {
+				serverCmd.Env[i] = prefix + value
+				return
+			}
+		}
+		serverCmd.Env = append(serverCmd.Env, prefix+value)
 	}
 	addEnvIfSet("AWS_ACCESS_KEY_ID", config.AccessKey)
 	addEnvIfSet("AWS_SECRET_ACCESS_KEY", config.SecretKey)

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -151,76 +151,19 @@ func newIcebergClient(config *Config, partitionInfo []PartitionInfo, threadID st
 		serverCmd = exec.Command("java", "-XX:+UseG1GC", "-jar", config.JarPath, string(configJSON))
 	}
 
-	// Create a map to hold the final environment variables for the subcommand.
-	envMap := make(map[string]string)
+	// Get current environment
+	serverCmd.Env = os.Environ()
 
-	// Define allowed environment variable prefixes for security
-	allowedEnvPrefixes := []string{
-		"AWS_",        // AWS credentials and configuration
-		"JAVA_",       // Java runtime options
-		"PATH",        // System PATH
-		"HOME",        // User home directory
-		"USER",        // Current user
-		"TZ",          // Timezone
-		"LANG",        // Language settings
-		"LC_",         // Locale settings
-		"SSL_CERT_",   // SSL certificate paths
-		"CA_BUNDLE",   // Certificate authority bundle
-		"HTTPS_PROXY", // Proxy settings
-		"HTTP_PROXY",  // Proxy settings
-		"NO_PROXY",    // Proxy exclusions
-	}
-
-	// Filter and inherit parent environment variables
-	for _, envVar := range os.Environ() {
-		parts := strings.SplitN(envVar, "=", 2)
-		if len(parts) >= 1 {
-			envKey := parts[0]
-			envValue := ""
-			if len(parts) == 2 {
-				envValue = parts[1]
-			}
-
-			// Check if this environment variable is allowed
-			allowed := false
-			for _, prefix := range allowedEnvPrefixes {
-				if envKey == prefix || strings.HasPrefix(envKey, prefix) {
-					allowed = true
-					break
-				}
-			}
-
-			if allowed {
-				envMap[envKey] = envValue
-			}
+	addEnvIfSet := func(key, value string) {
+		if value != "" {
+			serverCmd.Env = append(serverCmd.Env, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
-
-	// Override with static credentials from config if they are set.
-	// This ensures that values from your config file take precedence.
-	if config.AccessKey != "" {
-		envMap["AWS_ACCESS_KEY_ID"] = config.AccessKey
-	}
-	if config.SecretKey != "" {
-		envMap["AWS_SECRET_ACCESS_KEY"] = config.SecretKey
-	}
-	if config.Region != "" {
-		envMap["AWS_REGION"] = config.Region
-	}
-	if config.SessionToken != "" {
-		envMap["AWS_SESSION_TOKEN"] = config.SessionToken
-	}
-	if config.ProfileName != "" {
-		envMap["AWS_PROFILE"] = config.ProfileName
-	}
-
-	envSlice := make([]string, 0, len(envMap))
-	for key, val := range envMap {
-		envSlice = append(envSlice, key+"="+val)
-	}
-
-	// Assign the correctly merged environment to the command.
-	serverCmd.Env = envSlice
+	addEnvIfSet("AWS_ACCESS_KEY_ID", config.AccessKey)
+	addEnvIfSet("AWS_SECRET_ACCESS_KEY", config.SecretKey)
+	addEnvIfSet("AWS_REGION", config.Region)
+	addEnvIfSet("AWS_SESSION_TOKEN", config.SessionToken)
+	addEnvIfSet("AWS_PROFILE", config.ProfileName)
 
 	// Set up and start the process with logging
 	if err := logger.SetupAndStartProcess(fmt.Sprintf("Thread[%s:%d]", threadID, port), serverCmd); err != nil {


### PR DESCRIPTION
IRSA relies on the environment variables AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE. We should be passing these to the child process to allow working in Kubernetes environments without using hardcoded credentials. This also enables other vars such as JAVA_TOOL_OPTS to be used as needed.

# Description

Without this patch it is impossible to use Olake in Kubernetes with AWS IAM roles for service accounts. Using IAM roles in this fashion is the recommended way to provide temporary AWS credentials inside EKS clusters. 

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I am running this patch successfully inside our EKS clusters. The icerberg writer successfully finds and uses the IRSA credentials. 
