### PR TITLE
fix: fallback to bucketAutoStrategy when multiple _id types exist in mongo 

### DIFF
--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -164,7 +164,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		pipeline := mongo.Pipeline{
 			{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
 		}
-		// Add filter for ObjectID type when multiple types are detected
+		// chunk only ObjectID type _id when multiple types are detected
 		if hasMultipleType(stream) {
 			logger.Warnf("Caution: collection %s contains multiple _id types. Only documents with ObjectID _id will be synced; other types are skipped, which could result in data loss.", stream.ID())
 			pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: "_id", Value: bson.D{{Key: "$type", Value: 7}}}}}})
@@ -483,11 +483,5 @@ func isObjectID(ctx context.Context, collection *mongo.Collection) (bool, error)
 
 func hasMultipleType(stream types.StreamInterface) bool {
 	_, idProperty := stream.Schema().GetProperty("_id")
-	var validType []types.DataType
-	for _, t := range idProperty.Type.Array() {
-		if t != types.Null {
-			validType = append(validType, t)
-		}
-	}
-	return len(validType) > 1
+	return len(idProperty.Type.Array()) > 1
 }

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -268,8 +268,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		chunks, err := splitVectorStrategy()
 		// check if authorization error occurs
 		if err != nil && (strings.Contains(err.Error(), "not authorized") ||
-			strings.Contains(err.Error(), "CMD_NOT_ALLOWED") ||
-			strings.Contains(err.Error(), "multiple type _id exist")) {
+			strings.Contains(err.Error(), "CMD_NOT_ALLOWED")) {
 			logger.Warnf("failed to get chunks via split vector strategy: %s", err)
 			return bucketAutoStrategy(storageSize)
 		}

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -263,7 +263,8 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		chunks, err := splitVectorStrategy()
 		// check if authorization error occurs
 		if err != nil && (strings.Contains(err.Error(), "not authorized") ||
-			strings.Contains(err.Error(), "CMD_NOT_ALLOWED")) {
+			strings.Contains(err.Error(), "CMD_NOT_ALLOWED") ||
+			strings.Contains(err.Error(), "multiple type _id exist")) {
 			logger.Warnf("failed to get chunks via split vector strategy: %s", err)
 			return bucketAutoStrategy(storageSize)
 		}

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -483,5 +483,8 @@ func isObjectID(ctx context.Context, collection *mongo.Collection) (bool, error)
 
 func hasMultipleType(stream types.StreamInterface) bool {
 	_, idProperty := stream.Schema().GetProperty("_id")
+	if idProperty == nil {
+		return false
+	}
 	return idProperty.Type.Len() > 1
 }

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -455,7 +455,7 @@ func reformatID(v interface{}) (interface{}, error) {
 	switch t := v.(type) {
 	case primitive.ObjectID:
 		return t.Hex(), nil
-	case int32, int64:
+	case int32, int64, float64:
 		return t, nil
 	default:
 		// fallback
@@ -483,5 +483,5 @@ func isObjectID(ctx context.Context, collection *mongo.Collection) (bool, error)
 
 func hasMultipleType(stream types.StreamInterface) bool {
 	_, idProperty := stream.Schema().GetProperty("_id")
-	return len(idProperty.Type.Array()) > 1
+	return idProperty.Type.Len() > 1
 }


### PR DESCRIPTION

fixes #514 

When multiple _id types exist in mongo, it was still trying to use the split vector strategy which would fail. This adds a check for the multiple _id type condition so things correctly fall back to the bucket auto strategy. 

I tested by running this patch internally where we have some collections with multiple _id types.
