### PR TITLE
fix: Capture and surface first error line from Java Iceberg process

### DIFF
--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -565,7 +565,7 @@ func (i *Iceberg) parsePartitionRegex(pattern string) error {
 
 		// Append to ordered slice to preserve partition order
 		i.partitionInfo = append(i.partitionInfo, PartitionInfo{
-			field:     colName,
+			field:     utils.Reformat(colName),
 			transform: transform,
 		})
 	}

--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -286,6 +286,9 @@ func (i *Iceberg) Check(ctx context.Context) error {
 
 	res, err := server.sendClientRequest(ctx, request)
 	if err != nil {
+		if recent := logger.GetFirstErrorLine(fmt.Sprintf("Thread[%s:%d]", server.serverID, server.port)); recent != "" {
+			return fmt.Errorf("failed to create or get table: %s : %s", err, recent)
+		}
 		return fmt.Errorf("failed to create or get table: %s", err)
 	}
 

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -98,7 +98,13 @@ public class OlakeRpcServer {
             }
         }
 
-        icebergCatalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergProperties, hadoopConf);
+     // q: should we through exception if catalog init fails? or keep it as it is
+        try {
+            icebergCatalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergProperties, hadoopConf);
+        } catch (Throwable t) {
+            throw new Exception("Iceberg catalog init failed: " + t.toString());
+
+        }
 
         // configure and set
         valSerde.configure(Collections.emptyMap(), false);

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -370,7 +370,7 @@ func (p *Parquet) getPartitionedFilePath(values map[string]any, olakeTimestamp t
 			return ""
 		}
 
-		colName := strings.TrimSpace(strings.Trim(regexVarBlock[0], `'`))
+		colName := utils.Reformat(strings.TrimSpace(strings.Trim(regexVarBlock[0], `'`)))
 		defaultValue := strings.TrimSpace(strings.Trim(regexVarBlock[1], `'`))
 		granularity := strings.TrimSpace(strings.Trim(regexVarBlock[2], `'`))
 


### PR DESCRIPTION
# Description

Improves error handling when starting the Iceberg Java writer by capturing the first error line from process logs and including it in the returned Go error. This makes failures more actionable by showing the root cause instead of only the generic gRPC connection failure.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
