### PR TITLE
fix: enhance CDC for MongoDB sharded clusters with robust resume token handling

### DIFF
--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -24,11 +24,12 @@ const (
 )
 
 type Mongo struct {
-	config     *Config
-	client     *mongo.Client
-	CDCSupport bool // indicates if the MongoDB instance supports Change Streams
-	cdcCursor  sync.Map
-	state      *types.State // reference to globally present state
+	config        *Config
+	client        *mongo.Client
+	CDCSupport    bool // indicates if the MongoDB instance supports Change Streams
+	cdcCursor     sync.Map
+	state         *types.State        // reference to globally present state
+	clusterOpTime primitive.Timestamp // Cluster opTime is the latest timestamp of any operation applied in the MongoDB cluster
 }
 
 // config reference; must be pointer

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -29,7 +29,7 @@ type Mongo struct {
 	CDCSupport    bool // indicates if the MongoDB instance supports Change Streams
 	cdcCursor     sync.Map
 	state         *types.State        // reference to globally present state
-	clusterOpTime primitive.Timestamp // Cluster opTime is the latest timestamp of any operation applied in the MongoDB cluster
+	LastOplogTime primitive.Timestamp // Cluster opTime is the latest timestamp of any operation applied in the MongoDB cluster
 }
 
 // config reference; must be pointer


### PR DESCRIPTION
# Description
Fixes issues with CDC in sharded MongoDB clusters by improving PBRT handling. Enhance CDC Robustness for Sharded Clusters with PBRT. 

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested by simulating CDC using a Go script against a local **MongoDB sharded cluster** (via Docker Compose).  

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
