### PR TITLE
fix: include both start and end binlog positions for mysql cdc sync

### DIFF
--- a/drivers/mongodb/internal/cdc.go
+++ b/drivers/mongodb/internal/cdc.go
@@ -57,6 +57,7 @@ func (m *Mongo) PreCDC(cdcCtx context.Context, streams []types.StreamInterface) 
 		m.cdcCursor.Store(stream.ID(), prevResumeToken)
 	}
 
+	// TODO:move it to stream change function
 	lastOplogTime, err := m.getClusterOpTime(cdcCtx, m.config.AuthDB)
 	if err != nil {
 		logger.Warnf("Failed to get cluster op time: %s", err)

--- a/drivers/mysql/internal/cdc.go
+++ b/drivers/mysql/internal/cdc.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/pkg/binlog"
-	"github.com/datazip-inc/olake/pkg/jdbc"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
-	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
 func (m *MySQL) prepareBinlogConn(ctx context.Context, globalState MySQLGlobalState, streams []types.StreamInterface) (*binlog.Connection, error) {
@@ -36,24 +34,15 @@ func (m *MySQL) prepareBinlogConn(ctx context.Context, globalState MySQLGlobalSt
 		InitialWaitTime: time.Duration(m.cdcConfig.InitialWaitTime) * time.Second,
 		SSHClient:       m.sshClient,
 	}
-	conn, err := binlog.NewConnection(ctx, config, globalState.State.Position, streams, m.dataTypeConverter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare binlog conn: %s", err)
-	}
-	// Determine the currentlatest binlog position on the server.
-	latestBinlogPos, err := m.getCurrentBinlogPosition()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get latest binlog position: %s", err)
-	}
-	conn.SetLatestBinlogPos(latestBinlogPos)
-	return conn, nil
+
+	return binlog.NewConnection(ctx, config, globalState.State.Position, streams, m.dataTypeConverter)
 }
 
 func (m *MySQL) PreCDC(ctx context.Context, streams []types.StreamInterface) error {
 	// Load or initialize global state
 	globalState := m.state.GetGlobal()
 	if globalState == nil || globalState.State == nil {
-		binlogPos, err := m.getCurrentBinlogPosition()
+		binlogPos, err := binlog.GetCurrentBinlogPosition(m.client)
 		if err != nil {
 			return fmt.Errorf("failed to get current binlog position: %s", err)
 		}
@@ -76,6 +65,10 @@ func (m *MySQL) PreCDC(ctx context.Context, streams []types.StreamInterface) err
 	return nil
 }
 
+func (m *MySQL) StreamChanges(ctx context.Context, _ types.StreamInterface, OnMessage abstract.CDCMsgFn) error {
+	return m.BinlogConn.StreamMessages(ctx, m.client, OnMessage)
+}
+
 func (m *MySQL) PostCDC(ctx context.Context, stream types.StreamInterface, noErr bool) error {
 	if noErr {
 		m.state.SetGlobal(MySQLGlobalState{
@@ -88,41 +81,4 @@ func (m *MySQL) PostCDC(ctx context.Context, stream types.StreamInterface, noErr
 	}
 	m.BinlogConn.Cleanup()
 	return nil
-}
-
-func (m *MySQL) StreamChanges(ctx context.Context, _ types.StreamInterface, OnMessage abstract.CDCMsgFn) error {
-	return m.BinlogConn.StreamMessages(ctx, OnMessage)
-}
-
-// getCurrentBinlogPosition retrieves the current binlog position from MySQL.
-func (m *MySQL) getCurrentBinlogPosition() (mysql.Position, error) {
-	// SHOW MASTER STATUS is not supported in MySQL 8.4 and after
-
-	// Get MySQL version
-	majorVersion, minorVersion, err := jdbc.MySQLVersion(m.client)
-	if err != nil {
-		return mysql.Position{}, fmt.Errorf("failed to get MySQL version: %s", err)
-	}
-
-	// Use the appropriate query based on the MySQL version
-	query := utils.Ternary(majorVersion > 8 || (majorVersion == 8 && minorVersion >= 4), jdbc.MySQLMasterStatusQueryNew(), jdbc.MySQLMasterStatusQuery()).(string)
-
-	rows, err := m.client.Query(query)
-	if err != nil {
-		return mysql.Position{}, fmt.Errorf("failed to get master status: %s", err)
-	}
-	defer rows.Close()
-
-	if !rows.Next() {
-		return mysql.Position{}, fmt.Errorf("no binlog position available")
-	}
-
-	var file string
-	var position uint32
-	var binlogDoDB, binlogIgnoreDB, executeGtidSet string
-	if err := rows.Scan(&file, &position, &binlogDoDB, &binlogIgnoreDB, &executeGtidSet); err != nil {
-		return mysql.Position{}, fmt.Errorf("failed to scan binlog position: %s", err)
-	}
-
-	return mysql.Position{Name: file, Pos: position}, nil
 }

--- a/drivers/mysql/internal/mysql.go
+++ b/drivers/mysql/internal/mysql.go
@@ -242,9 +242,10 @@ func (m *MySQL) Close() error {
 
 func (m *MySQL) IsCDCSupported(ctx context.Context) (bool, error) {
 	// Permission check via SHOW MASTER STATUS / SHOW BINARY LOG STATUS
-	if _, err := m.getCurrentBinlogPosition(); err != nil {
+	if _, err := binlog.GetCurrentBinlogPosition(m.client); err != nil {
 		return false, fmt.Errorf("failed to get binlog position: %s", err)
 	}
+
 	// checkMySQLConfig checks a MySQL configuration value against an expected value
 	checkMySQLConfig := func(ctx context.Context, query, expectedValue, warnMessage string) (bool, error) {
 		var name, value string

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -114,7 +114,6 @@ func (c *Connection) StreamMessages(ctx context.Context, callback abstract.CDCMs
 				}
 			}
 		}
-
 	}
 }
 

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -58,7 +58,7 @@ func (c *Connection) StreamMessages(ctx context.Context, callback abstract.CDCMs
 
 	streamer, err := c.syncer.StartSync(c.CurrentPos)
 	if err != nil {
-		return fmt.Errorf("failed to start binlog sync: %w", err)
+		return fmt.Errorf("failed to start binlog sync: %s", err)
 	}
 
 	startTime := time.Now()

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -81,7 +81,7 @@ func (c *Connection) StreamMessages(ctx context.Context, client *sqlx.DB, callba
 			return nil
 		default:
 			if !messageReceived && c.initialWaitTime > 0 && time.Since(startTime) > c.initialWaitTime {
-				logger.Debug("Idle timeout reached, exiting bin syncer")
+				logger.Warnf("no records found in given initial wait time, try increasing it")
 				return nil
 			}
 

--- a/pkg/binlog/filter.go
+++ b/pkg/binlog/filter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/types"
-	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
@@ -56,7 +55,6 @@ func (f ChangeFilter) FilterRowsEvent(ctx context.Context, e *replication.RowsEv
 	for i, ct := range e.Table.ColumnType {
 		columnTypes[i] = mysqlTypeName(ct)
 	}
-	logger.Debugf("Column types: %v", columnTypes)
 
 	var rowsToProcess [][]interface{}
 	if operationType == "update" {


### PR DESCRIPTION
# Description

improve state cursor handling and binlog position tracking with start and end for mysql cdc sync.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
