### PR TITLE
Fix/processed record semantic types

### DIFF
--- a/destination/interface.go
+++ b/destination/interface.go
@@ -25,9 +25,9 @@ type Writer interface {
 	// avoiding the headover for different streams
 	Setup(ctx context.Context, stream types.StreamInterface, schema any, opts *Options) (any, error)
 	// Write function being used by drivers
-	Write(ctx context.Context, record []types.RawRecord) error
+	Write(ctx context.Context, record []types.ProcessedRecord) error
 	// flatten data and validates thread schema (return true if thread schema is different w.r.t records)
-	FlattenAndCleanData(records []types.RawRecord) (bool, []types.RawRecord, any, error)
+	FlattenAndCleanData(records []types.RawRecord) (bool, []types.ProcessedRecord, any, error)
 	// EvolveSchema updates the schema based on changes.
 	// Need to pass olakeTimestamp as end argument to get the correct partition path based on record ingestion time.
 	EvolveSchema(ctx context.Context, globalSchema, recordsSchema any) (any, error)

--- a/destination/writers.go
+++ b/destination/writers.go
@@ -220,12 +220,12 @@ func (wt *WriterThread) flush(ctx context.Context, buf []types.RawRecord) (err e
 	flushCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	evolution, buf, threadSchema, err := wt.writer.FlattenAndCleanData(buf)
+	evolution, processedBuf, threadSchema, err := wt.writer.FlattenAndCleanData(buf)
 	if err != nil {
 		return fmt.Errorf("failed to flatten and clean data: %s", err)
 	}
 
-	// TODO: after flattening record type raw_record not make sense
+	// After flattening, records are now ProcessedRecord type (no longer raw)
 	if evolution {
 		wt.streamArtifact.mu.Lock()
 		newSchema, err := wt.writer.EvolveSchema(flushCtx, wt.streamArtifact.schema, threadSchema)
@@ -238,11 +238,11 @@ func (wt *WriterThread) flush(ctx context.Context, buf []types.RawRecord) (err e
 		}
 	}
 
-	if err := wt.writer.Write(flushCtx, buf); err != nil {
+	if err := wt.writer.Write(flushCtx, processedBuf); err != nil {
 		return fmt.Errorf("failed to write records: %s", err)
 	}
 
-	logger.Infof("Thread[%s]: successfully wrote %d records", wt.threadID, len(buf))
+	logger.Infof("Thread[%s]: successfully wrote %d records", wt.threadID, len(processedBuf))
 	return nil
 }
 

--- a/types/data_types.go
+++ b/types/data_types.go
@@ -70,6 +70,10 @@ type RawRecord struct {
 	CdcTimestamp   *time.Time     `parquet:"_cdc_timestamp"` // pointer because it will only be available for cdc sync
 }
 
+// ProcessedRecord represents a record that has undergone normalization/flattening
+// It has the same structure as RawRecord but semantically represents processed data
+type ProcessedRecord RawRecord
+
 func CreateRawRecord(olakeID string, data map[string]any, operationType string, cdcTimestamp *time.Time) RawRecord {
 	return RawRecord{
 		OlakeID:       olakeID,
@@ -77,6 +81,20 @@ func CreateRawRecord(olakeID string, data map[string]any, operationType string, 
 		OperationType: operationType,
 		CdcTimestamp:  cdcTimestamp,
 	}
+}
+
+// ToProcessedRecord converts a RawRecord to ProcessedRecord after normalization
+func (r RawRecord) ToProcessedRecord() ProcessedRecord {
+	return ProcessedRecord(r)
+}
+
+// ToProcessedRecords converts a slice of RawRecord to ProcessedRecord after normalization
+func ToProcessedRecords(rawRecords []RawRecord) []ProcessedRecord {
+	processedRecords := make([]ProcessedRecord, len(rawRecords))
+	for i, record := range rawRecords {
+		processedRecords[i] = record.ToProcessedRecord()
+	}
+	return processedRecords
 }
 
 func (d DataType) ToNewParquet() parquet.Node {


### PR DESCRIPTION
# Description

Fixed semantic confusion where records were still called `RawRecord` after normalization/flattening. Added `ProcessedRecord` type to clearly distinguish processed data from raw data.

Fixes #481

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Full project builds successfully (`go build ./...`)
- [x] No functionality changes - only improved type semantics

# Screenshots or Recordings

N/A - Code quality improvement only.

## Related PR's (If Any):

None.