### PR TITLE
fix(mysql): enforce non-zero initial wait time for CDC setup

### DIFF
--- a/drivers/mysql/internal/mysql.go
+++ b/drivers/mysql/internal/mysql.go
@@ -110,9 +110,9 @@ func (m *MySQL) Setup(ctx context.Context) error {
 		if err := utils.Unmarshal(m.config.UpdateMethod, cdc); err != nil {
 			return err
 		}
-		if cdc.InitialWaitTime == 0 {
-			// default set 10 sec
-			cdc.InitialWaitTime = 10
+		if cdc.InitialWaitTime <= 0 {
+			// Fail the setup if initial_wait_time is 0 or negative
+			return fmt.Errorf("Failed to setup CDC: Initial wait time must be greater than 0")
 		}
 		m.cdcConfig = *cdc
 	}


### PR DESCRIPTION
# Description

Fail the setup if initial_wait_time is 0 or negative

Fixes #492 

# Screenshots or Recordings

**UI**
<img width="800" height="400" alt="Screenshot 2025-10-05 at 1 34 01 AM" src="https://github.com/user-attachments/assets/b5d87925-23b1-4fbe-8e03-d3bcf570e460" />

**CLI**
<img width="780" height="209" alt="Screenshot 2025-10-05 at 1 38 52 AM" src="https://github.com/user-attachments/assets/e6df48b1-ee8d-44b2-b2ff-d6e77ac0f25d" />
