### PR TITLE
feat: add iam support for mongodb

### DIFF
--- a/destination/parquet/resources/spec.json
+++ b/destination/parquet/resources/spec.json
@@ -11,7 +11,8 @@
         "s3_access_key": {
           "type": "string",
           "title": "AWS Access Key",
-          "description": "The AWS access key for authenticating S3 requests, typically a 20 character alphanumeric string"
+          "description": "The AWS access key for authenticating S3 requests, typically a 20 character alphanumeric string",
+          "format": "password"
         },
         "s3_bucket": {
           "type": "string",

--- a/drivers/mongodb/internal/cdc.go
+++ b/drivers/mongodb/internal/cdc.go
@@ -58,7 +58,7 @@ func (m *Mongo) PreCDC(cdcCtx context.Context, streams []types.StreamInterface) 
 	}
 
 	// TODO:move it to stream change function
-	lastOplogTime, err := m.getClusterOpTime(cdcCtx, m.config.AuthDB)
+	lastOplogTime, err := m.getClusterOpTime(cdcCtx, m.config.Database)
 	if err != nil {
 		logger.Warnf("Failed to get cluster op time: %s", err)
 		return err
@@ -201,12 +201,12 @@ func (m *Mongo) getCurrentResumeToken(cdcCtx context.Context, collection *mongo.
 
 // getClusterOpTime retrieves the latest cluster operation time from MongoDB.
 // It first tries the modern 'hello' command and falls back to 'isMaster' for older servers.
-func (m *Mongo) getClusterOpTime(ctx context.Context, authDB string) (primitive.Timestamp, error) {
+func (m *Mongo) getClusterOpTime(ctx context.Context, dbName string) (primitive.Timestamp, error) {
 	var opTime primitive.Timestamp
 
 	// Helper to run a command and return raw result
 	runCmd := func(cmd bson.M) (bson.Raw, error) {
-		return m.client.Database(authDB).RunCommand(ctx, cmd).Raw()
+		return m.client.Database(dbName).RunCommand(ctx, cmd).Raw()
 	}
 
 	// Try 'hello' command first

--- a/drivers/mongodb/resources/spec.json
+++ b/drivers/mongodb/resources/spec.json
@@ -70,7 +70,7 @@
             "title": "Username",
             "description": "Username for MongoDB authentication"
         },
-        "useIAM": {
+        "use_iam": {
             "type": "boolean",
             "title": "IAM Authentication",
             "description": "Enable this option to use IAM-based authentication instead of username and password",
@@ -82,11 +82,11 @@
         "database"
     ],
     "dependencies": {
-        "useIAM": {
+        "use_iam": {
             "oneOf": [
                 {
                     "properties": {
-                        "useIAM": {
+                        "use_iam": {
                             "const": false
                         },
                         "password": { "type": "string", "minLength": 1 }
@@ -99,7 +99,7 @@
                 },
                 {
                     "properties": {
-                        "useIAM": {
+                        "use_iam": {
                             "const": true
                         }
                     }

--- a/drivers/mongodb/resources/spec.json
+++ b/drivers/mongodb/resources/spec.json
@@ -47,8 +47,7 @@
             "type": "string",
             "title": "Password",
             "description": "Password with the username for authentication",
-            "format": "password",
-            "minLength": 1
+            "format": "password"
         },
         "read_preference": {
             "type": "string",
@@ -70,13 +69,42 @@
             "type": "string",
             "title": "Username",
             "description": "Username for MongoDB authentication"
+        },
+        "useIAM": {
+            "type": "boolean",
+            "title": "IAM Authentication",
+            "description": "Enable this option to use IAM-based authentication instead of username and password",
+            "default": false
         }
     },
     "required": [
         "hosts",
-        "database",
-        "authdb",
-        "username",
-        "password"
-    ]
+        "database"
+    ],
+    "dependencies": {
+        "useIAM": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "useIAM": {
+                            "const": false
+                        },
+                        "password": { "type": "string", "minLength": 1 }
+                    },
+                    "required": [
+                        "authdb",
+                        "username",
+                        "password"
+                    ]
+                },
+                {
+                    "properties": {
+                        "useIAM": {
+                            "const": true
+                        }
+                    }
+                }
+            ]
+        }
+    }
 }

--- a/drivers/postgres/internal/postgres.go
+++ b/drivers/postgres/internal/postgres.go
@@ -120,7 +120,7 @@ func (p *Postgres) Setup(ctx context.Context) error {
 			if strings.Contains(err.Error(), "sql: no rows in result set") {
 				err = fmt.Errorf("no record found")
 			}
-			return fmt.Errorf("failed to valicate cdc configuration for slot %s: %s", cdc.ReplicationSlot, err)
+			return fmt.Errorf("failed to validate cdc configuration for slot %s: %s", cdc.ReplicationSlot, err)
 		}
 
 		if !exists {

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -21,12 +21,12 @@ const MongoDBUISchema = `{
         { "password": 12, "replica_set": 12 },
         { "read_preference": 12, "srv": 12 },
         { "max_threads": 12, "backoff_retry_count": 12 },
-        { "chunking_strategy": 12, "useIAM": 12 }
+        { "chunking_strategy": 12, "use_iam": 12 }
     ],
     "srv": {
         "ui:widget": "boolean"
     },
-    "useIAM": {
+    "use_iam": {
         "ui:widget": "boolean"
     },
     "hosts": {

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -21,9 +21,12 @@ const MongoDBUISchema = `{
         { "password": 12, "replica_set": 12 },
         { "read_preference": 12, "srv": 12 },
         { "max_threads": 12, "backoff_retry_count": 12 },
-        { "chunking_strategy": 12 }
+        { "chunking_strategy": 12, "useIAM": 12 }
     ],
     "srv": {
+        "ui:widget": "boolean"
+    },
+    "useIAM": {
         "ui:widget": "boolean"
     },
     "hosts": {


### PR DESCRIPTION
# Description

Earlier, the user connecting to mongodb through olake needed to mandatorily enter password and username to connect. Now if IAM user configurations are done in machine and IamUser config is set to true , there is no need to enter username and password.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested using new configuration
- [x] Tested using old configuration , backward compatibility 


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [x] Documentation Link: [https://olake.io/#]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):