### PR TITLE
fix: set allowDiskUse=true on bucketAutoStrategy

### DIFF
--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -170,7 +170,8 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 			{Key: "buckets", Value: numberOfBuckets},
 		}}})
 
-		cursor, err := collection.Aggregate(ctx, pipeline)
+		opts := options.Aggregate().SetAllowDiskUse(true)
+		cursor, err := collection.Aggregate(ctx, pipeline, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute bucketAuto aggregation: %s", err)
 		}


### PR DESCRIPTION
# Description

Resolves failure due to sort exceeding server's allotted disk size. The splitVector strategy already enabled allowDiskUse but bucketAuto did not. This led to failures syncing collections with string type _id fields when the sort size exceeded the allowed memory.

```
FATAL error occurred while reading records: failed to run change stream: failed to run backfill: failed to get or split chunks: failed after retry backoff: failed to execute bucketAuto aggregation: (QueryExceededMemoryLimitNoDiskUseAllowed) PlanExecutor error during aggregation :: caused by :: Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting.
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I am running this internally and resolved the error message shown in the description above.

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

