### PR TITLE
Added validation for each catalog

### DIFF
--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -239,7 +239,7 @@ func (i *Iceberg) Close(ctx context.Context) error {
 	}
 
 	// Send commit request for this thread using a special message format
-	ctx, cancel := context.WithTimeout(ctx, 300*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3600*time.Second)
 	defer cancel()
 
 	request := &proto.IcebergPayload{
@@ -279,7 +279,7 @@ func (i *Iceberg) Check(ctx context.Context) error {
 		i.Close(ctx)
 	}()
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 300*time.Second)
 	defer cancel()
 
 	// try to create table

--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -84,7 +84,7 @@ func compareStreams() error {
 		return fmt.Errorf("failed to read new catalog: %s", derr)
 	}
 
-	diffCatalog := types.GetStreamsDelta(&oldStreams, &newStreams, connector.Type())
+	diffCatalog := types.GetStreamsDelta(&oldStreams, &newStreams)
 	if err := logger.FileLoggerWithPath(diffCatalog, viper.GetString(constants.DifferencePath)); err != nil {
 		return fmt.Errorf("failed to write difference streams: %s", err)
 	}


### PR DESCRIPTION
# Description

This PR implements a robust validation framework for Iceberg catalog configurations, addressing the lack of proper validation for different catalog types this enhancement prevents runtime failures by catching configuration errors early during initialization.

Fixes #478

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### AWS Glue Catalog
- [x] Valid Glue configuration with region
- [x] Missing region validation
- [x] AWS credentials validation (access key/secret key pairs)
- [x] Profile configuration validation

### JDBC Catalog
- [x] Valid JDBC configuration with URL and credentials
- [x] JDBC URL format validation
- [x] Missing required credentials validation
- [x] Invalid URL format detection

### REST Catalog
- [x] Token-based authentication validation
- [x] OAuth2 authentication validation
- [x] Missing authentication parameters
- [x] REST signing configuration validation
- [x] URL format validation

### Hive Metastore
- [x] Valid Hive configuration with thrift URI
- [x] URI format validation
- [x] Client configuration limits
- [x] Missing required parameters

### General Tests
- [x] Default value initialization
- [x] Required S3 path validation
- [x] Mixed credential configuration validation
- [x] Error message clarity and actionability