### PR TITLE
fix: Integration test spark error fixed

### DIFF
--- a/utils/testutils/test_utils.go
+++ b/utils/testutils/test_utils.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/apache/spark-connect-go/v35/spark/sql"
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/typeutils"
@@ -382,33 +383,40 @@ func VerifyIcebergSync(t *testing.T, tableName, icebergDB string, datatypeSchema
 	)
 	t.Logf("Executing query: %s", selectQuery)
 
-	// Retry the query to handle error due to catalog consistency (spark error)
-	var selectQueryDf sql.DataFrame
+	var selectRows []types.Row
+	var queryErr error
 	maxRetries := 5
 	retryDelay := 2 * time.Second
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
-			t.Logf("Query attempt %d/%d (waiting %v for catalog consistency)", attempt+1, maxRetries, retryDelay)
 			time.Sleep(retryDelay)
 		}
-
-		df, queryErr := spark.Sql(ctx, selectQuery)
+		var selectQueryDf sql.DataFrame
+		// This is to check if the table exists in destination, as race condition might cause table to not be created yet
+		selectQueryDf, queryErr = spark.Sql(ctx, selectQuery)
 		if queryErr != nil {
 			t.Logf("Query attempt %d failed: %v", attempt+1, queryErr)
-			if attempt == maxRetries-1 {
-				require.NoError(t, queryErr, "Failed to query table after %d attempts", maxRetries)
-			}
 			continue
 		}
 
-		selectQueryDf = df
-		break
-	}
-	require.NotNil(t, selectQueryDf, "Failed to get query results after %d attempts", maxRetries)
+		// To ensure stale data is not being used for verification
+		selectRows, queryErr = selectQueryDf.Collect(ctx)
+		if queryErr != nil {
+			t.Logf("Query attempt %d failed (Collect error): %v", attempt+1, queryErr)
+			continue
+		}
+		if len(selectRows) > 0 {
+			queryErr = nil
+			break
+		}
 
-	selectRows, err := selectQueryDf.Collect(ctx)
-	require.NoError(t, err, "Failed to collect data rows from Iceberg")
+		// for every type of operation, op symbol will be different, using that to ensure data is not stale
+		queryErr = fmt.Errorf("stale data: query succeeded but returned 0 rows for _op_type = '%s'", opSymbol)
+		t.Logf("Query attempt %d/%d failed: %v", attempt+1, maxRetries, queryErr)
+	}
+
+	require.NoError(t, queryErr, "Failed to collect data rows from Iceberg after %d attempts: %v", maxRetries, queryErr)
 	require.NotEmpty(t, selectRows, "No rows returned for _op_type = '%s'", opSymbol)
 
 	// delete row checked


### PR DESCRIPTION
# Description

While running the integration tests, sometimes this error used to appear.
```
Received unexpected error:
        	            	[sparkerror] Error Type: execution error
        	            	Error Cause: failed to execute sql: SELECT * FROM olake_iceberg.postgres_postgres_public.postgres_test_table_olake WHERE _op_type = 'r': execution error: [Internal] Cannot check and eventually update SQL schema
        	            	/home/runner/go/pkg/mod/github.com/apache/spark-connect-go/v35@v35.0.0-20250317154112-ffd832059443/spark/sql/sparksession.go:141 (0x125c503)
        	            		(*sparkSessionImpl).Sql: return nil, sparkerrors.WithType(fmt.Errorf("failed to execute sql: %s: %w", query, err), sparkerrors.ExecutionError)
        	            	/home/runner/work/olake/olake/utils/testutils/test_utils.go:374 (0x127d213)
        	            		VerifyIcebergSync: selectQueryDf, err := spark.Sql(ctx, selectQuery)
        	            	/home/runner/work/olake/olake/utils/testutils/test_utils.go:320 (0x127bccc)
        	            		(*IntegrationTest).TestIntegration.func2.3.1: VerifyIcebergSync(t, currentTestTable, cfg.IcebergDB, cfg.DataTypeSchema, schema, opSymbol, cfg.TestConfig.Driver)
```

The error occurred due to a race condition, where the data was not properly updated in the catalog side, and before that only the spark query was fired. Which eventually threw this error.

Now, this  is handled by attempting this query ( if it fails) for `maxRetryCounts` (for now 5) after every 2 seconds.



## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots or Recordings

Previously
<img width="1314" height="774" alt="Screenshot 2025-10-18 at 3 40 16 AM" src="https://github.com/user-attachments/assets/9baa803f-2493-400b-b02f-924526e1a1fe" />

After the change
<img width="1289" height="204" alt="Screenshot 2025-10-19 at 12 15 37 PM" src="https://github.com/user-attachments/assets/62569603-5a08-410a-b5c4-6152a0633992" />

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)
