### PR TITLE
fix: remove version attribute from docker compose files

### DIFF
--- a/destination/iceberg/local-test/docker-compose.yml
+++ b/destination/iceberg/local-test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   lakekeeper:
     image: &lakekeeper-image ${LAKEKEEPER__SERVER_IMAGE:-quay.io/lakekeeper/catalog:latest-main}

--- a/drivers/mysql/docker-compose.yml
+++ b/drivers/mysql/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mysql:
     image: mysql:8.0

--- a/drivers/mysql/internal/backfill.go
+++ b/drivers/mysql/internal/backfill.go
@@ -17,7 +17,7 @@ import (
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 )
-
+//  integration test check
 func (m *MySQL) ChunkIterator(ctx context.Context, stream types.StreamInterface, chunk types.Chunk, OnMessage abstract.BackfillMsgFn) error {
 	opts := jdbc.DriverOptions{
 		Driver: constants.MySQL,

--- a/drivers/postgres/docker-compose.yml
+++ b/drivers/postgres/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
# Description

The integration test infrastructure setup was failing throwing this error

```
time="2025-10-20T08:13:48Z" level=warning msg="/home/runner/work/olake/olake/drivers/mysql/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
```

This is because the current docker files contain the version attribute which won't be needed and is removed in this PR.

from the following docker-compose files
- [x] postgres 
- [x] mysql
- [x] destination local-test  

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Testing is under process

# Screenshots or Recordings

Before this change
<img width="1321" height="328" alt="Screenshot 2025-10-20 at 1 54 30 PM" src="https://github.com/user-attachments/assets/6c971d43-db78-4edc-b900-bead24db8ed1" />


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)
