### PR TITLE
fix: handle chunk generation for partitioned PostgreSQL tables using max page ID

### DIFF
--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           check-latest: "true"
-          go-version: "1.23.x"
+          go-version: "1.24.x"
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run vulnerability checks

--- a/drivers/mongodb/go.mod
+++ b/drivers/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mongodb
 
-go 1.23.2
+go 1.24.0
 
 toolchain go1.24.3
 

--- a/drivers/mysql/go.mod
+++ b/drivers/mysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mysql
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/datazip-inc/olake v0.0.0-20250312070222-ed705d25bc0c

--- a/drivers/mysql/internal/mysql.go
+++ b/drivers/mysql/internal/mysql.go
@@ -263,7 +263,7 @@ func (m *MySQL) IsCDCSupported(ctx context.Context) (bool, error) {
 		}
 
 		if strings.ToUpper(value) != expectedValue {
-			logger.Warnf(warnMessage)
+			logger.Warn(warnMessage)
 			return false, nil
 		}
 

--- a/drivers/oracle/go.mod
+++ b/drivers/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/oracle
 
-go 1.23.2
+go 1.24.0
 
 toolchain go1.24.3
 

--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/postgres
 
-go 1.23.2
+go 1.24.0
 
 toolchain go1.24.3
 

--- a/drivers/postgres/internal/backfill.go
+++ b/drivers/postgres/internal/backfill.go
@@ -233,7 +233,7 @@ func loadPartitionPages(ctx context.Context, db *sql.DB, stream types.StreamInte
 	query := jdbc.PostgresPartitionPages(stream)
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to load partition pages: %v", err)
+		return nil, 0, fmt.Errorf("failed to load partition pages: %s", err)
 	}
 	var maxPageID uint32
 	defer rows.Close()

--- a/drivers/postgres/internal/backfill.go
+++ b/drivers/postgres/internal/backfill.go
@@ -73,12 +73,7 @@ func (p *Postgres) GetOrSplitChunks(ctx context.Context, pool *destination.Write
 
 func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.StreamInterface) (*types.Set[types.Chunk], error) {
 	generateCTIDRanges := func(stream types.StreamInterface) (*types.Set[types.Chunk], error) {
-		var (
-			relpages  uint32
-			maxPageID uint32
-			blockSize uint64
-		)
-
+		var relpages, maxPageID, blockSize uint32
 		// Fetch actual table page stats
 		storageStatsquery := jdbc.PostgresTableStorageStats(stream)
 		err := p.client.QueryRowContext(ctx, storageStatsquery).Scan(&relpages, &maxPageID)

--- a/drivers/postgres/internal/backfill.go
+++ b/drivers/postgres/internal/backfill.go
@@ -74,11 +74,11 @@ func (p *Postgres) GetOrSplitChunks(ctx context.Context, pool *destination.Write
 func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.StreamInterface) (*types.Set[types.Chunk], error) {
 	generateCTIDRanges := func(stream types.StreamInterface) (*types.Set[types.Chunk], error) {
 		var maxPageID, blockSize uint32
-		var relpages int64
+		var relPages int64
 		var partitionCount int
 		// Fetch actual table page stats
-		storageStatsquery := jdbc.PostgresTableStorageStats(stream)
-		err := p.client.QueryRowContext(ctx, storageStatsquery).Scan(&relpages, &maxPageID, &partitionCount)
+		storageStatsQuery := jdbc.PostgresTableStorageStats(stream)
+		err := p.client.QueryRowContext(ctx, storageStatsQuery).Scan(&relPages, &maxPageID, &partitionCount)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get table storage stats: %s", err)
 		}
@@ -93,7 +93,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		batchSize := uint32(math.Ceil(float64(batchPages) / float64(partitionCount)))
 
 		if maxPageID <= 0 {
-			maxPageID = uint32(max(1, int(relpages)))
+			maxPageID = uint32(max(1, int(relPages)))
 		}
 		chunks := types.NewSet[types.Chunk]()
 		for start := uint32(0); start < maxPageID; start += batchSize {

--- a/drivers/postgres/internal/backfill.go
+++ b/drivers/postgres/internal/backfill.go
@@ -73,9 +73,12 @@ func (p *Postgres) GetOrSplitChunks(ctx context.Context, pool *destination.Write
 
 func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.StreamInterface) (*types.Set[types.Chunk], error) {
 	generateCTIDRanges := func(stream types.StreamInterface) (*types.Set[types.Chunk], error) {
-		var maxPageID, blockSize uint32
-		var relPages int64
-		var partitionCount int
+		var (
+			maxPageID      uint32
+			blockSize      uint32
+			relPages       int64
+			partitionCount int
+		)
 		// Fetch actual table page stats
 		storageStatsQuery := jdbc.PostgresTableStorageStats(stream)
 		err := p.client.QueryRowContext(ctx, storageStatsQuery).Scan(&relPages, &maxPageID, &partitionCount)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/datazip-inc/olake
 
-go 1.23.2
-
-toolchain go1.23.7
+go 1.24.0
 
 require (
 	github.com/apache/spark-connect-go/v35 v35.0.0-20250317154112-ffd832059443
@@ -14,27 +12,35 @@ require (
 	github.com/go-playground/validator/v10 v10.25.0
 	github.com/goccy/go-json v0.10.5
 	github.com/jackc/pglogrepl v0.0.0-20250322012620-f1e2b1498ed6
+	github.com/jackc/pgtype v1.10.0
 	github.com/jackc/pgx/v5 v5.7.3
 	github.com/jmoiron/sqlx v1.4.0
+	github.com/lib/pq v1.10.9
 	github.com/parquet-go/parquet-go v0.25.0
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20241021075129-b732d2ac9c9b
 	go.mongodb.org/mongo-driver v1.17.3
-	golang.org/x/tools v0.30.0
-	google.golang.org/grpc v1.71.3
-	google.golang.org/protobuf v1.36.6
+	google.golang.org/grpc v1.74.2
+	google.golang.org/protobuf v1.36.8
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
-	sigs.k8s.io/yaml v1.4.0
 )
 
-require github.com/paulmach/orb v0.12.0 // indirect
+require (
+	dario.cat/mergo v1.0.1 // indirect
+	github.com/moby/sys/atomicwriter v0.1.0 // indirect
+	github.com/paulmach/orb v0.12.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
+	golang.org/x/tools v0.34.0 // indirect
+)
 
 require (
-	cloud.google.com/go/compute/metadata v0.6.0 // indirect
+	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -53,8 +59,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
 	github.com/aws/smithy-go v1.22.4 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/brainicorn/goblex v0.0.0-20220304181919-81f017b0ee95 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -63,7 +67,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v28.3.3+incompatible // indirect
+	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
@@ -71,13 +75,12 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -112,9 +115,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/sagikazarmark/locafero v0.8.0 // indirect
-	github.com/segmentio/backo-go v1.1.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed // indirect
@@ -123,41 +124,39 @@ require (
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/testcontainers/testcontainers-go v0.37.0 // indirect
+	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.35.0 // indirect
-	go.opentelemetry.io/otel/metric v1.35.0 // indirect
-	go.opentelemetry.io/otel/trace v1.35.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/crypto v0.40.0
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
-	golang.org/x/mod v0.23.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.28.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
-	golang.org/x/text v0.24.0 // indirect
+	golang.org/x/mod v0.25.0 // indirect
+	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
-	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6
-	github.com/brainicorn/ganno v0.0.0-20220304182003-e638228cd865
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/oklog/ulid v1.3.1
 	github.com/spf13/pflag v1.0.6 // indirect
-	golang.org/x/sync v0.13.0
+	golang.org/x/sync v0.16.0
 )
 
 replace (

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.23.2
+go 1.24.0
 
 toolchain go1.23.7
 

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -163,6 +163,25 @@ SELECT name, pages FROM partitions ORDER BY pages DESC;`,
 	)
 }
 
+// PostgresIsPartitionedQuery returns a SQL query that checks whether a table is partitioned.
+// It counts how many partitions exist under the given parent table in the specified schema.
+func PostgresIsPartitionedQuery(stream types.StreamInterface) string {
+	return fmt.Sprintf(`
+SELECT COUNT(i.inhrelid)
+FROM pg_inherits i
+JOIN pg_class c ON c.oid = i.inhparent
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = '%s'
+  AND c.relname = '%s';`,
+		stream.Namespace(), stream.Name(),
+	)
+}
+
+// PostgresRelPageCount returns the query to fetch relation page count in PostgreSQL
+func PostgresRelPageCount(stream types.StreamInterface) string {
+	return fmt.Sprintf(`SELECT relpages FROM pg_class WHERE relname = '%s' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '%s')`, stream.Name(), stream.Namespace())
+}
+
 // PostgresWalLSNQuery returns the query to fetch the current WAL LSN in PostgreSQL
 func PostgresWalLSNQuery() string {
 	return `SELECT pg_current_wal_lsn()::text::pg_lsn`

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -133,48 +133,60 @@ func PostgresBlockSizeQuery() string {
 // PostgresPartitionPages returns total relpages for each partition and the parent table.
 // This can be used to dynamically adjust chunk sizes based on partition distribution.
 func PostgresPartitionPages(stream types.StreamInterface) string {
-	return fmt.Sprintf(`
-WITH parent AS (
-    SELECT c.oid AS parent_oid
-    FROM pg_class c
-    JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = '%s'
-      AND c.relname = '%s'
-),
-partitions AS (
-    SELECT
-        child.relname AS name,
-        CEIL(1.05 * (pg_relation_size(child.oid) / current_setting('block_size')::int)) AS pages
-    FROM pg_inherits i
-    JOIN pg_class child ON child.oid = i.inhrelid
-    JOIN parent p ON p.parent_oid = i.inhparent
-    UNION ALL
-    SELECT
-        c.relname AS name,
-        CEIL(1.05 * (pg_relation_size(c.oid) / current_setting('block_size')::int)) AS pages
-    FROM pg_class c
-    JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = '%s'
-      AND c.relname = '%s'
-)
-SELECT name, pages FROM partitions ORDER BY pages DESC;`,
-		stream.Namespace(), stream.Name(),
-		stream.Namespace(), stream.Name(),
-	)
+    return fmt.Sprintf(`
+        WITH parent AS (
+            SELECT c.oid AS parent_oid
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = '%s'
+                AND c.relname = '%s'
+        ),
+        partitions AS (
+            SELECT
+                child.relname AS name,
+                CEIL(1.05 * (pg_relation_size(child.oid) / current_setting('block_size')::int)) AS pages
+            FROM pg_inherits i
+            JOIN pg_class child ON child.oid = i.inhrelid
+            JOIN parent p ON p.parent_oid = i.inhparent
+            
+            UNION ALL
+            
+            SELECT
+                c.relname AS name,
+                CEIL(1.05 * (pg_relation_size(c.oid) / current_setting('block_size')::int)) AS pages
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = '%s'
+                AND c.relname = '%s'
+        )
+        SELECT 
+            name, 
+            pages 
+        FROM partitions 
+        ORDER BY pages DESC;
+    `,
+        stream.Namespace(),
+        stream.Name(),
+        stream.Namespace(),
+        stream.Name(),
+    )
 }
 
 // PostgresIsPartitionedQuery returns a SQL query that checks whether a table is partitioned.
 // It counts how many partitions exist under the given parent table in the specified schema.
 func PostgresIsPartitionedQuery(stream types.StreamInterface) string {
-	return fmt.Sprintf(`
-SELECT COUNT(i.inhrelid)
-FROM pg_inherits i
-JOIN pg_class c ON c.oid = i.inhparent
-JOIN pg_namespace n ON n.oid = c.relnamespace
-WHERE n.nspname = '%s'
-  AND c.relname = '%s';`,
-		stream.Namespace(), stream.Name(),
-	)
+    return fmt.Sprintf(`
+        SELECT 
+            COUNT(i.inhrelid)
+        FROM pg_inherits i
+        JOIN pg_class c ON c.oid = i.inhparent
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = '%s'
+            AND c.relname = '%s';
+    `,
+        stream.Namespace(),
+        stream.Name(),
+    )
 }
 
 // PostgresRelPageCount returns the query to fetch relation page count in PostgreSQL

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -135,7 +135,7 @@ func PostgresBlockSizeQuery() string {
 //
 // It returns:
 //   - max_page_id: estimated upper bound of page IDs (using pg_relation_size)
-//   - partition_count: number of partitions (or 1 if not partitioned)
+//   - relpages: estimated page count from pg_class (used as fallback)
 func PostgresTableStorageStats(stream types.StreamInterface) string {
 	return fmt.Sprintf(`
 SELECT

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -133,7 +133,7 @@ func PostgresBlockSizeQuery() string {
 // PostgresPartitionPages returns total relpages for each partition and the parent table.
 // This can be used to dynamically adjust chunk sizes based on partition distribution.
 func PostgresPartitionPages(stream types.StreamInterface) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         WITH parent AS (
             SELECT c.oid AS parent_oid
             FROM pg_class c
@@ -165,17 +165,17 @@ func PostgresPartitionPages(stream types.StreamInterface) string {
         FROM partitions 
         ORDER BY pages DESC;
     `,
-        stream.Namespace(),
-        stream.Name(),
-        stream.Namespace(),
-        stream.Name(),
-    )
+		stream.Namespace(),
+		stream.Name(),
+		stream.Namespace(),
+		stream.Name(),
+	)
 }
 
 // PostgresIsPartitionedQuery returns a SQL query that checks whether a table is partitioned.
 // It counts how many partitions exist under the given parent table in the specified schema.
 func PostgresIsPartitionedQuery(stream types.StreamInterface) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         SELECT 
             COUNT(i.inhrelid)
         FROM pg_inherits i
@@ -184,9 +184,9 @@ func PostgresIsPartitionedQuery(stream types.StreamInterface) string {
         WHERE n.nspname = '%s'
             AND c.relname = '%s';
     `,
-        stream.Namespace(),
-        stream.Name(),
-    )
+		stream.Namespace(),
+		stream.Name(),
+	)
 }
 
 // PostgresRelPageCount returns the query to fetch relation page count in PostgreSQL

--- a/utils/testutils/test_utils.go
+++ b/utils/testutils/test_utils.go
@@ -166,7 +166,7 @@ func (cfg *IntegrationTest) TestIntegration(t *testing.T) {
 
 	t.Run("Discover", func(t *testing.T) {
 		req := testcontainers.ContainerRequest{
-			Image: "golang:1.23.2",
+			Image: "golang:1.24.0",
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.Binds = []string{
 					fmt.Sprintf("%s:/test-olake:rw", cfg.TestConfig.HostRootPath),
@@ -239,7 +239,7 @@ func (cfg *IntegrationTest) TestIntegration(t *testing.T) {
 
 	t.Run("Sync", func(t *testing.T) {
 		req := testcontainers.ContainerRequest{
-			Image: "golang:1.23.2",
+			Image: "golang:1.24.0",
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.Binds = []string{
 					fmt.Sprintf("%s:/test-olake:rw", cfg.TestConfig.HostRootPath),
@@ -513,7 +513,7 @@ func (cfg *PerformanceTest) TestPerformance(t *testing.T) {
 
 	t.Run("performance", func(t *testing.T) {
 		req := testcontainers.ContainerRequest{
-			Image: "golang:1.23.2",
+			Image: "golang:1.24.0",
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.Binds = []string{
 					fmt.Sprintf("%s:/test-olake:rw", cfg.TestConfig.HostRootPath),


### PR DESCRIPTION
# Description

This PR fixes chunk generation for PostgreSQL tables, ensuring correct CTID range calculation when handling partitioned or large tables.
- Added new query to compute `maxPageID` and `partitionCount` with a 5% safety margin.
- Implemented fallback to `relpages` when `maxPageID` <= 0

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):