### PR TITLE
fix: s3 parquet path clear destination

### DIFF
--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -529,8 +529,8 @@ func (p *Parquet) clearS3Files(ctx context.Context, paths []string) error {
 			logger.Warnf("invalid stream ID format: %s, skipping", streamID)
 			continue
 		}
-		namespace, tableName := parts[0], parts[1]
-		s3TablePath := filepath.Join(p.config.Prefix, namespace, tableName, "/")
+		prefix, namespace, tableName := strings.TrimLeft(p.config.Prefix, "/"), parts[0], parts[1]
+		s3TablePath := filepath.Join(prefix, namespace, tableName, "/")
 
 		logger.Debugf("clearing S3 prefix: s3://%s/%s", p.config.Bucket, s3TablePath)
 		if err := deleteS3PrefixStandard(s3TablePath); err != nil {


### PR DESCRIPTION
# Description
Trim added in path provided in s3 parquet

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
clear destination command was run in s3 parquet.


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)
