### PR TITLE
fix: toast values placeholder fix

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -16,6 +16,7 @@ const (
 	MongoPrimaryID         = "_id"
 	OlakeID                = "_olake_id"
 	OlakeTimestamp         = "_olake_timestamp"
+	OlakeUnavailableValue  = "_olake_unavailable_value"
 	OpType                 = "_op_type"
 	CdcTimestamp           = "_cdc_timestamp"
 	DBName                 = "_db"

--- a/pkg/waljs/pgoutput.go
+++ b/pkg/waljs/pgoutput.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/drivers/abstract"
+	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/jackc/pglogrepl"
@@ -154,7 +156,7 @@ func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tu
 		colName := rel.Columns[idx].Name
 		colType := rel.Columns[idx].DataType
 		if col.Data == nil {
-			data[colName] = nil
+			data[colName] = utils.Ternary(col.DataType == uint8('u'), constants.OlakeUnavailableValue, nil)
 			continue
 		}
 

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -126,7 +126,7 @@ var syncCmd = &cobra.Command{
 		// Sync Telemetry tracking
 		telemetry.TrackSyncStarted(syncID, streams, selectedStreamsMetadata.SelectedStreams, selectedStreamsMetadata.CDCStreams, connector.Type(), destinationConfig, catalog)
 		defer func() {
-			telemetry.TrackSyncCompleted(err == nil, pool.GetStats().ReadCount.Load())
+			telemetry.TrackSyncCompleted(syncID, err == nil, pool.GetStats().ReadCount.Load())
 			logger.Infof("Sync completed, wait 5 seconds cleanup in progress...")
 			time.Sleep(5 * time.Second)
 		}()

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -135,12 +135,13 @@ func TrackSyncStarted(syncID string, streams []*types.Stream, selectedStreams []
 	}()
 }
 
-func TrackSyncCompleted(status bool, records int64) {
+func TrackSyncCompleted(syncID string, status bool, records int64) {
 	go func() {
 		if telemetry == nil {
 			return
 		}
 		props := map[string]interface{}{
+			"sync_id":        syncID,
 			"sync_end":       time.Now(),
 			"sync_status":    utils.Ternary(status, "SUCCESS", "FAILED").(string),
 			"records_synced": records,


### PR DESCRIPTION
# Description

During updation in cdc, if updated value is non-toasted value, then a placeholder `_olake_unavailable_value` is put in place for toasted value. This is done as wal does not has logs for toasted columns if replica identity is default, so to remove confusion with 'none', this above placeholder is introduced.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- insertion change of toast column description
<img width="563" height="228" alt="Screenshot 2025-11-11 at 3 44 10 PM" src="https://github.com/user-attachments/assets/eeefe5e3-52f6-4317-9a31-41faf4e2975b" />

- updation changes of non-toasted column (here placeholder for toasted value has occured)
<img width="882" height="146" alt="Screenshot 2025-11-11 at 3 45 58 PM" src="https://github.com/user-attachments/assets/1ab11acc-6ebf-4c89-8535-2f6d3ded5428" />

- when null toasted column record inserted (id = 12)
<img width="864" height="199" alt="Screenshot 2025-11-11 at 3 47 10 PM" src="https://github.com/user-attachments/assets/df722dc0-1f42-44e5-96f4-6b04113a0150" />

- when toasted column updated to null
<img width="1578" height="356" alt="image" src="https://github.com/user-attachments/assets/98315537-165e-4f00-90de-29727c37b4e1" />

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):