### PR TITLE
fix: update docker-compose for local_test

### DIFF
--- a/destination/iceberg/local-test/docker-compose.yml
+++ b/destination/iceberg/local-test/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   lakekeeper:
+    profiles: ["lakekeeper"]
     image: &lakekeeper-image ${LAKEKEEPER__SERVER_IMAGE:-quay.io/lakekeeper/catalog:latest-main}
     pull_policy: &lakekeeper-pull-policy always
     environment: &lakekeeper-environment
@@ -32,6 +33,7 @@ services:
 
 
   migrate:
+    profiles: ["lakekeeper"]
     image: *lakekeeper-image
     pull_policy: *lakekeeper-pull-policy
     environment: *lakekeeper-environment


### PR DESCRIPTION
# Description

Updated the docker-compose file for local testing with adding profile for lakekeeper. The lakekeeper service now does not automatically spin up when we docker-compose up. If there is need for lakekeeper then we can up the docker compose by specifying the profile.

Fixes # (N/A)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

- [x] Verified if all the services are running properly and are healthy
- docker-compose up succeeded both with profile and without profile making sure services are healthy and running.
- Transferred small table from postgres to iceberg after spinning up the modified docker-compose file.
 


# Screenshots or Recordings


## Documentation

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):