### PR TITLE
fix: Decouple Read Preference from Replica Set configuration for SRV support

### DIFF
--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"go/parser"
 	"net/url"
 	"strings"
 
@@ -50,9 +51,9 @@ func (c *Config) URI() string {
 
 	if c.ReplicaSet != "" {
 		query.Set("replicaSet", c.ReplicaSet)
-		if c.ReadPreference == "" {
-			c.ReadPreference = constants.DefaultReadPreference
-		}
+	}
+	setReadPreference(c)
+	if c.ReadPreference != "" {
 		query.Set("readPreference", c.ReadPreference)
 	}
 
@@ -71,6 +72,12 @@ func (c *Config) URI() string {
 	}
 
 	return u.String()
+}
+
+func setReadPreference(c *Config) {
+	if c.ReadPreference == "" {
+		c.ReadPreference = constants.DefaultReadPreference
+	}
 }
 
 // TODO: Add go struct validation in Config


### PR DESCRIPTION
# Description
This change resolves an issue where users connecting to MongoDB Atlas via `mongodb+srv://` URIs were unable to configure custom read preferences. 

The fix decouples read preference handling from the replica set check:
- The default read preference is applied if none is provided.
- The `readPreference` parameter is added to the URI whenever a value is set, regardless of whether a replica set name is specified or whether the connection uses SRV.

Fixes #682 

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [ ] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):