### PR TITLE
fix: clear destination state fix during full load cancel 

### DIFF
--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -136,10 +136,6 @@ func (a *AbstractDriver) ClearState(streams []types.StreamInterface) (*types.Sta
 		for streamID := range dropStreams {
 			a.state.Global.Streams.Remove(streamID)
 		}
-		// if all global streams are dropped, no point for global state itself, making it null
-		if len(a.state.Global.Streams.Array()) == 0 {
-			a.state.Global.State = nil
-		}
 	}
 
 	if len(a.state.Streams) > 0 {


### PR DESCRIPTION
# Description

This PR solves the issue of repeated full load, when running olake through UI.

Case:

- Clear destination is triggered at 2 points, 1st is through manual trigger where streams.json is passed and all the streams are cleared. 2nd is during streams edit, where the old streams and new streams have some properties difference, which generates a difference streams.json which is then cleared.
- Earlier this check was added because during manual trigger, the streams array in both global and stream state was cleared but the state global pointer (LSN) was never cleared. Due to this, even after full manual clear destination, there were issue of LSN mismatch in next sync, where the expectation were full refresh.
- But now this check is causing problem in case streams are edited. What can happen is let's say a sync is running in full refresh+cdc mode, and during the full load this sync activity was cancelled, and then streams are edited. 
- In this sync mode, pre-cdc is called first, and global pointer is persisted in state, but streams array is not populated until full load is over. Now for a canceled sync (during full load), if streams are edited, then clear destination is triggered, and as the global streams array is empty, this removes the global pointer from state.
- Now when sync is ran again, for the streams whose full load was already completed, again its full load starts.

Solution:

- Olake UI during manual clear destination will update state in database to be nil, sending empty object `{}` state file in clear destination and clear destination will also update the state to be `{}`, so then every time after manual clear destination, full refresh will compulsorily happen. This way the work the check was doing earlier, it won't be needed anymore.
- No changes will be encountered in edit streams though.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested in CLI by passing empty object in state file, provided during clear destination. This will be tested fully after Olake UI changes as well.


# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):