### PR TITLE
fix(parquet): improve file naming convention

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -240,7 +240,7 @@ func genULID(t time.Time) string {
 // Returns a timestamped
 func TimestampedFileName(extension string) string {
 	now := time.Now().UTC()
-	return fmt.Sprintf("%d-%d-%d_%d-%d-%d_%s.%s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(), genULID(now), extension)
+	return fmt.Sprintf("%d-%02d-%02d_%02d-%02d-%02d_%s.%s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(), genULID(now), extension)
 }
 
 func IsJSON(str string) bool {


### PR DESCRIPTION
# Description

Fix the parquet file naming convention for proper sorting.

Previous:
`2026-1-3_8-27-56_01KE1FGTKPFDMN79ZN9P47KYY0.parquet`

With the fix:
`2026-01-03_08-26-26_01KE1FE28V82MCTY1M02DBM3G7.parquet`

Fixes #717 

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Local Parquet Writer

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)