### PR TITLE
docs(s3): clarify optional authentication fields and add IAM role examples

### DIFF
--- a/drivers/s3/README.md
+++ b/drivers/s3/README.md
@@ -30,9 +30,16 @@ Production-ready S3 source connector for Olake that enables ingesting data from 
 |-------|------|-------------|
 | `bucket_name` | string | S3 bucket name |
 | `region` | string | AWS region (e.g., "us-east-1") |
-| `access_key_id` | string | AWS access key ID |
-| `secret_access_key` | string | AWS secret access key |
 | `file_format` | string | File format: `csv`, `json`, or `parquet` |
+
+### Authentication Fields (Optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `access_key_id` | string | AWS access key ID (optional - see note below) |
+| `secret_access_key` | string | AWS secret access key (optional - see note below) |
+
+**Authentication Note**: Both `access_key_id` and `secret_access_key` are **optional**. If omitted, the driver uses AWS default credential chain (IAM roles, environment variables, instance profiles, ECS task roles, etc.). If you provide one, you must provide both.
 
 ### Optional Fields
 
@@ -129,19 +136,40 @@ cd drivers/s3/examples
 
 ## Example Configurations
 
-### AWS S3 with Parquet (Folder Grouping)
+### AWS S3 with Parquet (IAM Role Authentication)
 
 ```json
 {
   "bucket_name": "my-data-warehouse",
   "region": "us-east-1",
   "path_prefix": "data/",
-  "access_key_id": "YOUR_ACCESS_KEY",
-  "secret_access_key": "YOUR_SECRET_KEY",
   "file_format": "parquet",
   "max_threads": 10
 }
 ```
+
+**Note**: No credentials needed when using IAM roles, environment variables, or instance profiles.
+
+### AWS S3 with Static Credentials
+
+```json
+{
+  "bucket_name": "my-data-warehouse",
+  "region": "us-east-1",
+  "path_prefix": "data/",
+  "access_key_id": "<YOUR_AWS_ACCESS_KEY_ID>",
+  "secret_access_key": "<YOUR_AWS_SECRET_ACCESS_KEY>",
+  "file_format": "parquet",
+  "max_threads": 10
+}
+```
+
+**Alternative**: Use environment variables:
+```bash
+export AWS_ACCESS_KEY_ID="your_access_key"
+export AWS_SECRET_ACCESS_KEY="your_secret_key"
+```
+Then omit credentials from config - the driver uses environment variables automatically.
 
 **Folder Structure**:
 ```
@@ -181,8 +209,8 @@ Handles both `.csv` and `.csv.gz` files automatically!
   "bucket_name": "event-logs",
   "region": "us-west-2",
   "path_prefix": "events/",
-  "access_key_id": "YOUR_ACCESS_KEY",
-  "secret_access_key": "YOUR_SECRET_KEY",
+  "access_key_id": "<YOUR_AWS_ACCESS_KEY_ID>",
+  "secret_access_key": "<YOUR_AWS_SECRET_ACCESS_KEY>",
   "file_format": "json",
   "max_threads": 5
 }
@@ -305,9 +333,8 @@ Configure in `streams.json`:
 ## Known Limitations
 
 1. **Schema Evolution**: Manual re-discovery needed if file schema changes
-2. **Authentication**: Only access key/secret key (no IAM roles yet)
-3. **Compression**: Only gzip supported (no zip/bzip2)
-4. **Stream Grouping**: Fixed at level 1 (first folder only)
+2. **Compression**: Only gzip supported (no zip/bzip2)
+3. **Stream Grouping**: Fixed at level 1 (first folder only)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Updates the S3 driver README to clarify that authentication fields are optional and provides comprehensive examples for both IAM role-based and static credential authentication methods.

## Changes

### Authentication Section Restructuring
- **Moved authentication fields** from "Required Fields" to a new dedicated "Authentication Fields (Optional)" section
- **Added explicit note** that both `access_key_id` and `secret_access_key` are optional
- **Documented AWS Default Credential Chain**: When credentials are omitted, the driver automatically uses:
  - IAM roles
  - Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
  - Instance profiles
  - ECS task roles
  - Other AWS credential sources

### Enhanced Examples
- **Split configuration examples** into two clear sections:
  1. **IAM Role Authentication**: Shows configuration without any credentials (recommended for production)
  2. **Static Credentials**: Shows explicit credential usage with environment variable alternative
- **Improved placeholder values**: Changed from `YOUR_ACCESS_KEY` to `<YOUR_AWS_ACCESS_KEY_ID>` for clarity
- **Added environment variable documentation**: Shows how to use `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars instead of config file

### Documentation Cleanup
- **Removed outdated limitation**: Removed "Only access key/secret key (no IAM roles yet)" from Known Limitations section since IAM roles are fully supported

## Benefits

- **Reduces Confusion**: Users no longer need to guess whether credentials are required
- **Security Best Practices**: Encourages use of IAM roles over static credentials in production
- **Better Onboarding**: Clear examples for both authentication approaches
- **Flexibility**: Documents multiple authentication methods (IAM roles, static credentials, environment variables)
- **Accurate Documentation**: Removes outdated limitations about IAM role support

## Example Configurations

### IAM Role Authentication (No Credentials)
```json
{
  "bucket_name": "my-data-warehouse",
  "region": "us-east-1",
  "path_prefix": "data/",
  "file_format": "parquet",
  "max_threads": 10
}
```

### Static Credentials
```json
{
  "bucket_name": "my-data-warehouse",
  "region": "us-east-1",
  "path_prefix": "data/",
  "access_key_id": "<YOUR_AWS_ACCESS_KEY_ID>",
  "secret_access_key": "<YOUR_AWS_SECRET_ACCESS_KEY>",
  "file_format": "parquet",
  "max_threads": 10
}
```

**Alternative**: Use environment variables:
```bash
export AWS_ACCESS_KEY_ID="your_access_key"
export AWS_SECRET_ACCESS_KEY="your_secret_key"
```

## Testing

- [x] Verified README formatting and markdown syntax
- [x] Confirmed all JSON examples are syntactically correct
- [x] Reviewed authentication flow documentation for accuracy
- [x] Validated that examples match actual driver behavior

## Checklist

- [x] Documentation Link: [S3 Driver README](drivers/s3/README.md)