### PR TITLE
fix: evaluate idle checkpoint after every emitted change

### DIFF
--- a/types/data_types.go
+++ b/types/data_types.go
@@ -71,9 +71,6 @@ type RawRecord struct {
 }
 
 func CreateRawRecord(olakeID string, data map[string]any, operationType string, cdcTimestamp *time.Time) RawRecord {
-	if data == nil {
-		data = make(map[string]any)
-	}
 	return RawRecord{
 		OlakeID:       olakeID,
 		Data:          data,


### PR DESCRIPTION
# Description

Evaluate idle checkpoint after each processed change instead of only on empty change stream iterations, enabling faster and deterministic CDC termination when caught up.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):