### PR TITLE
feat: remove dedup logic from golang side

### DIFF
--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -247,41 +247,6 @@ func (i *Iceberg) Type() string {
 
 // validate schema change & evolution and removes null records
 func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRecord) (bool, []types.RawRecord, any, error) {
-	// dedup records according to cdc timestamp and olakeID
-	dedupRecords := func(records []types.RawRecord) []types.RawRecord {
-		// only dedup if it is upsert mode
-		if !isUpsertMode(i.stream, i.options.Backfill) {
-			return records
-		}
-
-		// map olakeID -> index of record to keep (index into original slice)
-		keepIdx := make(map[string]int, len(records))
-		for idx, record := range records {
-			existingIdx, ok := keepIdx[record.OlakeID]
-			if !ok {
-				keepIdx[record.OlakeID] = idx
-				continue
-			}
-			if record.CdcTimestamp == nil {
-				keepIdx[record.OlakeID] = idx // keep latest reord (in incremental)
-				continue
-			}
-
-			ex := records[existingIdx]
-			if ex.CdcTimestamp.Before(*record.CdcTimestamp) {
-				keepIdx[record.OlakeID] = idx // keep latest reord (w.r.t cdc timestamp)
-			}
-		}
-
-		out := make([]types.RawRecord, 0, len(keepIdx))
-		for rIdx, record := range records {
-			if idx, ok := keepIdx[record.OlakeID]; ok && idx == rIdx {
-				out = append(out, record)
-			}
-		}
-		return out
-	}
-
 	// extractSchemaFromRecords detects difference in current thread schema and the batch that being received
 	// Also extracts current batch schema
 	extractSchemaFromRecords := func(ctx context.Context, records []types.RawRecord) (bool, map[string]string, error) {
@@ -379,8 +344,6 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 
 		return diffThreadSchema.Load(), schemaMap, err
 	}
-
-	records = dedupRecords(records)
 
 	if !i.stream.NormalizationEnabled() {
 		return false, records, i.schema, nil


### PR DESCRIPTION
# Description

We no longer need to handle the de-duplication logic towards the golang side as iceberg java engine handles this on its own, by creating positional delete files.

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Iceberg + Spark
- [x] Both in the same destination buffer and different destination buffer

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)