### PR TITLE
Change binlog check from metadata to image

### DIFF
--- a/drivers/mysql/internal/mysql.go
+++ b/drivers/mysql/internal/mysql.go
@@ -276,9 +276,9 @@ func (m *MySQL) IsCDCSupported(ctx context.Context) (bool, error) {
 		expectedValue string
 		errMessage    string
 	}{
-		{jdbc.MySQLLogBinQuery(), "ON", "log_bin is not enabled"},
+		{jdbc.MySQLBinLogQuery(), "ON", "log_bin is not enabled"},
 		{jdbc.MySQLBinlogFormatQuery(), "ROW", "binlog_format is not set to ROW"},
-		{jdbc.MySQLBinlogRowMetadataQuery(), "FULL", "binlog_row_metadata is not set to FULL"},
+		{jdbc.MySQLBinlogRowImageQuery(), "FULL", "binlog_row_image is not set to FULL"},
 	}
 
 	for _, check := range configChecks {

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -375,8 +375,8 @@ func MySQLMasterStatusQueryNew() string {
 	return "SHOW BINARY LOG STATUS"
 }
 
-// MySQLLogBinQuery returns the query to fetch the log_bin variable in MySQL
-func MySQLLogBinQuery() string {
+// MySQLBinLogQuery returns the query to fetch the log_bin variable in MySQL
+func MySQLBinLogQuery() string {
 	return "SHOW VARIABLES LIKE 'log_bin'"
 }
 
@@ -388,6 +388,11 @@ func MySQLBinlogFormatQuery() string {
 // MySQLBinlogRowMetadataQuery returns the query to fetch the binlog_row_metadata variable in MySQL
 func MySQLBinlogRowMetadataQuery() string {
 	return "SHOW VARIABLES LIKE 'binlog_row_metadata'"
+}
+
+// MySQLBinlogRowImageQuery returns the query to fetch the binlog_row_image variable in MySQL
+func MySQLBinlogRowImageQuery() string {
+	return "SHOW VARIABLES LIKE 'binlog_row_image'"
 }
 
 // MySQLTableColumnsQuery returns the query to fetch column names of a table in MySQL


### PR DESCRIPTION
# Description

The [documentation](https://olake.io/docs/connectors/mysql/setup/generic/) specifies that binlog-row-metadata is optional and binlog-row-image is required to be FULL, but the check is done incorrectly. Right now IsCDCSupported checks for binlog-row-metadata instead of binlog-row-image

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
