### PR TITLE
Change binlog check from metadata to image

### DIFF
--- a/drivers/mysql/internal/mysql.go
+++ b/drivers/mysql/internal/mysql.go
@@ -278,7 +278,7 @@ func (m *MySQL) IsCDCSupported(ctx context.Context) (bool, error) {
 	}{
 		{jdbc.MySQLLogBinQuery(), "ON", "log_bin is not enabled"},
 		{jdbc.MySQLBinlogFormatQuery(), "ROW", "binlog_format is not set to ROW"},
-		{jdbc.MySQLBinlogRowMetadataQuery(), "FULL", "binlog_row_metadata is not set to FULL"},
+		{jdbc.MySQLBinlogRowImageQuery(), "FULL", "binlog_row_image is not set to FULL"},
 	}
 
 	for _, check := range configChecks {

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -390,6 +390,11 @@ func MySQLBinlogRowMetadataQuery() string {
 	return "SHOW VARIABLES LIKE 'binlog_row_metadata'"
 }
 
+// MySQLBinlogRowImageQuery returns the query to fetch the binlog_row_image variable in MySQL
+func MySQLBinlogRowImageQuery() string {
+	return "SHOW VARIABLES LIKE 'binlog_row_image'"
+}
+
 // MySQLTableColumnsQuery returns the query to fetch column names of a table in MySQL
 func MySQLTableColumnsQuery() string {
 	return `


### PR DESCRIPTION
# Description

The [documentation](https://olake.io/docs/connectors/mysql/setup/generic/) specifies that binlog-row-metadata is optional and binlog-row-image is required to be FULL, but the check is done incorrectly. Right now IsCDCSupported checks for binlog-row-metadata instead of binlog-row-image

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
