### PR TITLE
fix: add case for number handling during flatten for Kafka

### DIFF
--- a/utils/typeutils/flatten.go
+++ b/utils/typeutils/flatten.go
@@ -60,7 +60,8 @@ func (f *FlattenerImpl) flatten(key string, value any, destination types.Record)
 
 	// Type switch is faster than reflection for known types
 	switch v := value.(type) {
-	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, string, time.Time:
+	// json.Number is included because Kafka driver uses decoder.UseNumber() for number handling
+	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, string, time.Time, json.Number:
 		destination[reformattedKey] = v
 	case []byte:
 		destination[reformattedKey] = string(v)

--- a/utils/typeutils/flatten_test.go
+++ b/utils/typeutils/flatten_test.go
@@ -1,6 +1,7 @@
 package typeutils
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -498,6 +499,16 @@ func TestFlattenInternal(t *testing.T) {
 			},
 			expected: types.Record{
 				"all_numbers": `{"float32":3.14,"float64":3.14,"int":42,"int16":-42,"int32":423425,"int64":42425463733234,"int8":-42,"uint":42,"uint16":42,"uint32":42,"uint64":42,"uint8":42}`,
+			},
+			expectError: false,
+		},
+		// replicates scenario when Kafka driver parses JSON with decoder.UseNumber() for number handling
+		{
+			name:  "json.Number from Kafka UseNumber",
+			key:   "json_number",
+			value: json.Number("12345678901234567890"),
+			expected: types.Record{
+				"json_number": json.Number("12345678901234567890"),
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
# Description

The [flatten](cci:1://file:///Users/admin/Desktop/Olake/volake/utils/typeutils/flatten.go:50:0-77:1) utility was falling back to default marshaling for `json.Number` types, effectively converting them into JSON strings. This is problematic for drivers like Kafka that use `json.Decoder.UseNumber()` to preserve numeric precision.

Because `json.Number` was not explicitly handled in the type switch, it fell through to the default case, was re-marshaled as a string, and caused type mismatch errors during schema detection (e.g., `expected type: long, detected type: string`).

This PR adds `json.Number` to the allowed primitive types in [flatten.go](cci:7://file:///Users/admin/Desktop/Olake/volake/utils/typeutils/flatten.go:0:0-0:0), ensuring valid numbers are passed through correctly to the writers without being converted to strings.

Fixes an issue where syncing failed with:
`failed to validate schema for field[cm_id] (detected two different types in batch), expected type: long, detected type: string`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] **Unit Test**: Added a regression test case in [flatten_test.go](cci:7://file:///Users/admin/Desktop/Olake/volake/utils/typeutils/flatten_test.go:0:0-0:0) to ensure `json.Number` is preserved as-is.
- [x] **Manual Verification**: Successfully synced 2 million records from Kafka without type mismatch errors.

# Screenshots or Recordings
N/A

## Documentation
- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):