### PR TITLE
feat: add support for custom endpoint in glue catalog

### DIFF
--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	GlueEndpoint  string `json:"glue_endpoint,omitempty"`
 	GlueAccessKey string `json:"glue_access_key,omitempty"`
 	GlueSecretKey string `json:"glue_secret_key,omitempty"`
+	GlueRegion    string `json:"glue_region,omitempty"`
 	GlueCatalogID string `json:"glue_catalog_id,omitempty"`
 
 	// JDBC specific configuration

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -43,11 +43,12 @@ type Config struct {
 	CatalogName string      `json:"catalog_name,omitempty"`
 
 	// Glue catalog optional overrides
-	GlueEndpoint  string `json:"glue_endpoint,omitempty"`
-	GlueAccessKey string `json:"glue_access_key,omitempty"`
-	GlueSecretKey string `json:"glue_secret_key,omitempty"`
-	GlueRegion    string `json:"glue_region,omitempty"`
-	GlueCatalogID string `json:"glue_catalog_id,omitempty"`
+	UseGlueAdditionalConfig bool   `json:"glue_additional_config,omitempty"`
+	GlueEndpoint            string `json:"glue_endpoint,omitempty"`
+	GlueAccessKey           string `json:"glue_access_key,omitempty"`
+	GlueSecretKey           string `json:"glue_secret_key,omitempty"`
+	GlueRegion              string `json:"glue_region,omitempty"`
+	GlueCatalogID           string `json:"glue_catalog_id,omitempty"`
 
 	// JDBC specific configuration
 	JDBCUrl      string `json:"jdbc_url,omitempty"`

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -42,6 +42,12 @@ type Config struct {
 	CatalogType CatalogType `json:"catalog_type,omitempty"`
 	CatalogName string      `json:"catalog_name,omitempty"`
 
+	// Glue catalog optional overrides
+	GlueEndpoint  string `json:"glue_endpoint,omitempty"`
+	GlueAccessKey string `json:"glue_access_key,omitempty"`
+	GlueSecretKey string `json:"glue_secret_key,omitempty"`
+	GlueCatalogID string `json:"glue_catalog_id,omitempty"`
+
 	// JDBC specific configuration
 	JDBCUrl      string `json:"jdbc_url,omitempty"`
 	JDBCUsername string `json:"jdbc_username,omitempty"`

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -77,7 +77,7 @@ func getServerConfigJSON(config *Config, partitionInfo []internal.PartitionInfo,
 		serverConfig["catalog-impl"] = "org.apache.iceberg.aws.glue.GlueCatalog"
 
 		// if custom glue endpoint creds are passed
-		if config.GlueAccessKey != "" && config.GlueSecretKey != "" {
+		if config.UseGlueAdditionalConfig {
 			addMapKeyIfNotEmpty("client.factory", "io.debezium.server.iceberg.OlakeAwsClientFactory")
 			addMapKeyIfNotEmpty("glue.access-key-id", config.GlueAccessKey)
 			addMapKeyIfNotEmpty("glue.secret-access-key", config.GlueSecretKey)

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -84,6 +84,7 @@ func getServerConfigJSON(config *Config, partitionInfo []internal.PartitionInfo,
 			addMapKeyIfNotEmpty("client.factory", "io.debezium.server.iceberg.OlakeAwsClientFactory")
 			addMapKeyIfNotEmpty("glue.access-key-id", config.GlueAccessKey)
 			addMapKeyIfNotEmpty("glue.secret-access-key", config.GlueSecretKey)
+			addMapKeyIfNotEmpty("glue.region", config.GlueRegion)
 		}
 	case JDBCCatalog:
 		serverConfig["catalog-impl"] = "org.apache.iceberg.jdbc.JdbcCatalog"

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -75,6 +75,16 @@ func getServerConfigJSON(config *Config, partitionInfo []internal.PartitionInfo,
 	switch config.CatalogType {
 	case GlueCatalog:
 		serverConfig["catalog-impl"] = "org.apache.iceberg.aws.glue.GlueCatalog"
+
+		addMapKeyIfNotEmpty("glue.endpoint", config.GlueEndpoint)
+		addMapKeyIfNotEmpty("glue.id", config.GlueCatalogID)
+		addMapKeyIfNotEmpty("glue.catalog-id", config.GlueCatalogID)
+
+		if config.GlueAccessKey != "" && config.GlueSecretKey != "" {
+			addMapKeyIfNotEmpty("client.factory", "io.debezium.server.iceberg.OlakeAwsClientFactory")
+			addMapKeyIfNotEmpty("glue.access-key-id", config.GlueAccessKey)
+			addMapKeyIfNotEmpty("glue.secret-access-key", config.GlueSecretKey)
+		}
 	case JDBCCatalog:
 		serverConfig["catalog-impl"] = "org.apache.iceberg.jdbc.JdbcCatalog"
 		serverConfig["uri"] = config.JDBCUrl

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -76,14 +76,13 @@ func getServerConfigJSON(config *Config, partitionInfo []internal.PartitionInfo,
 	case GlueCatalog:
 		serverConfig["catalog-impl"] = "org.apache.iceberg.aws.glue.GlueCatalog"
 
-		addMapKeyIfNotEmpty("glue.endpoint", config.GlueEndpoint)
-		addMapKeyIfNotEmpty("glue.id", config.GlueCatalogID)
-		addMapKeyIfNotEmpty("glue.catalog-id", config.GlueCatalogID)
-
+		// if custom glue endpoint creds are passed
 		if config.GlueAccessKey != "" && config.GlueSecretKey != "" {
 			addMapKeyIfNotEmpty("client.factory", "io.debezium.server.iceberg.OlakeAwsClientFactory")
 			addMapKeyIfNotEmpty("glue.access-key-id", config.GlueAccessKey)
 			addMapKeyIfNotEmpty("glue.secret-access-key", config.GlueSecretKey)
+			addMapKeyIfNotEmpty("glue.endpoint", config.GlueEndpoint)
+			addMapKeyIfNotEmpty("glue.id", config.GlueCatalogID)
 			addMapKeyIfNotEmpty("glue.region", config.GlueRegion)
 		}
 	case JDBCCatalog:

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
@@ -72,7 +72,7 @@ public class OlakeAwsClientFactory implements AwsClientFactory {
         // Region: prefer glue.region if set, otherwise fall back to s3.region
         String region = props.get("glue.region");
         if (isBlank(region)) {
-             String s3Region = props.get("s3.region");
+             region = props.get("s3.region");
         }
         if (!isBlank(region)) {
             builder.region(Region.of(region));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
@@ -69,8 +69,11 @@ public class OlakeAwsClientFactory implements AwsClientFactory {
                         )
                 );
 
-        // Region: prefer s3.region (we set it from aws_region in Go)
-        String region = props.get("s3.region");
+        // Region: prefer glue.region if set, otherwise fall back to s3.region
+        String region = props.get("glue.region");
+        if (isBlank(region)) {
+             String s3Region = props.get("s3.region");
+        }
         if (!isBlank(region)) {
             builder.region(Region.of(region));
         }
@@ -98,4 +101,3 @@ public class OlakeAwsClientFactory implements AwsClientFactory {
         return s == null || s.trim().isEmpty();
     }
 }
-

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
@@ -1,0 +1,101 @@
+package io.debezium.server.iceberg;
+
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.AwsClientFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Custom Iceberg AwsClientFactory that keeps S3 FileIO credentials separate from Glue catalog credentials.
+ *
+ * <p>Behavior:
+ * <ul>
+ *   <li>S3 client: delegated to Iceberg's default factory (uses standard Iceberg S3 properties like s3.access-key-id)</li>
+ *   <li>Glue client: if glue.access-key-id/glue.secret-access-key are provided, use them as static credentials</li>
+ *   <li>Glue endpoint: if glue.endpoint is provided, use it as endpointOverride</li>
+ * </ul>
+ */
+public class OlakeAwsClientFactory implements AwsClientFactory {
+
+    private transient AwsClientFactory delegate;
+    private transient Map<String, String> props;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        // Iceberg passes a properties map; normalize to String->String
+        Map<String, String> p = new HashMap<>();
+        if (properties != null) {
+            for (Map.Entry<String, String> e : properties.entrySet()) {
+                if (e.getKey() != null && e.getValue() != null) {
+                    p.put(e.getKey(), e.getValue());
+                }
+            }
+        }
+        this.props = p;
+
+        this.delegate = AwsClientFactories.defaultFactory();
+        this.delegate.initialize(this.props);
+    }
+
+    @Override
+    public S3Client s3() {
+        return delegate.s3();
+    }
+
+    @Override
+    public GlueClient glue() {
+        String glueAccessKey = props.get("glue.access-key-id");
+        String glueSecretKey = props.get("glue.secret-access-key");
+
+        // If no separate Glue creds are provided, fall back to default behavior.
+        if (isBlank(glueAccessKey) || isBlank(glueSecretKey)) {
+            return delegate.glue();
+        }
+
+        GlueClientBuilder builder = GlueClient.builder()
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(glueAccessKey, glueSecretKey)
+                        )
+                );
+
+        // Region: prefer s3.region (we set it from aws_region in Go)
+        String region = props.get("s3.region");
+        if (!isBlank(region)) {
+            builder.region(Region.of(region));
+        }
+
+        // Optional Glue-compatible endpoint override
+        String endpoint = props.get("glue.endpoint");
+        if (!isBlank(endpoint)) {
+            builder.endpointOverride(URI.create(endpoint));
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public KmsClient kms() {
+        return delegate.kms();
+    }
+
+    @Override
+    public DynamoDbClient dynamo() {
+        return delegate.dynamo();
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}
+

--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -267,11 +267,7 @@
                           "title": "Glue Region",
                           "description": "AWS region for the Glue catalog, if different from the S3 region. Falls back to AWS Region if not set"
                         }
-                      },
-                      "required": [
-                        "glue_access_key",
-                        "glue_secret_key"
-                      ]
+                      }
                     },
                     {
                       "properties": {

--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -225,6 +225,11 @@
                 "catalog_type": {
                   "const": "glue"
                 },
+                "s3_endpoint": {
+                  "type": "string",
+                  "title": "S3 Endpoint",
+                  "description": "Specifies the endpoint URL for S3 compatible services"
+                },
                 "glue_additional_config": {
                   "type": "boolean",
                   "default": false,
@@ -243,24 +248,24 @@
                         "glue_catalog_id": {
                           "type": "string",
                           "title": "Glue Catalog ID",
-                          "description": "AWS account ID used as the Glue Data Catalog identifier (e.g., 123456789012)"
+                          "description": "AWS account ID used as the Glue Data Catalog identifier"
                         },
                         "glue_access_key": {
                           "type": "string",
                           "format": "password",
                           "title": "Glue Access Key",
-                          "description": "AWS access key for authenticating Glue catalog requests, required when Glue credentials differ from S3 credentials"
+                          "description": "Access key for authenticating Glue catalog requests, required when Glue credentials differ from S3 credentials"
                         },
                         "glue_secret_key": {
                           "type": "string",
                           "format": "password",
                           "title": "Glue Secret Key",
-                          "description": "AWS secret key for authenticating Glue catalog requests, required when Glue credentials differ from S3 credentials"
+                          "description": "Secret key for authenticating Glue catalog requests, required when Glue credentials differ from S3 credentials"
                         },
                         "glue_endpoint": {
                           "type": "string",
                           "title": "Glue Endpoint",
-                          "description": "Custom endpoint URL for AWS Glue or a Glue-compatible catalog service (e.g., https://glue.ap-south-1.amazonaws.com)"
+                          "description": "Custom endpoint URL for AWS Glue or a Glue-compatible catalog service"
                         },
                         "glue_region": {
                           "type": "string",

--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -224,6 +224,63 @@
               "properties": {
                 "catalog_type": {
                   "const": "glue"
+                },
+                "glue_additional_config": {
+                  "type": "boolean",
+                  "default": false,
+                  "title": "Custom Glue Endpoint Configuration",
+                  "description": "Enable separate credentials (access key and secret key), endpoint, and region for the Glue catalog"
+                }
+              },
+              "dependencies": {
+                "glue_additional_config": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "glue_additional_config": {
+                          "const": true
+                        },
+                        "glue_catalog_id": {
+                          "type": "string",
+                          "title": "Glue Catalog ID",
+                          "description": "AWS account ID used as the Glue Data Catalog identifier (e.g., 123456789012)"
+                        },
+                        "glue_access_key": {
+                          "type": "string",
+                          "format": "password",
+                          "title": "Glue Access Key",
+                          "description": "AWS access key for authenticating Glue catalog requests, required when Glue credentials differ from S3 credentials"
+                        },
+                        "glue_secret_key": {
+                          "type": "string",
+                          "format": "password",
+                          "title": "Glue Secret Key",
+                          "description": "AWS secret key for authenticating Glue catalog requests, required when Glue credentials differ from S3 credentials"
+                        },
+                        "glue_endpoint": {
+                          "type": "string",
+                          "title": "Glue Endpoint",
+                          "description": "Custom endpoint URL for AWS Glue or a Glue-compatible catalog service (e.g., https://glue.ap-south-1.amazonaws.com)"
+                        },
+                        "glue_region": {
+                          "type": "string",
+                          "title": "Glue Region",
+                          "description": "AWS region for the Glue catalog, if different from the S3 region. Falls back to AWS Region if not set"
+                        }
+                      },
+                      "required": [
+                        "glue_access_key",
+                        "glue_secret_key"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "glue_additional_config": {
+                          "const": false
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -394,7 +394,10 @@ const IcebergUISchema = `{
       { "rest_signing_name": 12, "rest_signing_region": 12 },
       { "rest_signing_v_4": 12, "scope": 12, "s3_endpoint": 12 },
       { "aws_access_key": 12, "aws_secret_key": 12 },
-      { "aws_region": 12, "arrow_writes": 12 }
+      { "aws_region": 12, "glue_additional_config": 12 },
+	 { "glue_catalog_id": 12, "glue_access_key": 12, "glue_secret_key": 12 },
+      { "glue_endpoint": 12, "glue_region": 12 },
+      { "arrow_writes": 12 }
     ],
     "no_identifier_fields": {
       "ui:widget": "boolean"
@@ -412,6 +415,9 @@ const IcebergUISchema = `{
       "ui:widget": "boolean"
     },
     "arrow_writes": {
+      "ui:widget": "boolean"
+    },
+    "glue_additional_config": {
       "ui:widget": "boolean"
     },
     "catalog_type": {


### PR DESCRIPTION
# Description

Adds optional Glue-specific config so catalog and storage can use different credentials and endpoint. New optional fields: `glue_endpoint`, `glue_access_key`, `glue_secret_key`, `glue_catalog_id`. When `glue_*` creds are set, a custom `AwsClientFactory` in the Java writer is used so Glue uses those creds while S3 FileIO keeps using `aws_*`. If `glue_*` is not set, behavior is unchanged (backward compatible).

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified the changes by setting up a local environment using MinIO (for S3) and Moto (for Glue) to simulate AWS services.

- [X] **Standard AWS Glue:** Verified backward compatibility by running against a real AWS Glue instance and S3 bucket with and without custom endpoints.

```json
{
     "type": "ICEBERG",
     "writer": {
          "catalog_type": "glue",
          "iceberg_s3_path": "",
          "aws_region": "",
          "aws_access_key": "",
          "aws_secret_key": "",
          "glue_additional_config": true,
          "glue_endpoint": "",
          "glue_access_key": "",
          "glue_secret_key": "",
          "glue_region": "",
          "glue_catalog_id": ""
     }
}
```

- [x] **Moto/MinIO Setup:** Configured the destination to point to a local Moto server for Glue and MinIO for S3. Verified that the Iceberg writer correctly connects to the custom Glue endpoint and successfully commits tables and metadata.
```yaml
version: "3.8"
services:
  moto-glue:
    image: motoserver/moto:latest
    container_name: moto-glue
    ports:
      - "5001:5001"
    environment:
      - MOTO_PORT=5001

```

# Screenshots or Recordings
N/A

## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):
None