### PR TITLE
fix: primary key order mismatch during chunk processing (MSSQL, DB2)

### DIFF
--- a/drivers/db2/internal/backfill.go
+++ b/drivers/db2/internal/backfill.go
@@ -38,6 +38,7 @@ func (d *DB2) ChunkIterator(ctx context.Context, stream types.StreamInterface, c
 
 	// if PK present then PK based chunking else RID based chunking
 	pkColumns := stream.GetStream().SourceDefinedPrimaryKey.Array()
+	sort.Strings(pkColumns)
 
 	var stmt string
 	if stream.Self().StreamMetadata.ChunkColumn != "" {

--- a/drivers/mssql/go.mod
+++ b/drivers/mssql/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/linkedin/goavro/v2 v2.15.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/drivers/mssql/internal/backfill.go
+++ b/drivers/mssql/internal/backfill.go
@@ -40,6 +40,7 @@ func (m *MSSQL) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 	// Use repeatable read isolation without read-only flag
 	return jdbc.WithIsolation(ctx, m.client, false, func(tx *sql.Tx) error {
 		pkColumns := stream.GetStream().SourceDefinedPrimaryKey.Array()
+		sort.Strings(pkColumns)
 		chunkColumn := stream.Self().StreamMetadata.ChunkColumn
 
 		logger.Debugf("Starting backfill from %v to %v with filter: %s, args: %v", chunk.Min, chunk.Max, filter, args)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, primary key columns were sorted only in the `SplitOrGetChunks` method, but not in `ChunkIterator`. This caused non-deterministic ordering for composite primary keys during backfill in MSSQL and DB2, leading to inconsistent lexicographical comparisons.

This PR ensures primary key columns are explicitly sorted within ChunkIterator, guaranteeing consistent ordering across chunk splitting and data scanning phases.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->
- With same error message on using a invalid value. 
<img width="1080" height="257" alt="Screenshot 2026-02-14 at 14 34 40" src="https://github.com/user-attachments/assets/dfd7316d-ef40-46b7-b61d-97bd894df73c" />

- With the same datetime format = `Jan 15 1950 12:00AM`
<img width="756" height="218" alt="Screenshot 2026-02-14 at 14 34 57" src="https://github.com/user-attachments/assets/f743c275-07a5-48d2-ad01-3916cca7f0d9" />


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):