### PR TITLE
perf: improve chunk-scan query by removing tuple comparison

### DIFF
--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -269,10 +269,7 @@ func buildLexicographicChunkCondition(quotedColumns []string, chunk types.Chunk,
 	// For upper bounds, it creates:
 	//   (c1 < v1) OR (c1 = v1 AND c2 < v2) OR (c1 = v1 AND c2 = v2 AND c3 < v3)
 	buildBound := func(values []string, isLower bool) string {
-		if len(values) == 0 {
-			return ""
-		}
-
+		//note: values can never be empty
 		orGroups := make([]string, 0, len(quotedColumns))
 		for colIdx := range quotedColumns {
 			andConds := make([]string, 0, colIdx+1)
@@ -302,9 +299,6 @@ func buildLexicographicChunkCondition(quotedColumns []string, chunk types.Chunk,
 			}
 		}
 
-		if len(orGroups) == 0 {
-			return ""
-		}
 		return "(" + strings.Join(orGroups, " OR ") + ")"
 	}
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR improves chunk-scan query generation by replacing tuple-based range predicates with explicit lexicographic predicates, and consolidates the logic into a shared builder.

**Why:**
**Performance**: tuple comparisons can lead to suboptimal query plans in some MySQL workloads, explicit lexicographic predicates are often easier for the optimizer to execute efficiently for chunk scans.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

<img width="1032" height="856" alt="trips2_count" src="https://github.com/user-attachments/assets/f19f2917-d3b6-40a6-9018-d9817a3d9b8d" />



**stats.json**
```json
{"Estimated Remaining Time":"Not Determined","Memory":"34 mb","Seconds Elapsed":"5700.00","Speed":"318652.17 rps","Synced Records":1816317587,"Writer Threads":0}
```

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):