### PR TITLE
fix: fixed signedness bitmap

### DIFF
--- a/pkg/binlog/filter.go
+++ b/pkg/binlog/filter.go
@@ -59,10 +59,24 @@ func (f ChangeFilter) FilterRowsEvent(ctx context.Context, e *replication.RowsEv
 		return nil
 	}
 
-	unsignedMap := e.Table.UnsignedMap()
+	bitmapIdx := 0
+	bitMask := byte(0x80)
+	// Iterate through column types and determine if the column is unsigned using SignednessBitmap,
+	// which stores one bit per "signedness" column (integer, YEAR, DECIMAL).
 	columnTypes := make([]string, len(e.Table.ColumnType))
 	for i, ct := range e.Table.ColumnType {
-		columnTypes[i] = mysqlTypeName(ct, unsignedMap != nil && unsignedMap[i])
+		unsigned := false
+		if hasSignednessInBinlog(ct) && len(e.Table.SignednessBitmap) > 0 {
+			if bitmapIdx < len(e.Table.SignednessBitmap) {
+				unsigned = (e.Table.SignednessBitmap[bitmapIdx] & bitMask) != 0
+				bitMask >>= 1
+				if bitMask == 0 {
+					bitMask = 0x80
+					bitmapIdx++
+				}
+			}
+		}
+		columnTypes[i] = mysqlTypeName(ct, unsigned)
 	}
 
 	var rowsToProcess [][]interface{}
@@ -213,5 +227,22 @@ func mysqlTypeName(t byte, unsigned bool) string {
 		return "GEOMETRY"
 	default:
 		return fmt.Sprintf("UNKNOWN_TYPE: %d", t)
+	}
+}
+
+// hasSignednessInBinlog returns true for column types that have a signedness bit in the TABLE_MAP_EVENT
+func hasSignednessInBinlog(t byte) bool {
+	switch t {
+	case mysql.MYSQL_TYPE_TINY,
+		mysql.MYSQL_TYPE_SHORT,
+		mysql.MYSQL_TYPE_INT24,
+		mysql.MYSQL_TYPE_LONG,
+		mysql.MYSQL_TYPE_LONGLONG,
+		mysql.MYSQL_TYPE_YEAR,
+		mysql.MYSQL_TYPE_DECIMAL,
+		mysql.MYSQL_TYPE_NEWDECIMAL:
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
# Description

This PR fixes an issue in the handling of the signedness bitmap for MySQL numeric columns.

Previously, the implementation relied on the UnsignedMap function from the MySQL driver to determine whether numeric columns were signed or unsigned. However, the driver's internal isNumeric logic had a mismatch with MySQL server behavior.

Specifically, the driver’s isNumeric function did not include the YEAR column type as a numeric type, while the MySQL server does include YEAR when generating the signedness bitmap in the binlog TABLE_MAP_EVENT.

Because of this mismatch:

MySQL writes a signedness bit for the YEAR column.

The driver skips YEAR when iterating numeric columns.

This causes a bit offset in the signedness bitmap parsing.

As a result, all numeric columns appearing after a YEAR column may be interpreted with incorrect signedness, which can lead to incorrect values being decoded during CDC processing.

This issue was introduced when switching to the UnsignedMap function from the MySQL driver in the following PR:

https://github.com/datazip-inc/olake/pull/846

This PR resolves the issue by aligning the numeric type handling with MySQL server behavior and ensuring that YEAR is treated consistently when parsing the signedness bitmap.

Relevant MySQL source references for signedness metadata:

https://github.com/mysql/mysql-server/blob/trunk/sql/field_common_properties.h#L11238

https://github.com/mysql/mysql-server/blob/trunk/sql/field_common_properties.h#L204

These references show how MySQL determines whether a column type contains signedness information when generating binlog metadata.

Fixes #842

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The fix was validated using CDC pipelines with both Iceberg and Parquet destinations.

A table containing a YEAR column followed by numeric columns was created. CDC replication was executed and the decoded values were verified to ensure that unsigned numeric columns appearing after the YEAR column are interpreted correctly.

Test procedure:

Create a table with a YEAR column and numeric columns following it.

Insert values into unsigned numeric columns.

Run CDC replication.

Verify decoded values in the destination.

- [x] Scenario A — CDC replication to Iceberg destination
- [x] Scenario B — CDC replication to Parquet destination

# Screenshots or Recordings
Output in iceberg:-
<img width="1126" height="408" alt="image" src="https://github.com/user-attachments/assets/8fa54358-51ca-4ff8-91c3-332b9f1c271b" />

Output in parquet :-
<img width="1508" height="579" alt="image" src="https://github.com/user-attachments/assets/599c675f-2b8b-452f-a472-23f1f9880b73" />


## Documentation
- [x] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):
https://github.com/datazip-inc/olake/pull/846