### PR TITLE
feat: add OLake version information to log output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -224,7 +224,7 @@ function build_and_run() {
     cd $path || fail "Failed to navigate to path: $path"
     
     go mod tidy
-    go build -ldflags="-w -s -X constants/constants.version=${GIT_VERSION} -X constants/constants.commitsha=${GIT_COMMITSHA} -X constants/constants.releasechannel=${RELEASE_CHANNEL}" -o olake main.go || fail "build failed"
+    go build -ldflags="-w -s -X github.com/datazip-inc/olake/constants.version=${GIT_VERSION} -X github.com/datazip-inc/olake/constants.commitSHA=${GIT_COMMITSHA} -X github.com/datazip-inc/olake/constants.releaseChannel=${RELEASE_CHANNEL}" -o olake main.go || fail "build failed"
     echo "============================== Executing connector: $connector with args [$joined_arguments] =============================="
     ./olake $joined_arguments
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,8 +2,40 @@ package constants
 
 import (
 	"fmt"
+	"os"
 	"time"
 )
+
+// Build-time version information, injected via ldflags.
+// Defaults are used when running locally without build flags.
+var (
+	version        = "dev"
+	commitSHA      = "unknown"
+	releaseChannel = "dev"
+)
+
+// GetVersion returns the OLake build version. It first checks the build-time
+// injected variable, then falls back to the DRIVER_VERSION environment variable
+// (set in Docker images), and finally returns "dev" if neither is available.
+func GetVersion() string {
+	if version != "" && version != "dev" {
+		return version
+	}
+	if v := os.Getenv("DRIVER_VERSION"); v != "" {
+		return v
+	}
+	return "dev"
+}
+
+// GetCommitSHA returns the git commit SHA used for the build.
+func GetCommitSHA() string {
+	return commitSHA
+}
+
+// GetReleaseChannel returns the release channel (e.g., stable, beta, dev).
+func GetReleaseChannel() string {
+	return releaseChannel
+}
 
 const (
 	DefaultRetryCount      = 3

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -66,6 +66,7 @@ var RootCmd = &cobra.Command{
 
 		// logger uses CONFIG_FOLDER
 		logger.Init()
+		logger.Infof("OLake version: %s (commit: %s, channel: %s)", constants.GetVersion(), constants.GetCommitSHA(), constants.GetReleaseChannel())
 		telemetry.Init()
 
 		if len(args) == 0 {

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -296,11 +296,8 @@ func countPartitionedStreams(catalog *types.Catalog) int {
 	return count
 }
 
-// getOlakeCLIVersion() extracts the olake version from the ENV embedded in the olake image
+// getOlakeCLIVersion returns the OLake CLI version using the centralized
+// version resolution from the constants package.
 func getOlakeCLIVersion() string {
-	version := os.Getenv("DRIVER_VERSION")
-	if version == "" {
-		return "Not Available"
-	}
-	return version
+	return constants.GetVersion()
 }


### PR DESCRIPTION
# Description

Add build-time version information (version, commit SHA, release channel) to the OLake log output. In Kubernetes environments with multiple OLake jobs running concurrently, it can be difficult to determine which OLake version was used for a particular job. This change logs the version as the first informational message after logger initialization, making it easy to identify the OLake version from log files.

Changes:
- Add `version`, `commitSHA`, and `releaseChannel` variables to the `constants` package, populated via ldflags during build
- Add `GetVersion()`, `GetCommitSHA()`, and `GetReleaseChannel()` getter functions for accessing version info
- Log version on startup in `protocol/root.go` after logger initialization
- Fix ldflags paths in `build.sh` to use the full Go import path (`github.com/datazip-inc/olake/constants`)
- Update telemetry to use the centralized `constants.GetVersion()` function, removing duplicated env var lookup

The version resolution follows a priority order:
1. Build-time injected ldflags variable
2. `DRIVER_VERSION` environment variable (set in Docker images)
3. Default `"dev"` for local development

Fixes #861

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Verified all modified packages compile successfully with `go vet`
- [x] Verified existing tests pass (`go test ./types/...`, `go test ./constants/...`)
- [x] Verified version defaults to "dev" when no ldflags or env vars are set
- [x] Verified `DRIVER_VERSION` env var fallback works when ldflags are not injected

# Screenshots or Recordings

N/A - log output change

## Documentation

- [x] N/A (new feature adds informational log line, no user-facing API changes)

## Related PR's (If Any):