### PR TITLE
feat: skip ProduceSchema during sync to improve performance

### DIFF
--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -122,6 +122,13 @@ func (a *AbstractDriver) Discover(ctx context.Context, maxDiscoverThreads int) (
 	return finalStreams, nil
 }
 
+// GetSourceStreamNames returns the list of stream names available in the source
+// without producing schemas. This is used during sync to verify stream existence
+// without the overhead of full schema discovery.
+func (a *AbstractDriver) GetSourceStreamNames(ctx context.Context) ([]string, error) {
+	return a.driver.GetStreamNames(ctx)
+}
+
 func (a *AbstractDriver) Setup(ctx context.Context) error {
 	return a.driver.Setup(ctx)
 }

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -175,7 +175,6 @@ func (m *Mongo) GetStreamNames(ctx context.Context) ([]string, error) {
 	return streamNames, collections.Err()
 }
 
-// TODO: omit usage of ProduceSchema when sync command is used
 func (m *Mongo) ProduceSchema(ctx context.Context, streamName string) (*types.Stream, error) {
 	produceCollectionSchema := func(ctx context.Context, db *mongo.Database, streamName string) (*types.Stream, error) {
 		logger.Infof("producing type schema for stream [%s]", streamName)

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -87,14 +87,16 @@ var syncCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		// Get Source Streams, sending 0 max discover threads to discover
-		streams, err := connector.Discover(cmd.Context(), 0)
+		// Get source stream names without producing schemas to avoid expensive
+		// schema inference (e.g., MongoDB samples 10k+ documents per collection).
+		// The catalog already contains the full schema from a prior discover run.
+		sourceStreamNames, err := connector.GetSourceStreamNames(cmd.Context())
 		if err != nil {
 			return err
 		}
 
 		// get all types of selected streams
-		selectedStreamsMetadata, err := classifyStreams(catalog, streams, state)
+		selectedStreamsMetadata, err := classifyStreams(catalog, sourceStreamNames, state)
 		if err != nil {
 			return fmt.Errorf("failed to get selected streams for clearing: %s", err)
 		}
@@ -129,7 +131,7 @@ var syncCmd = &cobra.Command{
 		// Setup State for Connector
 		connector.SetupState(state)
 		// Sync Telemetry tracking
-		telemetry.TrackSyncStarted(syncID, streams, selectedStreamsMetadata.SelectedStreams, selectedStreamsMetadata.FullLoadStreams, selectedStreamsMetadata.CDCStreams, connector.Type(), destinationConfig, catalog)
+		telemetry.TrackSyncStarted(syncID, len(sourceStreamNames), selectedStreamsMetadata.SelectedStreams, selectedStreamsMetadata.FullLoadStreams, selectedStreamsMetadata.CDCStreams, connector.Type(), destinationConfig, catalog)
 		defer func() {
 			telemetry.TrackSyncCompleted(syncID, err == nil, pool.GetStats().ReadCount.Load())
 			logger.Infof("Sync completed, wait 5 seconds cleanup in progress...")
@@ -150,7 +152,7 @@ var syncCmd = &cobra.Command{
 	},
 }
 
-func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *types.State) (*StreamClassification, error) {
+func classifyStreams(catalog *types.Catalog, sourceStreamNames []string, state *types.State) (*StreamClassification, error) {
 	// stream-specific classifications
 	classifications := &StreamClassification{
 		SelectedStreams:    []string{},
@@ -173,6 +175,15 @@ func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *typ
 		stateStreamMap[fmt.Sprintf("%s.%s", stream.Namespace, stream.Stream)] = stream
 	}
 
+	// Build a set of source stream names for fast existence checks.
+	// Stream names from GetStreamNames may be in different formats per driver
+	// (e.g., "schema.table" for relational DBs, "collectionName" for MongoDB,
+	// "topicName" for Kafka), so we check both elem.ID() and elem.Name().
+	var sourceStreamSet *types.Set[string]
+	if sourceStreamNames != nil {
+		sourceStreamSet = types.NewSet(sourceStreamNames...)
+	}
+
 	_, _ = utils.ArrayContains(catalog.Streams, func(elem *types.ConfiguredStream) bool {
 		sMetadata, selected := selectedStreamsMap[elem.ID()]
 		// Check if the stream is in the selectedStreamMap
@@ -181,18 +192,15 @@ func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *typ
 			return false
 		}
 
-		if streams != nil {
-			source, found := types.StreamsToMap(streams...)[elem.ID()]
-			if !found {
+		if sourceStreamSet != nil {
+			// Verify the configured stream still exists in the source.
+			// Check both full ID (namespace.name) and bare name to handle
+			// all driver naming conventions.
+			if !sourceStreamSet.Exists(elem.ID()) && !sourceStreamSet.Exists(elem.Name()) {
 				logger.Warnf("Skipping; Configured Stream %s not found in source", elem.ID())
 				return false
 			}
 			elem.StreamMetadata = sMetadata
-			err := elem.Validate(source)
-			if err != nil {
-				logger.Warnf("Skipping; Configured Stream %s found invalid due to reason: %s", elem.ID(), err)
-				return false
-			}
 			// TODO: move filter validation to validate method in types package
 			filter, isLegacy, err := elem.GetFilter()
 			if err != nil {
@@ -245,8 +253,8 @@ func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *typ
 		return false
 	})
 	// Clear previous state streams for non-selected streams.
-	// Must not be called during clear destination to retain the global and stream state. (clear dest. -> when streams == nil)
-	if streams != nil {
+	// Must not be called during clear destination to retain the global and stream state. (clear dest. -> when sourceStreamNames == nil)
+	if sourceStreamNames != nil {
 		state.Streams = classifications.NewStreamsState
 	}
 	if len(classifications.SelectedStreams) == 0 {

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -105,7 +105,7 @@ func TrackDiscover(streamCount int, sourceType string) {
 	}()
 }
 
-func TrackSyncStarted(syncID string, streams []*types.Stream, selectedStreams []string, fullLoadStreams, cdcStreams []types.StreamInterface, sourceType string, destinationConfig *types.WriterConfig, catalog *types.Catalog) {
+func TrackSyncStarted(syncID string, streamCount int, selectedStreams []string, fullLoadStreams, cdcStreams []types.StreamInterface, sourceType string, destinationConfig *types.WriterConfig, catalog *types.Catalog) {
 	go func() {
 		if telemetry == nil {
 			return
@@ -117,7 +117,7 @@ func TrackSyncStarted(syncID string, streams []*types.Stream, selectedStreams []
 		props := map[string]interface{}{
 			"sync_start":          time.Now(),
 			"sync_id":             syncID,
-			"stream_count":        len(streams),
+			"stream_count":        streamCount,
 			"selected_count":      len(selectedStreams),
 			"full_load_streams":   len(fullLoadStreams),
 			"cdc_streams":         len(cdcStreams),


### PR DESCRIPTION
# Description

During sync, the `Discover` method was called to get source streams, which internally runs `ProduceSchema` for every stream. This is expensive and redundant because the catalog already contains the full schema from a prior discover run.

For MongoDB, `ProduceSchema` samples up to 20,000 documents per collection (10k ascending + 10k descending order) and infers the schema from them. For Kafka, it reads messages from all partitions. For relational databases, it queries column schemas, primary keys, and indexes. All of this work is unnecessary during sync since the catalog already has this information.

This change replaces the full `Discover` call in sync with a lightweight `GetSourceStreamNames` call that only fetches stream names from the source. Stream existence is verified by checking catalog stream IDs against source names. The schema validation (sync mode, cursor fields, primary keys) is no longer re-run during sync since the catalog already contains validated information from the prior discover.

Changes:
- Add `GetSourceStreamNames` method to `AbstractDriver` that calls only `GetStreamNames` without `ProduceSchema`
- Update `classifyStreams` to accept `sourceStreamNames []string` instead of `[]*types.Stream`
- Replace `Discover(ctx, 0)` in sync with `GetSourceStreamNames(ctx)`
- Build a `Set[string]` from source names for O(1) existence checks, checking both `elem.ID()` and `elem.Name()` to handle all driver naming conventions
- Update `TrackSyncStarted` telemetry to accept `streamCount int` instead of `[]*types.Stream`
- Remove resolved TODO comment from MongoDB driver

Fixes #838

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Verified all modified packages compile successfully with `go vet` (protocol, abstract, telemetry, mongodb)
- [x] Verified existing tests pass (`go test ./types/...`)
- [x] Verified stream existence check logic handles all driver naming conventions:
  - Relational drivers (Postgres, MySQL, Oracle, DB2, MSSQL): `GetStreamNames` returns `schema.table` which matches `elem.ID()`
  - MongoDB: `GetStreamNames` returns `collectionName` which matches `elem.Name()`
  - Kafka: `GetStreamNames` returns `topicName` which matches `elem.Name()`
- [x] Verified `clear-destination` command behavior is preserved (passes `nil` for sourceStreamNames, skipping existence check and state clearing)

# Screenshots or Recordings

N/A - performance optimization with no UI changes

## Documentation

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):