### PR TITLE
fix: mongo out of bound dates for nested objects

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,9 @@ CVE-2018-1320
 CVE-2019-0205
 CVE-2020-13949
 CVE-2025-46762
+# CVE-2026-34040: Moby AuthZ plugin bypass via oversized request bodies.
+# TODO: Upgrade testcontainers-go once this PR is merged and released:
+# https://github.com/testcontainers/testcontainers-go/pull/3617
+# This vulnerability only affects Docker AuthZ plugins (not used by Olake)
+# and is only present in test-time dependencies.
+CVE-2026-34040

--- a/constants/state_version.go
+++ b/constants/state_version.go
@@ -26,11 +26,15 @@ package constants
 //     * Earlier if the session timezone or global was set in offset format, it was not parsed correctly and used to fallback to UTC.
 //     * Now it parses the offset correctly and uses the timezone offset to set the timezone for the connection.
 //
-//   - Version 4: (Current Version) Unsigned int/integer/bigint map to Int64.
+//   - Version 4: Unsigned int/integer/bigint map to Int64.
 //     * Earlier unsigned int/integer/bigint were mapped to Int32 which caused integer overflows.
+//
+//   - Version 5: (Current Version) MongoDB nested DateTime values decoded as UTC time.Time.
+//     * BSON DateTime at any depth is now decoded directly to time.Time (UTC) via a custom client registry, preventing json.Marshal crashes for out-of-range years ([0,9999]).
+//     * Top-level DateTime fields that previously formatted with the local machine timezone (e.g. "+05:30") now always output UTC ("Z").
 
 const (
-	LatestStateVersion = 4
+	LatestStateVersion = 5
 )
 
 // Used as the current version of the state when the program is running

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -26,33 +26,49 @@ import (
 )
 
 // safeDecodeRegistry is a BSON decode registry registered on the MongoDB client.
-// It overrides how the driver decodes BSON DateTime values that land in interface{}
-// slots (i.e. every field value inside a bson.M / map[string]any).
+// It intercepts two problem cases for interface{} slots (every value in bson.M):
 //
-// The default driver behaviour is: BSON DateTime → primitive.DateTime (an int64).
-// primitive.DateTime.MarshalJSON() calls time.Time.MarshalJSON(), which panics for
-// years outside [0, 9999].  By intercepting at decode time we produce time.Time
-// with the year already clamped, so all downstream json.Marshal calls are safe —
-// no recursion, no extra passes over the document, zero change to filterMongoObject.
+//  1. BSON Double (float64) — NaN and ±Inf are not valid JSON; they crash
+//     encoding/json.  These are coerced to nil for all state versions.
+//
+//  2. BSON DateTime — primitive.DateTime.MarshalJSON calls time.Time.MarshalJSON
+//     which panics for years outside [0, 9999].  For state version > 4, DateTime
+//     is decoded as a clamped UTC time.Time so downstream json.Marshal is always
+//     safe.  For state version ≤ 4 the fallback (primitive.DateTime) is used to
+//     preserve the pre-existing local-timezone output format.
 var safeDecodeRegistry = func() *bsoncodec.Registry {
 	tEmpty := reflect.TypeOf((*interface{})(nil)).Elem()
 	reg := bson.NewRegistry()
-	// Capture the stock interface{} decoder before we replace it so the fallback
+	// Capture the stock interface{} decoder before replacing it.
 	fallback, _ := reg.LookupDecoder(tEmpty)
 	reg.RegisterTypeDecoder(
 		tEmpty,
 		bsoncodec.ValueDecoderFunc(func(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
-			if vr.Type() == bson.TypeDateTime {
-				ms, err := vr.ReadDateTime()
+			switch vr.Type() {
+			case bson.TypeDouble:
+				f, err := vr.ReadDouble()
 				if err != nil {
 					return err
 				}
-				t, err := typeutils.ReformatDate(primitive.DateTime(ms).Time().UTC(), true)
-				if err != nil {
-					return err
+				if math.IsNaN(f) || math.IsInf(f, 0) {
+					val.Set(reflect.Zero(val.Type()))
+				} else {
+					val.Set(reflect.ValueOf(f))
 				}
-				val.Set(reflect.ValueOf(t))
 				return nil
+			case bson.TypeDateTime:
+				if constants.LoadedStateVersion > 4 {
+					ms, err := vr.ReadDateTime()
+					if err != nil {
+						return err
+					}
+					t, err := typeutils.ReformatDate(primitive.DateTime(ms).Time().UTC(), true)
+					if err != nil {
+						return err
+					}
+					val.Set(reflect.ValueOf(t))
+					return nil
+				}
 			}
 			return fallback.DecodeValue(dc, vr, val)
 		}),
@@ -122,9 +138,7 @@ func (m *Mongo) Setup(ctx context.Context) error {
 
 	opts.ApplyURI(m.config.URI())
 	opts.SetCompressors([]string{"snappy"}) // using Snappy compression; read here https://en.wikipedia.org/wiki/Snappy_(compression)
-	if constants.LoadedStateVersion > 4 {
-		opts.SetRegistry(safeDecodeRegistry)
-	}
+	opts.SetRegistry(safeDecodeRegistry)
 	if m.sshDialer != nil {
 		opts.SetDialer(m.sshDialer)
 	}
@@ -319,12 +333,6 @@ func filterMongoObject(doc bson.M) {
 			doc[key] = value.String()
 		case primitive.ObjectID:
 			doc[key] = value.Hex()
-		case float64:
-			if math.IsNaN(value) || math.IsInf(value, 0) {
-				doc[key] = nil
-			} else {
-				doc[key] = value
-			}
 		default:
 			doc[key] = value
 		}

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -47,12 +47,9 @@ var safeDecodeRegistry = func() *bsoncodec.Registry {
 				if err != nil {
 					return err
 				}
-				t := primitive.DateTime(ms).Time().UTC()
-				switch {
-				case t.Year() < 1:
-					t = time.Unix(0, 0).UTC()
-				case t.Year() > 9999:
-					t = t.AddDate(-(t.Year() - 9999), 0, 0)
+				t, err := typeutils.ReformatDate(primitive.DateTime(ms).Time().UTC(), true)
+				if err != nil {
+					return err
 				}
 				val.Set(reflect.ValueOf(t))
 				return nil
@@ -125,7 +122,9 @@ func (m *Mongo) Setup(ctx context.Context) error {
 
 	opts.ApplyURI(m.config.URI())
 	opts.SetCompressors([]string{"snappy"}) // using Snappy compression; read here https://en.wikipedia.org/wiki/Snappy_(compression)
-	opts.SetRegistry(safeDecodeRegistry)
+	if constants.LoadedStateVersion > 4 {
+		opts.SetRegistry(safeDecodeRegistry)
+	}
 	if m.sshDialer != nil {
 		opts.SetDialer(m.sshDialer)
 	}

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -322,7 +322,6 @@ func filterMongoObject(doc bson.M) {
 			var err error
 			doc[key], err = typeutils.ReformatDate(t, true)
 			if err != nil {
-				logger.Warnf("failed to reformat date for key %s: %s", key, err)
 				doc[key] = time.Unix(0, 0).UTC()
 			}
 		case primitive.Null:

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -16,11 +17,51 @@ import (
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/crypto/ssh"
 )
+
+// safeDecodeRegistry is a BSON decode registry registered on the MongoDB client.
+// It overrides how the driver decodes BSON DateTime values that land in interface{}
+// slots (i.e. every field value inside a bson.M / map[string]any).
+//
+// The default driver behaviour is: BSON DateTime → primitive.DateTime (an int64).
+// primitive.DateTime.MarshalJSON() calls time.Time.MarshalJSON(), which panics for
+// years outside [0, 9999].  By intercepting at decode time we produce time.Time
+// with the year already clamped, so all downstream json.Marshal calls are safe —
+// no recursion, no extra passes over the document, zero change to filterMongoObject.
+var safeDecodeRegistry = func() *bsoncodec.Registry {
+	tEmpty := reflect.TypeOf((*interface{})(nil)).Elem()
+	reg := bson.NewRegistry()
+	// Capture the stock interface{} decoder before we replace it so the fallback
+	fallback, _ := reg.LookupDecoder(tEmpty)
+	reg.RegisterTypeDecoder(
+		tEmpty,
+		bsoncodec.ValueDecoderFunc(func(dc bsoncodec.DecodeContext, vr bsonrw.ValueReader, val reflect.Value) error {
+			if vr.Type() == bson.TypeDateTime {
+				ms, err := vr.ReadDateTime()
+				if err != nil {
+					return err
+				}
+				t := primitive.DateTime(ms).Time().UTC()
+				switch {
+				case t.Year() < 1:
+					t = time.Unix(0, 0).UTC()
+				case t.Year() > 9999:
+					t = t.AddDate(-(t.Year() - 9999), 0, 0)
+				}
+				val.Set(reflect.ValueOf(t))
+				return nil
+			}
+			return fallback.DecodeValue(dc, vr, val)
+		}),
+	)
+	return reg
+}()
 
 const (
 	cdcCursorField = "_data"
@@ -84,6 +125,7 @@ func (m *Mongo) Setup(ctx context.Context) error {
 
 	opts.ApplyURI(m.config.URI())
 	opts.SetCompressors([]string{"snappy"}) // using Snappy compression; read here https://en.wikipedia.org/wiki/Snappy_(compression)
+	opts.SetRegistry(safeDecodeRegistry)
 	if m.sshDialer != nil {
 		opts.SetDialer(m.sshDialer)
 	}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a MongoDB sync failure when documents contain **nested** BSON `DateTime` values with years outside Go JSON’s supported range \([0, 9999]\).  
Instead of letting nested `primitive.DateTime` reach `encoding/json` (which can crash during marshaling), the MongoDB client is configured to decode BSON `DateTime` into safe, clamped `time.Time` values at decode-time. This prevents writer failures for `normalization=false` while preserving the existing RFC3339 JSON output format for nested structures.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Run the sync and verify it completes and reports the expected record count. and these are in same format as it was before the changes with both normalization true and false.

- [x] tested with deeply nested values as well, for both s3 and iceberg destination
```
db.comprehensive_datatypes_test.insertOne({
  _id: "doc_9_deeply_nested_invalid_dates",
  description: "Isolating out-of-bounds DateTimes buried 2-3 levels deep while keeping all numbers valid",
  
  // ─── ROOT LEVEL (Level 0) ────────────────────────────────────────
  root_string: "Valid numbers, deeply nested invalid dates",
  root_int: NumberInt(500),
  root_double: 987.654,                                      
  root_decimal: NumberDecimal("250.75"),                    
  root_datetime: new Date("2024-01-01T00:00:00Z"), // Normal Date 
  root_timestamp: Timestamp(1715767200, 1),        // Valid Timestamp
  
  // ─── LEVEL 1: NESTED MAP ─────────────────────────────────────────
  nested_map: {
    map_string: "Level 1 is safe",
    map_int: NumberInt(200), 
    map_datetime: new Date("2024-02-01T00:00:00Z"), // Normal Date
    
    // ─── LEVEL 2: MAP INSIDE A MAP ─────────────────────────────────
    level_2_details: {
       inner_double: 42.42, 
       
       // (Level 2): Future date buried in a sub-object
       level_2_datetime_trap: new Date(253402300800000), 

       // ─── LEVEL 3: ARRAY INSIDE A MAP INSIDE A MAP ───────────────
       level_3_history: [
         NumberInt(100),
         {
            event_id: new ObjectId(),
            valid_timestamp: Timestamp(1672531200, 1), 
            
            // (Level 3): Ancient date buried in an array element
            level_3_ancient_trap: new Date(-126009496800000), 
            status: "deep_trap_active"
         }
       ]
    }
  },

  // ─── LEVEL 1: NESTED ARRAY OF MAPS ───────────────────────────────
  nested_array_of_maps: [
    {
      index: NumberInt(0),
      event_time: new Date("2024-03-01T10:00:00Z"), //  Normal Date
      
      // ─── LEVEL 2: MAP INSIDE AN ARRAY ────────────────────────────
      metrics: {
         cpu_usage_double: 33.3, 
         memory_int: NumberInt(1024), 
         last_ping: Timestamp(1717200000, 1),
         
         // ─── LEVEL 3: ARRAY INSIDE A MAP INSIDE AN ARRAY ──────────
         deep_audits: [
           {
             audit_id: "A1",
             //  (Level 3): Future date
             audit_time: new Date(253402310000000) 
           },
           {
             audit_id: "A2",
             // (Level 3): Ancient date
             audit_time: new Date(-62167219200001) 
           }
         ]
      }
    }
  ]
});
```

- [x] tested for nested NaN values 
level 0 NaN and infinity syncs normally nested once fail with
for parquet
```
error occurred while reading records: error occurred while waiting for connections: thread[vbhv.nan_level_one_test_min[doc_2_nested_nan_trap]-max[<nil>]]: failed to close writer: failed to flush data while closing: failed to write records: failed to marshal data: %!s(<nil>)
```

for iceberg 

```
error occurred while reading records: error occurred while waiting for connections: thread[vbhv.nan_level_one_test_min[doc_2_nested_nan_trap]-max[<nil>]]: failed to close writer: failed to flush data while closing: failed to write records: failed to create arrow record: cannot identify value for the col data: failed to marshal map to JSON: json: unsupported value: NaN
```


table used
```
{
    "_id" : "doc_2_nested_nan_trap",
    "scenario" : "Trap: NaN buried in a Level 1 Map",
    "sensor_id" : NumberInt(202),
    "readings" : {
        "temperature_celsius" : NaN,
        "pressure_hpa" : NumberInt(1012)
    },
    "status" : "fault_detected"
}
```

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):