### PR TITLE
fix: govulncheck job in Go Security workflow and upgrade go version to v1.25.9

### DIFF
--- a/.cursor/rules/olake.mdc
+++ b/.cursor/rules/olake.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 
 OLake is an open-source, high-performance **EL (Extract-Load)** tool that replicates data from databases, Kafka, and S3 into **Apache Iceberg** tables or **plain Parquet** files.
 
-- **Languages:** Go 1.25.8 (primary) + Java 17 (Iceberg writer)
+- **Languages:** Go 1.25.9 (primary) + Java 17 (Iceberg writer)
 - **Go workspace:** `go.work` links the root module with 8 driver sub-modules
 - **CLI:** Cobra-based commands: `spec`, `check`, `discover`, `sync`, `clear`
 - **Sources:** Postgres, MongoDB, MySQL, Oracle, MSSQL, DB2, Kafka, S3

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -46,10 +46,13 @@ jobs:
             exit "$VULN_EXIT"
           fi
 
-          IGNORED=$(grep -oE 'GO-[0-9]+-[0-9]+' ../.govulnignore 2>/dev/null | sort -u | paste -sd'|')
+          # Repo root is the job working directory; do not use ../.govulnignore
+          IGNORED=$(grep -vE '^\s*(#|$)' .govulnignore 2>/dev/null | grep -oE 'GO-[0-9]+-[0-9]+' | sort -u | paste -s -d '|' -)
           FOUND=$(grep -oE 'GO-[0-9]+-[0-9]+' /tmp/govuln.txt | sort -u)
           UNKNOWN="$FOUND"
-          [ -n "$IGNORED" ] && UNKNOWN=$(echo "$UNKNOWN" | grep -vxE "$IGNORED" || true)
+          if [ -n "$IGNORED" ]; then
+            UNKNOWN=$(echo "$UNKNOWN" | grep -vE "$IGNORED" || true)
+          fi
 
           if [ -n "$UNKNOWN" ]; then
             echo "Unsuppressed vulnerabilities found: $UNKNOWN"

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "fix/govulncheck-ci"
     paths:
       - '**/*.go'
       - '**/*.java'

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -9,6 +9,7 @@ on:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
+      - '**/go.yaml'
   pull_request:
     branches:
       - "*"
@@ -16,6 +17,7 @@ on:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
+      - '**/go.yaml'
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -15,7 +15,6 @@ on:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
-
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -35,24 +35,25 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run vulnerability checks
         run: |
-          # govulncheck has no native ignore file; we read .govulnignore manually.
-          # Lines prefixed with '#' are comments; blank lines are skipped.
-          EXEMPT=$(grep -v '^\s*#' .govulnignore | grep -v '^\s*$' | paste -sd '|')
-          set +e
-          govulncheck -json ./... > /tmp/govuln.json 2>&1
-          GOVULN_EXIT=$?
-          set -e
-          if [ "$GOVULN_EXIT" -eq 0 ]; then
-            echo "No vulnerabilities found."
-            exit 0
+          govulncheck ./... >/tmp/govuln.txt 2>&1 || VULN_EXIT=$?
+          VULN_EXIT=${VULN_EXIT:-0}
+          cat /tmp/govuln.txt
+
+          if [ "$VULN_EXIT" -ne 3 ]; then
+            exit "$VULN_EXIT"
           fi
-          REMAINING=$(grep -o '"GO-[0-9-]*"' /tmp/govuln.json | tr -d '"' | sort -u | grep -vE "$EXEMPT" || true)
-          if [ -n "$REMAINING" ]; then
-            echo "Unexempted vulnerabilities found: $REMAINING"
-            govulncheck ./...
+
+          IGNORED=$(grep -oE 'GO-[0-9]+-[0-9]+' ../.govulnignore 2>/dev/null | sort -u | paste -sd'|')
+          FOUND=$(grep -oE 'GO-[0-9]+-[0-9]+' /tmp/govuln.txt | sort -u)
+          UNKNOWN="$FOUND"
+          [ -n "$IGNORED" ] && UNKNOWN=$(echo "$UNKNOWN" | grep -vxE "$IGNORED" || true)
+
+          if [ -n "$UNKNOWN" ]; then
+            echo "Unsuppressed vulnerabilities found: $UNKNOWN"
             exit 1
           fi
-          echo "All findings are exempted via .govulnignore: $EXEMPT"
+
+          echo -e "\033[0;32m✅ govulncheck: all findings suppressed via .govulnignore\033[0m"
 
   gosec:
     name: GoSec Security Scanner

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - "master"
-      - "fix/govulncheck-ci"
     paths:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
-      - '**/go.yaml'
   pull_request:
     branches:
       - "*"
@@ -17,7 +15,7 @@ on:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
-      - '**/go.yaml'
+
   workflow_dispatch:
     inputs:
       logLevel:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.25.8-bookworm AS builder
+FROM golang:1.25.9-bookworm AS builder
 
 WORKDIR /home/app
 COPY . .

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -33,7 +33,6 @@ const (
 	EffectiveParquetSize        = int64(256) * 1024 * 1024 * int64(8)
 	DB2StateTimestampFormat     = "2006-01-02 15:04:05.000000"
 	DefaultStateTimestampFormat = "2006-01-02T15:04:05.000000000Z"
-	DummyColumn                 = "dummy"
 )
 
 type DriverType string

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -33,6 +33,7 @@ const (
 	EffectiveParquetSize        = int64(256) * 1024 * 1024 * int64(8)
 	DB2StateTimestampFormat     = "2006-01-02 15:04:05.000000"
 	DefaultStateTimestampFormat = "2006-01-02T15:04:05.000000000Z"
+	DummyColumn                 = "dummy"
 )
 
 type DriverType string

--- a/drivers/db2/go.mod
+++ b/drivers/db2/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/db2
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0
@@ -59,8 +59,10 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -116,17 +118,18 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/drivers/kafka/go.mod
+++ b/drivers/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/kafka
 
-go 1.25.8
+go 1.25.9
 
 replace github.com/datazip-inc/olake => ../../
 
@@ -62,6 +62,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -124,16 +125,17 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/drivers/mongodb/go.mod
+++ b/drivers/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mongodb
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0
@@ -57,6 +57,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -129,11 +130,12 @@ require (
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
@@ -163,7 +165,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 )

--- a/drivers/mssql/go.mod
+++ b/drivers/mssql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mssql
 
-go 1.25.8
+go 1.25.9
 
 replace (
 	github.com/datazip-inc/olake => ../../
@@ -70,6 +70,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -139,17 +140,18 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/drivers/mysql/go.mod
+++ b/drivers/mysql/go.mod
@@ -1,12 +1,12 @@
 module github.com/datazip-inc/olake/drivers/mysql
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/datazip-inc/olake v0.0.0-20250312070222-ed705d25bc0c
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect; Added explicit requirement
-	github.com/jackc/pgx/v4 v4.18.2 // Updated from v4.15.0
+	github.com/jackc/pgx/v4 v4.18.3 // Updated from v4.15.0
 )
 
 require (
@@ -58,6 +58,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.3 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -109,10 +110,11 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
@@ -179,7 +181,7 @@ require (
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 )
 

--- a/drivers/oracle/go.mod
+++ b/drivers/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/oracle
 
-go 1.25.8
+go 1.25.9
 
 replace (
 	github.com/datazip-inc/olake => ../../
@@ -70,6 +70,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -145,16 +146,17 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/postgres
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0
@@ -65,6 +65,7 @@ require (
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -137,11 +138,12 @@ require (
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
@@ -159,11 +161,11 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/pgx/v4 v4.18.2
+	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 )
 

--- a/drivers/s3/go.mod
+++ b/drivers/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/s3
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.2
@@ -126,11 +126,11 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/spark-connect-go/v35 v35.0.0-20250317154112-ffd832059443
@@ -12,7 +12,7 @@ require (
 	github.com/go-playground/validator/v10 v10.25.0
 	github.com/goccy/go-json v0.10.5
 	github.com/jackc/pglogrepl v0.0.0-20250322012620-f1e2b1498ed6
-	github.com/jackc/pgtype v1.10.0
+	github.com/jackc/pgtype v1.14.0
 	github.com/jackc/pgx/v5 v5.7.3
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
@@ -37,6 +37,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
+	github.com/jackc/pgx/v4 v4.18.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
@@ -46,6 +47,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/rs/xid v1.6.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 )
@@ -151,18 +153,18 @@ require (
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
+	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.46.0
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect; from staging

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.8
+go 1.25.9
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 use (
 	.

--- a/utils/testutils/test_utils.go
+++ b/utils/testutils/test_utils.go
@@ -784,7 +784,7 @@ func (cfg *IntegrationTest) TestIntegration(t *testing.T) {
 
 	t.Run("Discover", func(t *testing.T) {
 		req := testcontainers.ContainerRequest{
-			Image:         "golang:1.25.8-bookworm",
+			Image:         "golang:1.25.9-bookworm",
 			ImagePlatform: "linux/amd64",
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.Binds = []string{
@@ -858,7 +858,7 @@ func (cfg *IntegrationTest) TestIntegration(t *testing.T) {
 
 	t.Run("Sync", func(t *testing.T) {
 		req := testcontainers.ContainerRequest{
-			Image:         "golang:1.25.8-bookworm",
+			Image:         "golang:1.25.9-bookworm",
 			ImagePlatform: "linux/amd64",
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.Binds = []string{
@@ -1386,7 +1386,7 @@ func (cfg *PerformanceTest) TestPerformance(t *testing.T) {
 
 	t.Run("performance", func(t *testing.T) {
 		req := testcontainers.ContainerRequest{
-			Image: "golang:1.25.8-bookworm",
+			Image: "golang:1.25.9-bookworm",
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.Binds = []string{
 					fmt.Sprintf("%s:/test-olake:rw", cfg.TestConfig.HostRootPath),


### PR DESCRIPTION
# Description
make govulncheck respect exemptions and fail on unexempted vulns and upgrade go version to v1.25.9

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):