### PR TITLE
feat(mongodb): Added support for authentication mechanisms for mongoDB source

### DIFF
--- a/drivers/mongodb/internal/auth.go
+++ b/drivers/mongodb/internal/auth.go
@@ -1,0 +1,39 @@
+package driver
+
+import "fmt"
+
+type AuthMechanism string
+
+const (
+	AuthMechanismDefault     AuthMechanism = "" // SCRAM-SHA-1 (MongoDB default)
+	AuthMechanismSCRAMSHA1   AuthMechanism = "SCRAM-SHA-1"
+	AuthMechanismSCRAMSHA256 AuthMechanism = "SCRAM-SHA-256"
+	AuthMechanismX509        AuthMechanism = "MONGODB-X509"
+	AuthMechanismPLAINTEXT   AuthMechanism = "PLAIN"      // LDAP
+	AuthMechanismGSSAPI      AuthMechanism = "GSSAPI"     // Kerberos
+	AuthMechanismMONGOAWS    AuthMechanism = "MONGO-AWS"  // AWS IAM
+	AuthMechanismMONGODBCR   AuthMechanism = "MONGODB-CR" // Legacy (deprecated)
+)
+
+type TLSConfig struct {
+	Mode       string `json:"mode"`
+	ServerCA   string `json:"server_ca"`
+	ClientCert string `json:"client_cert"`
+	ClientKey  string `json:"client_key"`
+}
+
+func (tc *TLSConfig) Validate() error {
+	if tc.Mode == "" || tc.Mode == "disable" {
+		return nil
+	}
+	if tc.ServerCA == "" {
+		return fmt.Errorf("tls.server_ca is required when TLS is enabled")
+	}
+	if tc.ClientCert != "" && tc.ClientKey == "" {
+		return fmt.Errorf("tls.client_key is required when tls.client_cert is provided")
+	}
+	if tc.ClientCert == "" && tc.ClientKey != "" {
+		return fmt.Errorf("tls.client_cert is required when tls.client_key is provided")
+	}
+	return nil
+}

--- a/drivers/mongodb/internal/auth.go
+++ b/drivers/mongodb/internal/auth.go
@@ -26,8 +26,8 @@ func (tc *TLSConfig) Validate() error {
 	if tc.Mode == "" || tc.Mode == "disable" {
 		return nil
 	}
-	if tc.ServerCA == "" {
-		return fmt.Errorf("tls.server_ca is required when TLS is enabled")
+	if (tc.Mode == "verify-ca" || tc.Mode == "verify-full") && tc.ServerCA == "" {
+		return fmt.Errorf("tls.server_ca is required for %s mode", tc.Mode)
 	}
 	if tc.ClientCert != "" && tc.ClientKey == "" {
 		return fmt.Errorf("tls.client_key is required when tls.client_cert is provided")

--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -25,6 +26,8 @@ type Config struct {
 	UseIAM           bool              `json:"use_iam"`
 	SSHConfig        *utils.SSHConfig  `json:"ssh_config"`
 	AdditionalParams map[string]string `json:"additional_params"`
+	AuthMechanism    AuthMechanism     `json:"auth_mechanism"`
+	TLSConfig        TLSConfig         `json:"tls_config"`
 }
 
 func (c *Config) URI() string {
@@ -42,11 +45,16 @@ func (c *Config) URI() string {
 	// Build query parameters
 	query := url.Values{}
 
-	if c.UseIAM {
+	if c.AuthMechanism != "" {
+		query.Set("authMechanism", string(c.AuthMechanism))
+	}
+
+	switch c.AuthMechanism {
+	case AuthMechanismX509, AuthMechanismPLAINTEXT, AuthMechanismGSSAPI, AuthMechanismMONGOAWS:
 		query.Set("authSource", "$external")
-		query.Set("authMechanism", "MONGODB-AWS")
-	} else {
+	default:
 		query.Set("authSource", c.AuthDB)
+
 	}
 
 	if c.ReplicaSet != "" {
@@ -71,7 +79,12 @@ func (c *Config) URI() string {
 		RawQuery: query.Encode(),
 	}
 
-	if !c.UseIAM {
+	skipUser := c.AuthMechanism == AuthMechanismX509 ||
+		c.AuthMechanism == AuthMechanismPLAINTEXT ||
+		c.AuthMechanism == AuthMechanismGSSAPI ||
+		c.AuthMechanism == AuthMechanismMONGOAWS
+
+	if !skipUser {
 		u.User = utils.Ternary(c.Password != "", url.UserPassword(c.Username, c.Password), url.User(c.Username)).(*url.Userinfo)
 	}
 
@@ -80,5 +93,34 @@ func (c *Config) URI() string {
 
 // TODO: Add go struct validation in Config
 func (c *Config) Validate() error {
-	return utils.Validate(c)
+	if err := utils.Validate(c); err != nil {
+		return err
+	}
+
+	// Validations for specific Auth Mechanisms
+	switch c.AuthMechanism {
+	case AuthMechanismMONGODBCR:
+		logger.Warn("MONGODB-CR is deprecated, consider using SCRAM-SHA-256")
+	case AuthMechanismX509:
+		if c.Username == "" {
+			return fmt.Errorf("username is required for X.509 authentication")
+		}
+		if c.Password != "" {
+			logger.Warn("password is ignored for X.509 authentication")
+		}
+	case AuthMechanismSCRAMSHA1, AuthMechanismSCRAMSHA256, "":
+		if c.Username == "" {
+			return fmt.Errorf("username is required for %s authentication", c.AuthMechanism)
+		}
+		if c.Password == "" {
+			return fmt.Errorf("password is required for %s authentication", c.AuthMechanism)
+		}
+	}
+
+	// TLS validation
+	if err := c.TLSConfig.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/drivers/mongodb/internal/config_test.go
+++ b/drivers/mongodb/internal/config_test.go
@@ -1,0 +1,550 @@
+package driver
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+func TestMongo_BuildTLSConfig(t *testing.T) {
+	certs := generateTestCerts()
+
+	tests := []struct {
+		name       string
+		config     *Config
+		expectErr  bool
+		assertions func(t *testing.T, tlsCfg *tls.Config)
+	}{
+		{
+			name: "TLS disabled returns minimal config",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode: "disable",
+				},
+			},
+			expectErr: false,
+			assertions: func(t *testing.T, tlsCfg *tls.Config) {
+				if tlsCfg.MinVersion != tls.VersionTLS12 {
+					t.Fatalf("expected MinVersion to be TLS 1.2")
+				}
+			},
+		},
+		{
+			name: "TLS require returns config without CA verification",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode: "require",
+				},
+			},
+			expectErr: false,
+			assertions: func(t *testing.T, tlsCfg *tls.Config) {
+				if tlsCfg.MinVersion != tls.VersionTLS12 {
+					t.Fatalf("expected MinVersion to be TLS 1.2")
+				}
+				if tlsCfg.RootCAs != nil {
+					t.Fatalf("expected RootCAs to be nil for require mode")
+				}
+			},
+		},
+		{
+			name: "TLS verify-ca with CA certificate",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode:     "verify-ca",
+					ServerCA: certs.CACert,
+				},
+			},
+			expectErr: false,
+			assertions: func(t *testing.T, tlsCfg *tls.Config) {
+				if tlsCfg.RootCAs == nil {
+					t.Fatalf("expected RootCAs to be set for verify-ca mode")
+				}
+				if tlsCfg.MinVersion != tls.VersionTLS12 {
+					t.Fatalf("expected MinVersion to be TLS 1.2")
+				}
+			},
+		},
+		{
+			name: "TLS verify-full with CA and client certificates",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode:       "verify-full",
+					ServerCA:   certs.CACert,
+					ClientCert: certs.ClientCert,
+					ClientKey:  certs.ClientKey,
+				},
+			},
+			expectErr: false,
+			assertions: func(t *testing.T, tlsCfg *tls.Config) {
+				if tlsCfg.RootCAs == nil {
+					t.Fatalf("expected RootCAs to be set for verify-full mode")
+				}
+				if len(tlsCfg.Certificates) == 0 {
+					t.Fatalf("expected client certificates to be loaded")
+				}
+				if tlsCfg.MinVersion != tls.VersionTLS12 {
+					t.Fatalf("expected MinVersion to be TLS 1.2")
+				}
+			},
+		},
+		{
+			name: "TLS with only client cert and key",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode:       "require",
+					ClientCert: certs.ClientCert,
+					ClientKey:  certs.ClientKey,
+				},
+			},
+			expectErr: false,
+			assertions: func(t *testing.T, tlsCfg *tls.Config) {
+				if len(tlsCfg.Certificates) == 0 {
+					t.Fatalf("expected client certificates to be loaded")
+				}
+			},
+		},
+		{
+			name: "TLS with invalid CA PEM returns error",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode:     "verify-ca",
+					ServerCA: "not-a-valid-pem",
+				},
+			},
+			expectErr: true,
+			assertions: func(t *testing.T, _ *tls.Config) {
+			},
+		},
+		{
+			name: "TLS with invalid client certificate returns error",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode:       "require",
+					ClientCert: "not-a-valid-cert",
+					ClientKey:  certs.ClientKey,
+				},
+			},
+			expectErr: true,
+			assertions: func(t *testing.T, _ *tls.Config) {
+			},
+		},
+		{
+			name: "TLS with invalid client key returns error",
+			config: &Config{
+				TLSConfig: TLSConfig{
+					Mode:       "require",
+					ClientCert: certs.ClientCert,
+					ClientKey:  "not-a-valid-key",
+				},
+			},
+			expectErr: true,
+			assertions: func(t *testing.T, _ *tls.Config) {
+			},
+		},
+		{
+			name: "empty TLS config returns minimal config",
+			config: &Config{
+				TLSConfig: TLSConfig{},
+			},
+			expectErr: false,
+			assertions: func(t *testing.T, tlsCfg *tls.Config) {
+				if tlsCfg.MinVersion != tls.VersionTLS12 {
+					t.Fatalf("expected MinVersion to be TLS 1.2")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mongo := &Mongo{config: tt.config}
+			tlsCfg, err := mongo.BuildTLSConfig()
+
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+
+			if tlsCfg == nil {
+				t.Fatalf("expected TLS config to be returned")
+			}
+
+			tt.assertions(t, tlsCfg)
+		})
+	}
+}
+
+func TestConfig_URI(t *testing.T) {
+	tests := []struct {
+		name             string
+		config           *Config
+		expectedContains []string
+		notExpected      []string
+	}{
+		{
+			name: "default SCRAM-SHA-1 auth with username and password",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				Username:      "testuser",
+				Password:      "testpass",
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismSCRAMSHA1,
+			},
+			expectedContains: []string{
+				"mongodb://testuser:testpass@localhost:27017/",
+				"authSource=admin",
+				"authMechanism=SCRAM-SHA-1",
+			},
+		},
+		{
+			name: "SCRAM-SHA-256 auth with explicit mechanism",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				Username:      "testuser",
+				Password:      "testpass",
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismSCRAMSHA256,
+			},
+			expectedContains: []string{
+				"mongodb://testuser:testpass@localhost:27017/",
+				"authSource=admin",
+				"authMechanism=SCRAM-SHA-256",
+			},
+		},
+		{
+			name: "X509 auth with external auth source",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismX509,
+			},
+			expectedContains: []string{
+				"mongodb://localhost:27017/",
+				"authSource=%24external",
+				"authMechanism=MONGODB-X509",
+			},
+			notExpected: []string{
+				"authSource=admin",
+			},
+		},
+		{
+			name: "PLAIN auth with external auth source",
+			config: &Config{
+				Hosts:         []string{"ldap.example.com:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismPLAINTEXT,
+			},
+			expectedContains: []string{
+				"mongodb://ldap.example.com:27017/",
+				"authSource=%24external",
+				"authMechanism=PLAIN",
+			},
+		},
+		{
+			name: "GSSAPI auth with external auth source",
+			config: &Config{
+				Hosts:         []string{"kerberos.example.com:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismGSSAPI,
+			},
+			expectedContains: []string{
+				"mongodb://kerberos.example.com:27017/",
+				"authSource=%24external",
+				"authMechanism=GSSAPI",
+			},
+		},
+		{
+			name: "MONGODB-AWS auth with external auth source",
+			config: &Config{
+				Hosts:         []string{"aws.mongodb.example.com:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismMONGOAWS,
+			},
+			expectedContains: []string{
+				"mongodb://aws.mongodb.example.com:27017/",
+				"authSource=%24external",
+				"authMechanism=MONGO-AWS",
+			},
+		},
+		{
+			name: "default auth without explicit mechanism",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+			},
+			expectedContains: []string{
+				"mongodb://testuser:testpass@localhost:27017/",
+				"authSource=admin",
+			},
+			notExpected: []string{
+				"authMechanism=",
+			},
+		},
+		{
+			name: "SRV connection string",
+			config: &Config{
+				Hosts:    []string{"cluster0.mongodb.net"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				Srv:      true,
+			},
+			expectedContains: []string{
+				"mongodb+srv://testuser:testpass@cluster0.mongodb.net/",
+				"authSource=admin",
+			},
+		},
+		{
+			name: "replica set configuration",
+			config: &Config{
+				Hosts:      []string{"rs1:27017,rs2:27017,rs3:27017"},
+				Username:   "testuser",
+				Password:   "testpass",
+				AuthDB:     "admin",
+				Database:   "testdb",
+				ReplicaSet: "rs0",
+			},
+			expectedContains: []string{
+				"mongodb://testuser:testpass@rs1:27017,rs2:27017,rs3:27017/",
+				"replicaSet=rs0",
+				"readPreference=secondaryPreferred",
+			},
+		},
+		{
+			name: "with additional params",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				AdditionalParams: map[string]string{
+					"authSource": "custom",
+				},
+			},
+			expectedContains: []string{
+				"authSource=custom",
+			},
+			notExpected: []string{
+				"authSource=admin",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uri := tt.config.URI()
+
+			for _, expected := range tt.expectedContains {
+				if !strings.Contains(uri, expected) {
+					t.Errorf("Expected URI to contain '%s', got: %s", expected, uri)
+				}
+			}
+
+			for _, notExpected := range tt.notExpected {
+				if strings.Contains(uri, notExpected) {
+					t.Errorf("Expected URI to NOT contain '%s', got: %s", notExpected, uri)
+				}
+			}
+		})
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		expectErr bool
+	}{
+		{
+			name: "valid config with SCRAM-SHA-1",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				Username:      "testuser",
+				Password:      "testpass",
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismSCRAMSHA1,
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with SCRAM-SHA-256",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				Username:      "testuser",
+				Password:      "testpass",
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismSCRAMSHA256,
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with X509 and username",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				Username:      "CN=myClient,OU=Engineering,O=MyOrg",
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismX509,
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid config - X509 without username",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismX509,
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid config with PLAIN (LDAP)",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismPLAINTEXT,
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with GSSAPI (Kerberos)",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismGSSAPI,
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with MONGODB-AWS",
+			config: &Config{
+				Hosts:         []string{"localhost:27017"},
+				AuthDB:        "admin",
+				Database:      "testdb",
+				AuthMechanism: AuthMechanismMONGOAWS,
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with TLS disabled",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				TLSConfig: TLSConfig{
+					Mode: "disable",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with TLS require",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				TLSConfig: TLSConfig{
+					Mode: "require",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with TLS verify-ca and CA cert",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				TLSConfig: TLSConfig{
+					Mode:     "verify-ca",
+					ServerCA: generateTestCerts().CACert,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid config - TLS verify-ca without CA cert",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				TLSConfig: TLSConfig{
+					Mode: "verify-ca",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid config - TLS with client cert but no key",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				TLSConfig: TLSConfig{
+					Mode:       "require",
+					ClientCert: "cert",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid config - TLS with client key but no cert",
+			config: &Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "testuser",
+				Password: "testpass",
+				AuthDB:   "admin",
+				Database: "testdb",
+				TLSConfig: TLSConfig{
+					Mode:      "require",
+					ClientKey: "key",
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/drivers/mongodb/internal/config_test_util.go
+++ b/drivers/mongodb/internal/config_test_util.go
@@ -1,0 +1,99 @@
+package driver
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"sync"
+	"time"
+)
+
+type testCerts struct {
+	CACert     string
+	ClientCert string
+	ClientKey  string
+}
+
+var (
+	generatedCerts *testCerts
+	certOnce       sync.Once
+)
+
+func generateTestCerts() *testCerts {
+	certOnce.Do(func() {
+		caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			panic("failed to generate CA key: " + err.Error())
+		}
+
+		caTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				Country:            []string{"IN"},
+				Organization:       []string{"Olake Test"},
+				OrganizationalUnit: []string{"Testing"},
+				CommonName:         "Test CA",
+			},
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			IsCA:                  true,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+			BasicConstraintsValid: true,
+		}
+
+		caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+		if err != nil {
+			panic("failed to create CA cert: " + err.Error())
+		}
+
+		caCertPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: caCertDER,
+		})
+
+		clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			panic("failed to generate client key: " + err.Error())
+		}
+
+		clientTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(2),
+			Subject: pkix.Name{
+				Country:            []string{"IN"},
+				Organization:       []string{"Olake Test"},
+				OrganizationalUnit: []string{"Testing"},
+				CommonName:         "mongodb",
+			},
+			NotBefore:   time.Now().Add(-1 * time.Hour),
+			NotAfter:    time.Now().Add(24 * time.Hour),
+			KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+
+		clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+		if err != nil {
+			panic("failed to create client cert: " + err.Error())
+		}
+
+		clientCertPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: clientCertDER,
+		})
+
+		clientKeyPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(clientKey),
+		})
+
+		generatedCerts = &testCerts{
+			CACert:     string(caCertPEM),
+			ClientCert: string(clientCertPEM),
+			ClientKey:  string(clientKeyPEM),
+		}
+	})
+
+	return generatedCerts
+}

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -124,7 +124,6 @@ func (m *Mongo) CDCSupported() bool {
 }
 
 func (m *Mongo) Setup(ctx context.Context) error {
-
 	if m.config.SSHConfig != nil && m.config.SSHConfig.Host != "" {
 		logger.Info("Found SSH Configuration")
 		sshClient, err := m.config.SSHConfig.SetupSSHConnection()

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -2,6 +2,8 @@ package driver
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"math"
 	"net"
@@ -136,6 +138,16 @@ func (m *Mongo) Setup(ctx context.Context) error {
 	opts := options.Client()
 
 	opts.ApplyURI(m.config.URI())
+
+	if m.config.TLSConfig.Mode != "" && m.config.TLSConfig.Mode != "disable" {
+		tlsConfig, err := m.BuildTLSConfig()
+		if err != nil {
+			return err
+		}
+
+		opts.SetTLSConfig(tlsConfig)
+	}
+
 	opts.SetCompressors([]string{"snappy"}) // using Snappy compression; read here https://en.wikipedia.org/wiki/Snappy_(compression)
 	opts.SetRegistry(safeDecodeRegistry)
 	if m.sshDialer != nil {
@@ -164,6 +176,30 @@ func (m *Mongo) Setup(ctx context.Context) error {
 	defer cancel()
 
 	return m.client.Ping(pingCtx, options.Client().ReadPreference)
+}
+
+func (m *Mongo) BuildTLSConfig() (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if m.config.TLSConfig.ServerCA != "" {
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM([]byte(m.config.TLSConfig.ServerCA)) {
+			return nil, fmt.Errorf("failed to parse CA certificate")
+		}
+		cfg.RootCAs = caCertPool
+	}
+
+	if m.config.TLSConfig.ClientCert != "" && m.config.TLSConfig.ClientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(m.config.TLSConfig.ClientCert), []byte(m.config.TLSConfig.ClientKey))
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate/key: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	return cfg, nil
 }
 
 func (m *Mongo) Close(ctx context.Context) error {


### PR DESCRIPTION
# Description

Added support for MongoDB authentication mechanisms (SCRAM-SHA-256, X509, PLAIN, GSSAPI, MONGO-AWS) and TLS/SSL configuration for MongoDB sources.

Fixes #777 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I have added unit tests for the changes that I have made accordingly ie, config_test.go, config_test_util.go. 

# Screenshots or Recordings
- [x] N/A

## Documentation
- [x] N/A - Added support to other authentication methods, also **since mysql driver had these implemented the auth methods it served as a great reference.**