### PR TITLE
feat: add partitioning support for normalization=false mod

### DIFF
--- a/destination/iceberg/arrow-writer/utils.go
+++ b/destination/iceberg/arrow-writer/utils.go
@@ -245,22 +245,21 @@ func createPositionalDeleteArrowRecord(posDeletes []PositionalDelete, allocator 
 	return recordBuilder.NewRecord()
 }
 
-func createArrowRecord(records []types.RawRecord, allocator memory.Allocator, schema *arrow.Schema, normalization bool) (arrow.Record, error) {
+func createArrowRecord(records []types.RawRecord, allocator memory.Allocator, schema *arrow.Schema) (arrow.Record, error) {
 	recordBuilder := array.NewRecordBuilder(allocator, schema)
 	defer recordBuilder.Release()
 	for _, record := range records {
 		for idx, field := range schema.Fields() {
 			var val any
-
-			// Check OlakeColumns first (CDC columns, _olake_id, _olake_timestamp, etc.)
 			if olakeVal, exists := record.OlakeColumns[field.Name]; exists {
+				// OLake system columns (_olake_id, _olake_timestamp, _op_type, _cdc_timestamp and driver specific cdc columns)
 				val = olakeVal
-			} else if normalization {
-				//  For normalized tables, get field from Data
+			} else {
+				// FlattenAndCleanData pre-shapes record.Data for both modes:
+				//   normalization=true:  typed columns + OlakeColumns merged in
+				//   normalization=false: StringifiedData + OlakeColumns + partition columns
+				// record.Data[field.Name] covers all remaining fields in both cases.
 				val = record.Data[field.Name]
-			} else if field.Name == constants.StringifiedData {
-				//  For non-normalized tables, the "data" column contains entire record.Data as JSON
-				val = record.Data
 			}
 
 			if val == nil {

--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -93,12 +93,14 @@ func (w *ArrowWriter) getRecordPartition(record types.RawRecord, olakeTimestamp 
 	values := make([]any, 0, len(w.partitionInfo))
 
 	for _, pInfo := range w.partitionInfo {
-		colType, ok := w.schema[pInfo.Field]
+		// SchemaField is the reformatted destination column name — matches w.schema keys
+		// and record.Data keys after FlattenAndCleanData pre-shaping.
+		colType, ok := w.schema[pInfo.SchemaField]
 		if !ok {
-			return "", nil, fmt.Errorf("partition field %q not in schema", pInfo.Field)
+			return "", nil, fmt.Errorf("partition field %q not in schema", pInfo.SchemaField)
 		}
 
-		fieldValue := utils.Ternary(pInfo.Field == constants.OlakeTimestamp, olakeTimestamp, record.Data[pInfo.Field])
+		fieldValue := utils.Ternary(pInfo.Field == constants.OlakeTimestamp, olakeTimestamp, record.Data[pInfo.SchemaField])
 		if colType == "timestamptz" {
 			if ts, err := typeutils.ReformatDate(fieldValue, true); err == nil {
 				fieldValue = ts
@@ -110,7 +112,7 @@ func (w *ArrowWriter) getRecordPartition(record types.RawRecord, olakeTimestamp 
 			return "", nil, fmt.Errorf("failed to get transformed value: %s", err)
 		}
 
-		paths = append(paths, ConstructColPath(pathStr, pInfo.Field, pInfo.Transform))
+		paths = append(paths, ConstructColPath(pathStr, pInfo.SchemaField, pInfo.Transform))
 		values = append(values, typedVal)
 	}
 
@@ -238,7 +240,7 @@ func (w *ArrowWriter) Write(ctx context.Context, records []types.RawRecord) erro
 			}
 		}
 
-		record, err := createArrowRecord(writer.data, w.allocator, w.arrowSchema[fileTypeData], w.stream.NormalizationEnabled())
+		record, err := createArrowRecord(writer.data, w.allocator, w.arrowSchema[fileTypeData])
 		if err != nil {
 			return fmt.Errorf("failed to create arrow record: %s", err)
 		}

--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -86,6 +86,21 @@ func (i *Iceberg) Setup(ctx context.Context, stream types.StreamInterface, globa
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse partition regex: %s", err)
 		}
+
+		// For normalization=false, partition columns must exist in the discovered schema
+		// with a concrete type — Iceberg partition specs reference columns by field ID
+		if !stream.NormalizationEnabled() {
+			for _, pInfo := range i.partitionInfo {
+				found, prop := stream.Schema().GetProperty(pInfo.Field)
+				if !found {
+					return nil, nil, fmt.Errorf("partition field %s not found in stream schema; with normalization=false, partition columns must exist in the discovered schema", pInfo.Field)
+				}
+				colType := prop.DataType()
+				if colType == types.Null || colType == types.Unknown {
+					return nil, nil, fmt.Errorf("partition field %s has type %s in stream schema; cannot create Iceberg partition spec without a concrete column type", pInfo.Field, colType)
+				}
+			}
+		}
 	}
 
 	server, err := newIcebergClient(i.config, i.partitionInfo, options.ThreadID, false, isUpsertMode(stream, options.Backfill), i.stream.GetDestinationDatabase(&i.config.IcebergDatabase))
@@ -103,8 +118,17 @@ func (i *Iceberg) Setup(ctx context.Context, stream types.StreamInterface, globa
 	if globalSchema == nil {
 		logger.Infof("Creating destination table [%s] in Iceberg database [%s] for stream [%s]", i.stream.GetDestinationTable(), i.stream.GetDestinationDatabase(&i.config.IcebergDatabase), i.stream.Name())
 
+		// when normalization=false, include partition columns in the Iceberg schema so
+		// the Java server can build the partition spec (spec references columns by field ID)
+		partitionFields := make([]string, 0, len(i.partitionInfo))
+		if !stream.NormalizationEnabled() {
+			for _, p := range i.partitionInfo {
+				partitionFields = append(partitionFields, p.Field)
+			}
+		}
+
 		var requestPayload proto.IcebergPayload
-		iceSchema := stream.Schema().ToIceberg(!stream.NormalizationEnabled(), i.stream)
+		iceSchema := stream.Schema().ToIceberg(!stream.NormalizationEnabled(), i.stream, partitionFields...)
 		requestPayload = proto.IcebergPayload{
 			Type: proto.IcebergPayload_GET_OR_CREATE_TABLE,
 			Metadata: &proto.IcebergPayload_Metadata{
@@ -357,6 +381,32 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 	}
 
 	if !i.stream.NormalizationEnabled() {
+		err := utils.Concurrent(ctx, records, runtime.GOMAXPROCS(0)*16, func(_ context.Context, record types.RawRecord, idx int) error {
+			// JSON-encode original source data before overwriting the map
+			dataBytes, err := json.Marshal(record.Data)
+			if err != nil {
+				return fmt.Errorf("failed to marshal raw data: %s", err)
+			}
+			records[idx].Data = make(map[string]any, len(record.OlakeColumns)+1+len(i.partitionInfo))
+			records[idx].Data[constants.StringifiedData] = string(dataBytes)
+			maps.Copy(records[idx].Data, record.OlakeColumns)
+			// include partition column values from the original source data so writers
+			// can apply the Iceberg partition spec without a separate data buffer.
+			// Read with Field (original source key), write with SchemaField (reformatted
+			// destination key) so downstream lookups against the Iceberg schema succeed.
+			for _, pInfo := range i.partitionInfo {
+				if pInfo.Field == constants.OlakeTimestamp {
+					continue // _olake_timestamp is already copied via OlakeColumns above
+				}
+				if v, ok := record.Data[pInfo.Field]; ok {
+					records[idx].Data[pInfo.SchemaField] = v
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return false, nil, nil, fmt.Errorf("failed to pre-shape raw records: %s", err)
+		}
 		return false, records, i.schema, nil
 	}
 
@@ -475,10 +525,13 @@ func (i *Iceberg) parsePartitionRegex(pattern string) error {
 		colName := strings.Replace(strings.TrimSpace(strings.Trim(match[1], `'"`)), "now()", constants.OlakeTimestamp, 1)
 		transform := strings.TrimSpace(strings.Trim(match[2], `'"`))
 
-		// Append to ordered slice to preserve partition order
+		// Append to ordered slice to preserve partition order.
+		// SchemaField is reformatted once here so all consumers use the consistent
+		// destination column name without scattering utils.Reformat() calls.
 		i.partitionInfo = append(i.partitionInfo, internal.PartitionInfo{
-			Field:     colName,
-			Transform: transform,
+			Field:       colName,
+			SchemaField: utils.Reformat(colName),
+			Transform:   transform,
 		})
 	}
 

--- a/destination/iceberg/internal/utils.go
+++ b/destination/iceberg/internal/utils.go
@@ -9,8 +9,12 @@ type ServerClient interface {
 	ServerID() string
 }
 
-// PartitionInfo represents a Iceberg partition column with its transform, preserving order
+// PartitionInfo represents an Iceberg partition column with its transform, preserving order.
+// Field is the original source column name (used for record.Data lookups before pre-shaping).
+// SchemaField is the reformatted destination column name (used for schema, Java partition spec,
+// and record.Data lookups after pre-shaping). Computed once at parse time via utils.Reformat.
 type PartitionInfo struct {
-	Field     string
-	Transform string
+	Field       string // original case — matches source record.Data keys
+	SchemaField string // reformatted — matches Iceberg schema field names
+	Transform   string
 }

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -59,7 +59,7 @@ func getServerConfigJSON(config *Config, partitionInfo []internal.PartitionInfo,
 		partitionFields := make([]map[string]string, 0, len(partitionInfo))
 		for _, info := range partitionInfo {
 			partitionFields = append(partitionFields, map[string]string{
-				"field":     info.Field,
+				"field":     info.SchemaField, // reformatted to match the Iceberg schema field name
 				"transform": info.Transform,
 			})
 		}

--- a/destination/iceberg/legacy-writer/writer.go
+++ b/destination/iceberg/legacy-writer/writer.go
@@ -40,6 +40,10 @@ func (w *LegacyWriter) Write(ctx context.Context, records []types.RawRecord) err
 		})
 	}
 
+	// FlattenAndCleanData pre-shapes record.Data for both normalization modes:
+	//   normalization=true:  typed columns + OlakeColumns merged in
+	//   normalization=false: StringifiedData + OlakeColumns + partition columns
+	// A single loop over protoSchema covers both cases.
 	protoRecords := make([]*proto.IcebergPayload_IceRecord, 0, len(records))
 	for _, record := range records {
 		if record.Data == nil {
@@ -47,26 +51,17 @@ func (w *LegacyWriter) Write(ctx context.Context, records []types.RawRecord) err
 		}
 
 		protoColumnsValue := make([]*proto.IcebergPayload_IceRecord_FieldValue, 0, len(protoSchema))
-		var err error
-		if !w.stream.NormalizationEnabled() {
-			protoColumnsValue, err = RawDataColumnBuffer(record, protoSchema)
+		for _, field := range protoSchema {
+			val, exist := record.Data[field.Key]
+			if !exist {
+				protoColumnsValue = append(protoColumnsValue, nil)
+				continue
+			}
+			fv, err := toProtoFieldValue(field.IceType, val)
 			if err != nil {
-				return fmt.Errorf("failed to create raw data column buffer: %s", err)
+				return fmt.Errorf("field[%s]: %s", field.Key, err)
 			}
-		} else {
-			for _, field := range protoSchema {
-				val, exist := record.Data[field.Key]
-				if !exist {
-					protoColumnsValue = append(protoColumnsValue, nil)
-					continue
-				}
-				fv, err := toProtoFieldValue(field.IceType, val)
-				if err != nil {
-					return fmt.Errorf("field[%s]: %s", field.Key, err)
-				}
-
-				protoColumnsValue = append(protoColumnsValue, fv)
-			}
+			protoColumnsValue = append(protoColumnsValue, fv)
 		}
 
 		if len(protoColumnsValue) > 0 {
@@ -146,6 +141,9 @@ func (w *LegacyWriter) Close(ctx context.Context, finalMetadataState any) error 
 	return nil
 }
 
+// RawDataColumnBuffer is used by the connection health check in iceberg.go to build proto
+// field values for a synthetic non-normalized test record.
+// Normal write-path records are pre-shaped by FlattenAndCleanData and use the standard field loop in Write.
 func RawDataColumnBuffer(record types.RawRecord, protoSchema []*proto.IcebergPayload_SchemaField) ([]*proto.IcebergPayload_IceRecord_FieldValue, error) {
 	// 1. Start with a copy of OlakeColumns (already prepared upstream)
 	dataMap := make(map[string]any, len(record.OlakeColumns)+1)

--- a/types/type_schema.go
+++ b/types/type_schema.go
@@ -163,15 +163,18 @@ func (t *TypeSchema) ToParquet(defaultColumns bool, stream StreamInterface) *par
 	return parquet.NewSchema("olake_schema", groupNode)
 }
 
-func (t *TypeSchema) ToIceberg(defaultColumns bool, stream StreamInterface) []*proto.IcebergPayload_SchemaField {
+func (t *TypeSchema) ToIceberg(defaultColumns bool, stream StreamInterface, includeColumns ...string) []*proto.IcebergPayload_SchemaField {
 	var icebergFields []*proto.IcebergPayload_SchemaField
 	isSelected := stream.IsSelectedColumn()
+
+	// build a lookup set so partition columns can be included even in defaultColumns mode
+	includeSet := NewSet[string](includeColumns...)
 
 	t.Properties.Range(func(key, value interface{}) bool {
 		prop := value.(*Property)
 		colName := key.(string)
-		// skip non-olake columns if defaultColumns is set to true
-		if !isSelected(utils.Reformat(colName)) || (defaultColumns && !prop.OlakeColumn) {
+		// skip non-olake columns in defaultColumns mode unless explicitly included (e.g. partition columns)
+		if !isSelected(utils.Reformat(colName)) || (defaultColumns && !prop.OlakeColumn && !includeSet.Exists(colName)) {
 			return true
 		}
 		icebergFields = append(icebergFields, &proto.IcebergPayload_SchemaField{


### PR DESCRIPTION
# Description

Adds partitioning support when `normalization=false` for both the legacy and Arrow Iceberg writers.

Previously, partition transforms only worked for normalized streams. Non-normalized streams silently wrote all files to a `null` partition because:
- Partition column values were not carried through the pre-shaping step
- Column name case mismatches between source data and the Iceberg schema caused null lookups

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] MongoDB source with `normalization: false` and `partition_regex: "/{orderDate, month}"` — verified partitioned directories created in S3 with correct values (`orderdate_month=2024-01/`)
- [x] MySQL source with `normalization: false` and `partition_regex: "/{created_at, month}"` — verified correct partition layout and non-null column values in Spark query

# Screenshots or Recordings

_S3 partition directories and Spark query results attached_

## Key Changes


## Documentation

- [X] N/A (new feature — docs update to follow)

## Related PR's (If Any):