### PR TITLE
fix(iceberg): create one positional delete file per data file ref

### DIFF
--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/IcebergUtil.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/IcebergUtil.java
@@ -251,7 +251,8 @@ public class IcebergUtil {
           null,
           null,
           null)
-          .setAll(icebergTable.properties());
+          .setAll(icebergTable.properties())
+          .set("write.metadata.metrics.column.file_path", "full");
     } else {
       return new GenericAppenderFactory(
           icebergTable.schema(),
@@ -259,7 +260,8 @@ public class IcebergUtil {
           Ints.toArray(identifierFieldIds),
           TypeUtil.select(icebergTable.schema(), Sets.newHashSet(identifierFieldIds)),
           null)
-          .setAll(icebergTable.properties());
+          .setAll(icebergTable.properties())
+          .set("write.metadata.metrics.column.file_path", "full");
     }
   }
 

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
@@ -2,6 +2,7 @@ package io.debezium.server.iceberg.tableoperator;
 
 import com.google.common.collect.Sets;
 import org.apache.iceberg.*;
+import org.apache.iceberg.deletes.DeleteGranularity;
 import org.apache.iceberg.data.InternalRecordWrapper;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.BaseTaskWriter;
@@ -62,7 +63,8 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
 
   public class RowDataDeltaWriter extends BaseEqualityDeltaWriter {
     RowDataDeltaWriter(PartitionKey partition) {
-      super(partition, schema, deleteSchema);
+      // create one positional delete file per referenced data file,
+      super(partition, schema, deleteSchema, DeleteGranularity.FILE);
     }
 
     @Override


### PR DESCRIPTION
# Description

Compaction fails on tables with cdc upserts when multiple changes arrive for the same `_olake_id` in a single batch, due to the presence of positional delete file having multiple data file references in it.

A detailed explanation is provided [here](https://datazip.atlassian.net/wiki/x/B4BTGQ).

## Fix:
As this is a special case of OLake, where a positional delete only references the "new" data files. In case a positional delete references multiple data files, `lower_bound != upper_bound`,

Thus, Iceberg simply doesn't checks if the data file referenced in the positional delete is a new data file or old data file, and fails the compaction.

We fix this issue by making sure:

- Each positional delete file now references exactly one data file → `lower_bound == upper_bound` 
- Ensuring, complete S3 path is stored as string values, without any truncation

Iceberg's [DeleteGranularity Feature](https://iceberg.apache.org/javadoc/1.5.2/org/apache/iceberg/deletes/DeleteGranularity.html)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Multiple upserts in a single batch in a big table
- [x] Both partitioned and un-partitioned iceberg table
- [x] Backward Compatibility

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)