### PR TITLE
fix: upgrade pgx/v5 to 5.9.2 to fix Trivy CVE-2026-33816

### DIFF
--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.2.0
 	github.com/datazip-inc/olake v0.0.0-20250414061859-a168ad00bb4b
 	github.com/jackc/pglogrepl v0.0.0-20250322012620-f1e2b1498ed6
-	github.com/jackc/pgx/v5 v5.7.3
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.10.9
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.48.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/goccy/go-json v0.10.5
 	github.com/jackc/pglogrepl v0.0.0-20250322012620-f1e2b1498ed6
 	github.com/jackc/pgtype v1.14.0
-	github.com/jackc/pgx/v5 v5.7.3
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/linkedin/goavro/v2 v2.15.0


### PR DESCRIPTION
## Description

This PR upgrades `github.com/jackc/pgx/v5` from `v5.7.3` to `v5.9.2` (root module + `drivers/postgres`) to remediate Trivy security findings.

- Fixes **CVE-2026-33816 (CRITICAL)**: memory-safety vulnerability (fixed in `v5.9.0+`)
- Fixes **GHSA-j88v-2chj-qfwx (LOW)**: SQL injection advisory (fixed in `v5.9.2`)

This change is not affecting the existing code.


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `trivy fs --scanners vuln .` (no longer reports CVE-2026-33816 for `pgx/v5`)

# Screenshots or Recordings

N/A

## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

N/A