### PR TITLE
fix(postgres): use pg_catalog to discover primary keys correctly

### DIFF
--- a/drivers/postgres/internal/postgres.go
+++ b/drivers/postgres/internal/postgres.go
@@ -34,8 +34,27 @@ const (
 		AND nspname != 'information_schema';  -- Exclude information_schema`
 	// get table schema
 	getTableSchemaTmpl = `SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 ORDER BY ordinal_position`
-	// get primary key columns
-	getTablePrimaryKey = `SELECT column_name FROM information_schema.key_column_usage WHERE table_schema = $1 AND table_name = $2 ORDER BY ordinal_position`
+	// get primary key columns, query copied from pgjdbc's PgDatabaseMetaData.getPrimaryKeys() with the always-NULL TABLE_CAT column omitted
+	// ref: https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L2134
+	getTablePrimaryKey = `SELECT result.column_name
+		FROM (
+			SELECT n.nspname AS table_schema,
+				ct.relname AS table_name,
+				a.attname  AS column_name,
+				(information_schema._pg_expandarray(i.indkey)).n AS key_seq,
+				information_schema._pg_expandarray(i.indkey)     AS keys,
+				a.attnum AS a_attnum
+			FROM pg_catalog.pg_class ct
+			JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)
+			JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)
+			JOIN pg_catalog.pg_index i     ON (a.attrelid = i.indrelid)
+			JOIN pg_catalog.pg_class ci    ON (ci.oid = i.indexrelid)
+			WHERE i.indisprimary
+		) result
+		WHERE result.table_schema = $1
+		  AND result.table_name   = $2
+		  AND result.a_attnum     = (result.keys).x
+		ORDER BY result.key_seq`
 )
 
 type Postgres struct {

--- a/types/catalog.go
+++ b/types/catalog.go
@@ -148,6 +148,7 @@ func mergeCatalogs(oldCatalog, newCatalog *Catalog) *Catalog {
 			newStream.Stream.CursorField = oldStream.Stream.CursorField
 			newStream.Stream.DestinationDatabase = oldStream.Stream.DestinationDatabase
 			newStream.Stream.DestinationTable = oldStream.Stream.DestinationTable
+			newStream.Stream.SourceDefinedPrimaryKey = oldStream.Stream.SourceDefinedPrimaryKey
 			return nil
 		}
 


### PR DESCRIPTION
# Description

information_schema.key_column_usage returns columns for all named constraints (PRIMARY KEY, FOREIGN KEY, UNIQUE), causing FK columns to be incorrectly included in source_defined_primary_key. This produced wrong _olake_id hashes, which caused CDC upserts to miss equality deletes and write duplicate rows in Iceberg whenever a FK column value changed.
Replaced with a pg_catalog-based query (indisprimary=true) copied from pgjdbc's PgDatabaseMetaData.getPrimaryKeys(). This approach also works for read-only users and non-owner roles on managed databases (RDS, Supabase, Render etc.) where information_schema silently returns empty rows.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):