### PR TITLE
feat(iceberg): skip equality deletes for cdc inserts

### DIFF
--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -153,6 +153,8 @@ func (w *ArrowWriter) getOrCreateWriter(ctx context.Context, pKey string, values
 }
 
 // extract partitions records and tracks deletes for upsert mode.
+// Equality + positional dedup runs only for "d", "u", "i".  "c" (steady-state CDC insert)
+// and "r" (backfill read) skip both — no prior committed row can exist for those keys.
 func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) error {
 	for _, rec := range records {
 		pKey, values, err := w.getRecordPartition(rec, rec.OlakeColumns[constants.OlakeTimestamp].(time.Time))
@@ -168,8 +170,7 @@ func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) er
 		writer.data = append(writer.data, rec)
 		recordOpType := rec.OlakeColumns[constants.OpType].(string)
 		recordOlakeID := rec.OlakeColumns[constants.OlakeID].(string)
-		// Track deletes for upsert operations (d, u, c all need delete handling)
-		if w.upsertMode && (recordOpType == "d" || recordOpType == "u" || recordOpType == "c") {
+		if w.upsertMode && (recordOpType == "d" || recordOpType == "u" || recordOpType == "i") {
 			filePosition := writer.dataWriter.currentRowCount + int64(len(writer.data)-1)
 
 			if _, exists := writer.olakeIDPosition[recordOlakeID]; !exists {

--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -152,9 +152,7 @@ func (w *ArrowWriter) getOrCreateWriter(ctx context.Context, pKey string, values
 	return writer, nil
 }
 
-// extract partitions records and tracks deletes for upsert mode.
-// Equality + positional dedup runs only for "d", "u", "i".  "c" (steady-state CDC insert)
-// and "r" (backfill read) skip both — no prior committed row can exist for those keys.
+// extract partitions records and tracks deletes for upsert mode ("d"/"u"/"i" only; "c"/"r" skip dedup).
 func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) error {
 	for _, rec := range records {
 		pKey, values, err := w.getRecordPartition(rec, rec.OlakeColumns[constants.OlakeTimestamp].(time.Time))

--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -192,6 +192,11 @@ func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) er
 				}
 			}
 		}
+
+		// Normalise "i" → "c" in the data file so downstream consumers see a consistent op type.
+		if recordOpType == "i" {
+			rec.OlakeColumns[constants.OpType] = "c"
+		}
 	}
 
 	return nil

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/SchemaConvertor.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/SchemaConvertor.java
@@ -138,7 +138,7 @@ public class SchemaConvertor {
       case "u" -> Operation.UPDATE;
       case "d" -> Operation.DELETE;
       case "r" -> Operation.READ;
-      case "c" -> Operation.INSERT;
+      case "c" -> Operation.CREATE;
       case "i" -> Operation.INSERT;
       default ->
           throw new RuntimeException("Unexpected `" + cdcOpField + "` operation value received, expecting one of ['u','d','r','c', 'i']");

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/SchemaConvertor.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/SchemaConvertor.java
@@ -88,7 +88,6 @@ public class SchemaConvertor {
       }
       // check if it is append only or upsert
       if(!upsert) { 
-        // TODO: need a discussion previously Operation.Insert was being used
         return new RecordWrapper(genericRow, Operation.READ);
       }
       return new RecordWrapper(genericRow, cdcOpValue(data.getRecordType()));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
@@ -54,8 +54,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
     if (rowOperation == Operation.DELETE && !keepDeletes) {
       // deletes. doing hard delete. when keepDeletes = FALSE we dont keep deleted record
       writer.deleteKey(keyProjection.wrap(row));
+    } else if ("c".equals(String.valueOf(row.getField("_op_type")))) {
+      // Steady-state CDC insert: no prior committed row exists for this key, skip equality delete.
+      writer.write(row);
     } else {
-      // We are deleting key even for insert operations to avoid duplicate records for handling inserts happening while full-load
+      // "i" (first-CDC overlap) / UPDATE / READ: equality-delete the prior version, then write.
       writer.deleteKey(keyProjection.wrap(row));
       writer.write(row);
     }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
@@ -54,13 +54,13 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
     if (rowOperation == Operation.DELETE && !keepDeletes) {
       // deletes. doing hard delete. when keepDeletes = FALSE we dont keep deleted record
       writer.deleteKey(keyProjection.wrap(row));
-    } else if ("c".equals(String.valueOf(row.getField("_op_type")))) {
+    } else if (rowOperation == Operation.CREATE) {
       // Steady-state CDC insert: no prior committed row exists for this key, skip equality delete.
       writer.write(row);
     } else {
       // Phantom read possible: equality-delete before write to evict any prior committed version.
-      // Normalise "i" → "c" in the data file so downstream consumers see a consistent op type.
-      if ("i".equals(String.valueOf(row.getField("_op_type")))) {
+      // Normalise "i" → "c" so downstream sees a consistent op type.
+      if (rowOperation == Operation.INSERT) {
         row.setField("_op_type", "c");
       }
       writer.deleteKey(keyProjection.wrap(row));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
@@ -59,10 +59,8 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
       writer.write(row);
     } else {
       // Phantom read possible: equality-delete before write to evict any prior committed version.
-      // Normalise "i" → "c" so downstream sees a consistent op type.
-      if (rowOperation == Operation.INSERT) {
-        row.setField("_op_type", "c");
-      }
+      // _op_type normalisation ("i" -> "c") is done upstream in IcebergTableOperator
+      // for all writer types before reaching here.
       writer.deleteKey(keyProjection.wrap(row));
       writer.write(row);
     }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/BaseDeltaTaskWriter.java
@@ -58,7 +58,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
       // Steady-state CDC insert: no prior committed row exists for this key, skip equality delete.
       writer.write(row);
     } else {
-      // "i" (first-CDC overlap) / UPDATE / READ: equality-delete the prior version, then write.
+      // Phantom read possible: equality-delete before write to evict any prior committed version.
+      // Normalise "i" → "c" in the data file so downstream consumers see a consistent op type.
+      if ("i".equals(String.valueOf(row.getField("_op_type")))) {
+        row.setField("_op_type", "c");
+      }
       writer.deleteKey(keyProjection.wrap(row));
       writer.write(row);
     }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -82,6 +82,7 @@ public class IcebergTableOperator {
   private static final String STATE_KEY_2PC = "olake_2pc";
   private static final String STATE_FIELD_LATEST_THREAD_ID = "id";
   private static final String STATE_FIELD_FULL_REFRESH_COMMITTED_IDS = "full_refresh_committed_ids";
+  private static final String STATE_FIELD_DEDUP_INSERTS = "dedup_inserts";
 
 
   @ConfigProperty(name = "debezium.sink.iceberg.upsert-dedup-column", defaultValue = "_cdc_timestamp")
@@ -457,6 +458,7 @@ public class IcebergTableOperator {
               }
           } else {
               // No payload => backfill/snapshot style: append threadId to full_refresh_committed_ids
+              // and mark that the first CDC sync must use equality deletes (overlap window open).
               com.fasterxml.jackson.databind.node.ArrayNode committedIds;
               if (rootNode.has(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS) && rootNode.get(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS).isArray()) {
                   committedIds = (com.fasterxml.jackson.databind.node.ArrayNode) rootNode.get(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS);
@@ -464,6 +466,7 @@ public class IcebergTableOperator {
                   committedIds = rootNode.putArray(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS);
               }
               committedIds.add(threadId);
+              rootNode.put(STATE_FIELD_DEDUP_INSERTS, true);
           }
 
           updateProperties.set(STATE_KEY_2PC, mapper.writeValueAsString(rootNode));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -466,7 +466,14 @@ public class IcebergTableOperator {
                   committedIds = rootNode.putArray(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS);
               }
               committedIds.add(threadId);
-              rootNode.put(STATE_FIELD_DEDUP_INSERTS, true);
+              // Only flip the flag when it isn't already true: skips a redundant
+              // property write for every chunk after the first in a backfill, and
+              // correctly reopens the overlap window if a previous CDC had cleared
+              // it (dedup_inserts == false) and we're now committing new backfill data.
+              JsonNode dedup = rootNode.get(STATE_FIELD_DEDUP_INSERTS);
+              if (dedup == null || !dedup.isBoolean() || !dedup.booleanValue()) {
+                  rootNode.put(STATE_FIELD_DEDUP_INSERTS, true);
+              }
           }
 
           updateProperties.set(STATE_KEY_2PC, mapper.writeValueAsString(rootNode));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -74,7 +74,8 @@ public class IcebergTableOperator {
     cdcSourceTsMsField = "_cdc_timestamp";
   }
 
-  static final ImmutableMap<Operation, Integer> CDC_OPERATION_PRIORITY = ImmutableMap.of(Operation.INSERT, 1,
+  static final ImmutableMap<Operation, Integer> CDC_OPERATION_PRIORITY = ImmutableMap.of(
+      Operation.INSERT, 1, Operation.CREATE, 1,
       Operation.READ, 2, Operation.UPDATE, 3, Operation.DELETE, 4);
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergTableOperator.class);
   private static final ObjectMapper mapper = new ObjectMapper();

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -466,7 +466,7 @@ public class IcebergTableOperator {
                   committedIds = rootNode.putArray(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS);
               }
               committedIds.add(threadId);
-              // Only flip the flag when it isn't already true: skips a redundant
+              // Only flip the flag when it isn't already true: skips a redundant update
               // property write for every chunk after the first in a backfill, and
               // correctly reopens the overlap window if a previous CDC had cleared
               // it (dedup_inserts == false) and we're now committing new backfill data.

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -272,12 +272,12 @@ public class IcebergTableOperator {
     try {
       for (RecordWrapper record : events) {
         try{
-          // Normalise "i" -> "c" for all writer types before routing to the writer.
-          // Append writers (Operation.READ) have no normalisation in BaseDeltaTaskWriter,
-          // so we must handle them here. Delta writers still see Operation.INSERT on the
-          // RecordWrapper (op() is immutable) and correctly fire the equality-delete path;
-          // only the stored _op_type field in the output file is corrected to "c".
-          if ("i".equals(record.getField("_op_type"))) {
+          // Normalise _op_type "i" → "c" before routing to any writer.
+          // op() is immutable on RecordWrapper, so delta writers still see Operation.INSERT
+          // and correctly fire the equality-delete path; only the stored field is corrected.
+          // Note: append-mode records carry Operation.READ and are not normalised here;
+          // Go already emits "c" for STRICTCDC streams, so this covers all CDC insert cases.
+          if (record.op() == Operation.INSERT) {
             record.setField("_op_type", "c");
           }
            writer.write(record);

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -272,6 +272,14 @@ public class IcebergTableOperator {
     try {
       for (RecordWrapper record : events) {
         try{
+          // Normalise "i" -> "c" for all writer types before routing to the writer.
+          // Append writers (Operation.READ) have no normalisation in BaseDeltaTaskWriter,
+          // so we must handle them here. Delta writers still see Operation.INSERT on the
+          // RecordWrapper (op() is immutable) and correctly fire the equality-delete path;
+          // only the stored _op_type field in the output file is corrected to "c".
+          if ("i".equals(record.getField("_op_type"))) {
+            record.setField("_op_type", "c");
+          }
            writer.write(record);
         }catch (Exception ex) {
           LOGGER.error("Failed to write data: {}, exception: {}", record,ex);

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -273,11 +273,12 @@ public class IcebergTableOperator {
       for (RecordWrapper record : events) {
         try{
           // Normalise _op_type "i" → "c" before routing to any writer.
-          // op() is immutable on RecordWrapper, so delta writers still see Operation.INSERT
-          // and correctly fire the equality-delete path; only the stored field is corrected.
-          // Note: append-mode records carry Operation.READ and are not normalised here;
-          // Go already emits "c" for STRICTCDC streams, so this covers all CDC insert cases.
-          if (record.op() == Operation.INSERT) {
+          //   - Delta writers (upsert=true):  op() == INSERT, field == "i" → both would work
+          //   - Append writers (upsert=false, AppendMode/backfill): op() == READ, field == "i"
+          //     → op()-based check misses these entirely
+          // op() on RecordWrapper is immutable, so delta writers still see Operation.INSERT
+          // and correctly fire the equality-delete path in BaseDeltaTaskWriter.
+          if ("i".equals(record.getField("_op_type"))) {
             record.setField("_op_type", "c");
           }
            writer.write(record);

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -467,14 +467,7 @@ public class IcebergTableOperator {
                   committedIds = rootNode.putArray(STATE_FIELD_FULL_REFRESH_COMMITTED_IDS);
               }
               committedIds.add(threadId);
-              // Only flip the flag when it isn't already true: skips a redundant update
-              // property write for every chunk after the first in a backfill, and
-              // correctly reopens the overlap window if a previous CDC had cleared
-              // it (dedup_inserts == false) and we're now committing new backfill data.
-              JsonNode dedup = rootNode.get(STATE_FIELD_DEDUP_INSERTS);
-              if (dedup == null || !dedup.isBoolean() || !dedup.booleanValue()) {
-                  rootNode.put(STATE_FIELD_DEDUP_INSERTS, true);
-              }
+              rootNode.put(STATE_FIELD_DEDUP_INSERTS, true);
           }
 
           updateProperties.set(STATE_KEY_2PC, mapper.writeValueAsString(rootNode));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/Operation.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/Operation.java
@@ -19,7 +19,8 @@
 package io.debezium.server.iceberg.tableoperator;
 
 public enum Operation {
-  INSERT,
+  INSERT,  // "i" — first-CDC overlap insert; equality-delete before write
+  CREATE,  // "c" — steady-state CDC insert; no prior committed row, skip equality delete
   UPDATE,
   DELETE,
   READ

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -162,16 +162,14 @@ func (p *Parquet) Setup(_ context.Context, stream types.StreamInterface, schema 
 func (p *Parquet) Write(_ context.Context, records []types.RawRecord) error {
 	// TODO: use batch writing feature of pq writer
 	for _, record := range records {
-		// Normalise "i" -> "c": Parquet has no equality-delete concept, downstream
+		// Normalise "i" -? "c": Parquet has no equality-delete concept; downstream
 		// consumers must see a consistent "c" for all CDC inserts.
+		// OlakeColumns covers the non-normalized path; Data covers the normalized path
+		// where FlattenAndCleanData has already merged OlakeColumns into Data.
 		if opType, ok := record.OlakeColumns[constants.OpType].(string); ok && opType == "i" {
 			record.OlakeColumns[constants.OpType] = "c"
-			// FlattenAndCleanData (normalized path) already merged OlakeColumns into Data,
-			// so fix the Data map as well when the field is present.
-			if record.Data != nil {
-				if _, exists := record.Data[constants.OpType]; exists {
-					record.Data[constants.OpType] = "c"
-				}
+			if v, ok := record.Data[constants.OpType].(string); ok && v == "i" {
+				record.Data[constants.OpType] = "c"
 			}
 		}
 		partitionedPath := p.getPartitionedFilePath(record.Data, record.OlakeColumns[constants.OlakeTimestamp].(time.Time))

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -162,6 +162,11 @@ func (p *Parquet) Setup(_ context.Context, stream types.StreamInterface, schema 
 func (p *Parquet) Write(_ context.Context, records []types.RawRecord) error {
 	// TODO: use batch writing feature of pq writer
 	for _, record := range records {
+		// Normalise "i" -> "c": Parquet has no equality-delete concept, downstream
+		// consumers must see a consistent "c" for all CDC inserts.
+		if opType, ok := record.OlakeColumns[constants.OpType].(string); ok && opType == "i" {
+			record.OlakeColumns[constants.OpType] = "c"
+		}
 		partitionedPath := p.getPartitionedFilePath(record.Data, record.OlakeColumns[constants.OlakeTimestamp].(time.Time))
 		partitionFiles, exists := p.partitionedFiles[partitionedPath]
 		if !exists {
@@ -362,8 +367,12 @@ func (p *Parquet) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 	diffFound := atomic.Bool{} // to process records concurrently and detect schema difference
 
 	err := utils.Concurrent(ctx, records, runtime.GOMAXPROCS(0)*16, func(_ context.Context, record types.RawRecord, idx int) error {
+		// Normalise "i" → "c" before merging so the correct value lands in Data.
+		if opType, ok := record.OlakeColumns[constants.OpType].(string); ok && opType == "i" {
+			records[idx].OlakeColumns[constants.OpType] = "c"
+		}
 		// Add common fields
-		maps.Copy(records[idx].Data, record.OlakeColumns)
+		maps.Copy(records[idx].Data, records[idx].OlakeColumns)
 		flattenedRecord, err := typeutils.NewFlattener().Flatten(record.Data)
 		if err != nil {
 			return fmt.Errorf("failed to flatten record at index %d, pq writer: %s", idx, err)

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -168,7 +168,7 @@ func (p *Parquet) Write(_ context.Context, records []types.RawRecord) error {
 		// where FlattenAndCleanData has already merged OlakeColumns into Data.
 		if opType, ok := record.OlakeColumns[constants.OpType].(string); ok && opType == "i" {
 			record.OlakeColumns[constants.OpType] = "c"
-			if v, ok := record.Data[constants.OpType].(string); ok && v == "i" {
+			if _, exists := record.Data[constants.OpType]; exists {
 				record.Data[constants.OpType] = "c"
 			}
 		}

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -166,6 +166,13 @@ func (p *Parquet) Write(_ context.Context, records []types.RawRecord) error {
 		// consumers must see a consistent "c" for all CDC inserts.
 		if opType, ok := record.OlakeColumns[constants.OpType].(string); ok && opType == "i" {
 			record.OlakeColumns[constants.OpType] = "c"
+			// FlattenAndCleanData (normalized path) already merged OlakeColumns into Data,
+			// so fix the Data map as well when the field is present.
+			if record.Data != nil {
+				if _, exists := record.Data[constants.OpType]; exists {
+					record.Data[constants.OpType] = "c"
+				}
+			}
 		}
 		partitionedPath := p.getPartitionedFilePath(record.Data, record.OlakeColumns[constants.OlakeTimestamp].(time.Time))
 		partitionFiles, exists := p.partitionedFiles[partitionedPath]
@@ -367,12 +374,8 @@ func (p *Parquet) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 	diffFound := atomic.Bool{} // to process records concurrently and detect schema difference
 
 	err := utils.Concurrent(ctx, records, runtime.GOMAXPROCS(0)*16, func(_ context.Context, record types.RawRecord, idx int) error {
-		// Normalise "i" → "c" before merging so the correct value lands in Data.
-		if opType, ok := record.OlakeColumns[constants.OpType].(string); ok && opType == "i" {
-			records[idx].OlakeColumns[constants.OpType] = "c"
-		}
 		// Add common fields
-		maps.Copy(records[idx].Data, records[idx].OlakeColumns)
+		maps.Copy(records[idx].Data, record.OlakeColumns)
 		flattenedRecord, err := typeutils.NewFlattener().Flatten(record.Data)
 		if err != nil {
 			return fmt.Errorf("failed to flatten record at index %d, pq writer: %s", idx, err)

--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -268,16 +268,25 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 		}
 	}
 
+	// closeArg must be a true nil interface (not a typed nil pointer) when metadataState is nil.
+	// A typed nil *MetadataState stored in `any` is NOT nil, which causes LegacyWriter.Close to
+	// marshal it as "null" and send a non-empty payload — skipping Java's else-branch that sets
+	// dedup_inserts=true and updates full_refresh_committed_ids.
+	var closeArg any
+	if metadataState != nil {
+		closeArg = metadataState
+	}
+
 	switch w := writer.(type) {
 	case *destination.WriterThread:
-		if threadErr := w.Close(ctx, metadataState); threadErr != nil {
+		if threadErr := w.Close(ctx, closeArg); threadErr != nil {
 			closeErr = fmt.Errorf("failed to close writer: %s", threadErr)
 		}
 	case map[string]*destination.WriterThread:
 		// Multiple writers keyed by stream ID
 		for streamID, inserter := range w {
 			if inserter != nil {
-				if threadErr := inserter.Close(ctx, metadataState); threadErr != nil {
+				if threadErr := inserter.Close(ctx, closeArg); threadErr != nil {
 					closeErr = fmt.Errorf("%s; failed closing writer[%s]: %s", closeErr, streamID, threadErr)
 				}
 			}

--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -262,6 +262,8 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 		ms, setErr := types.SetMetadataState(*mtState, threadID)
 		if setErr != nil {
 			closeErr = fmt.Errorf("failed to set metadata state: %s", setErr)
+			cancel()
+			return
 		}
 		types.SetDedupInserts(ms, dedupInserts)
 		metadataState = ms

--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -263,7 +263,6 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 		if setErr != nil {
 			closeErr = fmt.Errorf("failed to set metadata state: %s", setErr)
 			cancel()
-			return
 		}
 		types.SetDedupInserts(ms, dedupInserts)
 		metadataState = ms

--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -256,37 +256,27 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 		cancel()
 	}
 
-	var metadataState *types.MetadataState
+	var metadataState any
 	var closeErr error
 	if mtState != nil {
-		metadataState, closeErr = types.SetMetadataState(*mtState, threadID)
-		if closeErr != nil {
-			closeErr = fmt.Errorf("failed to set metadata state: %s", closeErr)
+		ms, setErr := types.SetMetadataState(*mtState, threadID)
+		if setErr != nil {
+			closeErr = fmt.Errorf("failed to set metadata state: %s", setErr)
 		}
-		if dedupInserts != nil {
-			metadataState.DedupInserts = dedupInserts
-		}
-	}
-
-	// closeArg must be a true nil interface (not a typed nil pointer) when metadataState is nil.
-	// A typed nil *MetadataState stored in `any` is NOT nil, which causes LegacyWriter.Close to
-	// marshal it as "null" and send a non-empty payload — skipping Java's else-branch that sets
-	// dedup_inserts=true and updates full_refresh_committed_ids.
-	var closeArg any
-	if metadataState != nil {
-		closeArg = metadataState
+		types.SetDedupInserts(ms, dedupInserts)
+		metadataState = ms
 	}
 
 	switch w := writer.(type) {
 	case *destination.WriterThread:
-		if threadErr := w.Close(ctx, closeArg); threadErr != nil {
+		if threadErr := w.Close(ctx, metadataState); threadErr != nil {
 			closeErr = fmt.Errorf("failed to close writer: %s", threadErr)
 		}
 	case map[string]*destination.WriterThread:
 		// Multiple writers keyed by stream ID
 		for streamID, inserter := range w {
 			if inserter != nil {
-				if threadErr := inserter.Close(ctx, closeArg); threadErr != nil {
+				if threadErr := inserter.Close(ctx, metadataState); threadErr != nil {
 					closeErr = fmt.Errorf("%s; failed closing writer[%s]: %s", closeErr, streamID, threadErr)
 				}
 			}

--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -247,7 +247,7 @@ func generateThreadID(streamID, hash string) string {
 // The writer parameter can be either:
 //   - *destination.WriterThread for a single writer
 //   - map[string]*destination.WriterThread for multiple writers keyed by stream ID
-func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *error, writer any, threadID string, mtState *any) {
+func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *error, writer any, threadID string, mtState *any, dedupInserts *bool) {
 	if r := recover(); r != nil {
 		*err = utils.Ternary(*err == nil, fmt.Errorf("panic recovered: %v", r), fmt.Errorf("%s: panic recovered: %v", *err, r)).(error)
 	}
@@ -256,12 +256,15 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 		cancel()
 	}
 
-	var metadataState any
+	var metadataState *types.MetadataState
 	var closeErr error
 	if mtState != nil {
 		metadataState, closeErr = types.SetMetadataState(*mtState, threadID)
 		if closeErr != nil {
 			closeErr = fmt.Errorf("failed to set metadata state: %s", closeErr)
+		}
+		if dedupInserts != nil {
+			metadataState.DedupInserts = dedupInserts
 		}
 	}
 

--- a/drivers/abstract/backfill.go
+++ b/drivers/abstract/backfill.go
@@ -65,7 +65,7 @@ func (a *AbstractDriver) Backfill(mainCtx context.Context, backfilledStreams cha
 			logger.Infof("finished chunk min[%v] and max[%v] of stream %s", chunk.Min, chunk.Max, stream.ID())
 		}(backfillCtx)
 
-		defer handleWriterCleanup(backfillCtx, backfillCtxCancel, &err, inserter, threadID, nil)
+		defer handleWriterCleanup(backfillCtx, backfillCtxCancel, &err, inserter, threadID, nil, nil)
 
 		if prevMetadataState != nil {
 			if slices.Contains(prevMetadataState.FullRefreshCommittedIDs, threadID) {

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -113,6 +113,9 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 	var finalMetadataState any
 	writers := make(map[string]*destination.WriterThread)
 	metadataStates := make(map[string]any)
+	// dedupInserts[id]=true → first CDC after backfill, inserts emit "i" (equality delete needed).
+	// false → steady-state CDC, inserts emit "c" (no equality delete).  Defaults to true.
+	dedupInserts := make(map[string]bool, len(streams))
 
 	for _, stream := range streams {
 		threadID := generateThreadID(stream.ID(), "")
@@ -122,8 +125,12 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		}
 		writers[stream.ID()] = w
 		var writerMetaState any
+		dedupInserts[stream.ID()] = true
 		if writerMeta != nil {
 			writerMetaState = writerMeta.State
+			if writerMeta.DedupInserts != nil {
+				dedupInserts[stream.ID()] = *writerMeta.DedupInserts
+			}
 		}
 		metadataStates[stream.ID()] = writerMetaState
 	}
@@ -134,7 +141,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		writer := writers[change.Stream.ID()]
 		olakeColumns := map[string]any{
 			constants.OlakeID:        utils.GetKeysHash(change.Data, change.Stream.GetStream().SourceDefinedPrimaryKey.Array()...),
-			constants.OpType:         mapChangeKindToOperationType(change.Kind),
+			constants.OpType:         mapInsertOpType(change.Kind, dedupInserts[change.Stream.ID()]),
 			constants.CdcTimestamp:   change.Timestamp,
 			constants.OlakeTimestamp: time.Now().UTC(),
 		}
@@ -149,18 +156,28 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 
 		return writer.Push(ctx, types.CreateRawRecord(filteredData, olakeColumns))
 	})
+
+	// On successful CDC, clear the dedup flag so subsequent syncs skip equality deletes.
+	if err == nil && finalMetadataState != nil {
+		f := false
+		finalMetadataState = &types.MetadataState{State: finalMetadataState, DedupInserts: &f}
+	}
+
 	return err
 }
 
-// mapChangeKindToOperationType converts CDC change kind to operation type code.
-// "delete" -> "d", "update" -> "u", "insert"/"create" -> "c"
-func mapChangeKindToOperationType(kind string) string {
+// mapInsertOpType returns the _op_type string for a CDC change.
+// Inserts emit "i" during the backfill overlap window (dedupInserts=true) and "c" otherwise.
+func mapInsertOpType(kind string, dedupInserts bool) string {
 	switch kind {
 	case "delete":
 		return "d"
 	case "update":
 		return "u"
-	default: // "insert", "create", etc.
+	default:
+		if dedupInserts {
+			return "i"
+		}
 		return "c"
 	}
 }

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -113,8 +113,8 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 	var finalMetadataState any
 	writers := make(map[string]*destination.WriterThread)
 	metadataStates := make(map[string]any)
-	// dedupInserts[id]=true → first CDC after backfill, inserts emit "i" (equality delete needed).
-	// false → steady-state CDC, inserts emit "c" (no equality delete).  Defaults to true.
+	// true (default) → overlap window open, inserts emit "i" (equality delete + write).
+	// false          → steady-state, inserts emit "c" (write only).
 	dedupInserts := make(map[string]bool, len(streams))
 
 	for _, stream := range streams {
@@ -158,7 +158,10 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 	})
 
 	// On successful CDC, clear the dedup flag so subsequent syncs skip equality deletes.
-	if err == nil && finalMetadataState != nil {
+	// Wrap unconditionally on success: drivers that return a nil state (e.g. Kafka) still
+	// need the flag persisted, and SetMetadataState drops a nil State via omitempty so
+	// the existing `state` Iceberg property is left untouched in that case.
+	if err == nil {
 		f := false
 		finalMetadataState = &types.MetadataState{State: finalMetadataState, DedupInserts: &f}
 	}

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -142,7 +142,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		writer := writers[change.Stream.ID()]
 		olakeColumns := map[string]any{
 			constants.OlakeID:        utils.GetKeysHash(change.Data, change.Stream.GetStream().SourceDefinedPrimaryKey.Array()...),
-			constants.OpType:         mapInsertOpType(change.Kind, dedupInserts[change.Stream.ID()]),
+			constants.OpType:         mapChangeKindToOperationType(change.Kind, dedupInserts[change.Stream.ID()]),
 			constants.CdcTimestamp:   change.Timestamp,
 			constants.OlakeTimestamp: time.Now().UTC(),
 		}
@@ -163,7 +163,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 
 // mapInsertOpType returns the _op_type string for a CDC change.
 // Inserts emit "i" during the backfill overlap window (dedupInserts=true) and "c" otherwise.
-func mapInsertOpType(kind string, dedupInserts bool) string {
+func mapChangeKindToOperationType(kind string, dedupInserts bool) string {
 	switch kind {
 	case "delete":
 		return "d"

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -126,11 +126,8 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		}
 		writers[stream.ID()] = w
 		var writerMetaState any
-		// STRICTCDC streams (e.g. Kafka) never have a backfill overlap window,
-		// so the dedup-insert window defaults to false (steady-state, emit "c" directly).
-		// Non-STRICTCDC streams default to true until state says otherwise.
-		isStrictCDC := stream.GetStream().SyncMode == types.STRICTCDC
-		dedupInserts[stream.ID()] = !isStrictCDC
+
+		dedupInserts[stream.ID()] = true
 		if writerMeta != nil {
 			writerMetaState = writerMeta.State
 			if writerMeta.DedupInserts != nil {

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -111,6 +111,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 	}()
 
 	var finalMetadataState any
+	clearDedup := false
 	writers := make(map[string]*destination.WriterThread)
 	metadataStates := make(map[string]any)
 	// true (default) → overlap window open, inserts emit "i" (equality delete + write).
@@ -135,7 +136,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		metadataStates[stream.ID()] = writerMetaState
 	}
 
-	defer handleWriterCleanup(cdcCtx, cdcCtxCancel, &err, writers, "", &finalMetadataState)
+	defer handleWriterCleanup(cdcCtx, cdcCtxCancel, &err, writers, "", &finalMetadataState, &clearDedup)
 
 	finalMetadataState, err = a.driver.StreamChanges(cdcCtx, streamIndex, metadataStates, func(ctx context.Context, change CDCChange) error {
 		writer := writers[change.Stream.ID()]
@@ -156,15 +157,6 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 
 		return writer.Push(ctx, types.CreateRawRecord(filteredData, olakeColumns))
 	})
-
-	// On successful CDC, clear the dedup flag so subsequent syncs skip equality deletes.
-	// Wrap unconditionally on success: drivers that return a nil state (e.g. Kafka) still
-	// need the flag persisted, and SetMetadataState drops a nil State via omitempty so
-	// the existing `state` Iceberg property is left untouched in that case.
-	if err == nil {
-		f := false
-		finalMetadataState = &types.MetadataState{State: finalMetadataState, DedupInserts: &f}
-	}
 
 	return err
 }

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -126,7 +126,11 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		}
 		writers[stream.ID()] = w
 		var writerMetaState any
-		dedupInserts[stream.ID()] = true
+		// STRICTCDC streams (e.g. Kafka) never have a backfill overlap window,
+		// so the dedup-insert window defaults to false (steady-state, emit "c" directly).
+		// Non-STRICTCDC streams default to true until state says otherwise.
+		isStrictCDC := stream.GetStream().SyncMode == types.STRICTCDC
+		dedupInserts[stream.ID()] = !isStrictCDC
 		if writerMeta != nil {
 			writerMetaState = writerMeta.State
 			if writerMeta.DedupInserts != nil {

--- a/drivers/abstract/incremental.go
+++ b/drivers/abstract/incremental.go
@@ -89,7 +89,7 @@ func (a *AbstractDriver) Incremental(mainCtx context.Context, pool *destination.
 			}(incrementalCtx)
 
 			var mtState any
-			defer handleWriterCleanup(incrementalCtx, incrementalCtxCancel, &err, inserter, threadID, &mtState)
+			defer handleWriterCleanup(incrementalCtx, incrementalCtxCancel, &err, inserter, threadID, &mtState, nil)
 
 			defer func() {
 				mtStateMap := map[string]any{primaryCursor: a.FormatCursorValue(maxPrimaryCursorValue)}

--- a/types/metadata_state.go
+++ b/types/metadata_state.go
@@ -10,23 +10,33 @@ type MetadataState struct {
 	ID                      any      `json:"id,omitempty"`
 	State                   any      `json:"state,omitempty"`
 	FullRefreshCommittedIDs []string `json:"full_refresh_committed_ids,omitempty"`
+	// DedupInserts signals whether CDC inserts must generate equality deletes.
+	// true (or nil) = backfill committed, first CDC not yet → inserts emit "i" (equality delete).
+	// false         = first CDC committed → inserts emit "c" (no equality delete, steady state).
+	DedupInserts *bool `json:"dedup_inserts,omitempty"`
 }
 
-// SetMetadataState creates a MetadataState with State always stored as a JSON string.
-// Callers must not pass a nil mtState; use the nil guard at the call site.
-// If mtState is already a string it is used directly; otherwise it is JSON-marshaled into string.
+// SetMetadataState returns a MetadataState with State stored as a JSON string.
+// If mtState is already a *MetadataState, its fields (e.g. DedupInserts) are preserved
+// and only ID/State are normalised; otherwise mtState itself becomes State.
 func SetMetadataState(mtState any, threadID string) (*MetadataState, error) {
-	metadataState := &MetadataState{ID: threadID}
+	result, rawState := &MetadataState{ID: threadID}, mtState
+	if existing, ok := mtState.(*MetadataState); ok {
+		result, rawState = existing, existing.State
+		if threadID != "" {
+			result.ID = threadID
+		}
+	}
 
-	if value, ok := mtState.(string); ok {
-		metadataState.State = value
+	if s, ok := rawState.(string); ok {
+		result.State = s
 	} else {
-		stateBytes, err := json.Marshal(mtState)
+		stateBytes, err := json.Marshal(rawState)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal metadata state: %s", err)
 		}
-		metadataState.State = string(stateBytes)
+		result.State = string(stateBytes)
 	}
 
-	return metadataState, nil
+	return result, nil
 }

--- a/types/metadata_state.go
+++ b/types/metadata_state.go
@@ -10,28 +10,34 @@ type MetadataState struct {
 	ID                      any      `json:"id,omitempty"`
 	State                   any      `json:"state,omitempty"`
 	FullRefreshCommittedIDs []string `json:"full_refresh_committed_ids,omitempty"`
-	// DedupInserts signals whether CDC inserts must generate equality deletes.
-	// true (or nil) = backfill committed, first CDC not yet → inserts emit "i" (equality delete).
-	// false         = first CDC committed → inserts emit "c" (no equality delete, steady state).
+	// nil/true = overlap window open -> inserts emit "i" (equality delete + write).
+	// false    = steady state -> inserts emit "c" (write only).
 	DedupInserts *bool `json:"dedup_inserts,omitempty"`
 }
 
 // SetMetadataState returns a MetadataState with State stored as a JSON string.
-// If mtState is already a *MetadataState, its fields (e.g. DedupInserts) are preserved
-// and only ID/State are normalised; otherwise mtState itself becomes State.
+// If mtState is already a *MetadataState, its non-State fields (DedupInserts,
+// FullRefreshCommittedIDs, etc.) are preserved on a *copy* of the input — the
+// caller's struct is never mutated. Otherwise mtState itself becomes State.
+// A nil rawState produces a result with State unset so it's omitted from JSON,
+// leaving any previously-persisted `state` property untouched downstream.
 func SetMetadataState(mtState any, threadID string) (*MetadataState, error) {
 	result, rawState := &MetadataState{ID: threadID}, mtState
 	if existing, ok := mtState.(*MetadataState); ok {
-		result, rawState = existing, existing.State
+		clone := *existing
+		result, rawState = &clone, existing.State
 		if threadID != "" {
 			result.ID = threadID
 		}
 	}
 
-	if s, ok := rawState.(string); ok {
+	switch s := rawState.(type) {
+	case nil:
+		// leave result.State unset; omitempty drops it from the marshaled JSON
+	case string:
 		result.State = s
-	} else {
-		stateBytes, err := json.Marshal(rawState)
+	default:
+		stateBytes, err := json.Marshal(s)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal metadata state: %s", err)
 		}

--- a/types/metadata_state.go
+++ b/types/metadata_state.go
@@ -10,7 +10,7 @@ type MetadataState struct {
 	ID                      any      `json:"id,omitempty"`
 	State                   any      `json:"state,omitempty"`
 	FullRefreshCommittedIDs []string `json:"full_refresh_committed_ids,omitempty"`
-	// nil/true = overlap window open -> inserts emit "i" (equality delete + write).
+	// nil/true = overlap window open -> inserts emit "i" (equality delete + write), prevents phantom reads
 	// false    = steady state -> inserts emit "c" (write only).
 	DedupInserts *bool `json:"dedup_inserts,omitempty"`
 }

--- a/types/metadata_state.go
+++ b/types/metadata_state.go
@@ -15,34 +15,21 @@ type MetadataState struct {
 	DedupInserts *bool `json:"dedup_inserts,omitempty"`
 }
 
-// SetMetadataState returns a MetadataState with State stored as a JSON string.
-// If mtState is already a *MetadataState, its non-State fields (DedupInserts,
-// FullRefreshCommittedIDs, etc.) are preserved on a *copy* of the input — the
-// caller's struct is never mutated. Otherwise mtState itself becomes State.
-// A nil rawState produces a result with State unset so it's omitted from JSON,
-// leaving any previously-persisted `state` property untouched downstream.
+// SetMetadataState creates a MetadataState with State always stored as a JSON string.
+// Callers must not pass a nil mtState; use the nil guard at the call site.
+// If mtState is already a string it is used directly; otherwise it is JSON-marshaled into string.
 func SetMetadataState(mtState any, threadID string) (*MetadataState, error) {
-	result, rawState := &MetadataState{ID: threadID}, mtState
-	if existing, ok := mtState.(*MetadataState); ok {
-		clone := *existing
-		result, rawState = &clone, existing.State
-		if threadID != "" {
-			result.ID = threadID
-		}
-	}
+	metadataState := &MetadataState{ID: threadID}
 
-	switch s := rawState.(type) {
-	case nil:
-		// leave result.State unset; omitempty drops it from the marshaled JSON
-	case string:
-		result.State = s
-	default:
-		stateBytes, err := json.Marshal(s)
+	if value, ok := mtState.(string); ok {
+		metadataState.State = value
+	} else {
+		stateBytes, err := json.Marshal(mtState)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal metadata state: %s", err)
 		}
-		result.State = string(stateBytes)
+		metadataState.State = string(stateBytes)
 	}
 
-	return result, nil
+	return metadataState, nil
 }

--- a/types/metadata_state.go
+++ b/types/metadata_state.go
@@ -15,6 +15,13 @@ type MetadataState struct {
 	DedupInserts *bool `json:"dedup_inserts,omitempty"`
 }
 
+// SetDedupInserts sets DedupInserts on ms only when both ms and dedupInserts are non-nil.
+func SetDedupInserts(ms *MetadataState, dedupInserts *bool) {
+	if ms != nil && dedupInserts != nil {
+		ms.DedupInserts = dedupInserts
+	}
+}
+
 // SetMetadataState creates a MetadataState with State always stored as a JSON string.
 // Callers must not pass a nil mtState; use the nil guard at the call site.
 // If mtState is already a string it is used directly; otherwise it is JSON-marshaled into string.

--- a/utils/testutils/test_utils.go
+++ b/utils/testutils/test_utils.go
@@ -381,7 +381,7 @@ func (cfg *IntegrationTest) runSyncAndVerify(
 	schema map[string]interface{},
 	isCDC bool,
 ) error {
-	destDBPrefix := fmt.Sprintf("integration_%s", cfg.TestConfig.Driver)
+	destDBPrefix := utils.Ternary(cfg.TestConfig.DataFormat != "", fmt.Sprintf("integration_%s_%s", cfg.TestConfig.Driver, cfg.TestConfig.DataFormat), fmt.Sprintf("integration_%s", cfg.TestConfig.Driver)).(string)
 	cmd := syncCommand(*cfg.TestConfig, useState, destinationType, "--destination-database-prefix", destDBPrefix)
 
 	// Execute operation before sync if needed


### PR DESCRIPTION
# Description

Equality deletes are only required during the backfill→CDC overlap window. Track this with a new `dedup_inserts` flag in the Iceberg `olake_2pc` table property: Java sets it to `true` on backfill commit; Go clears it to `false` after the first successful CDC commit. While the flag is `true`, CDC inserts emit `_op_type="i"` (equality delete + write); otherwise `_op_type="c"` (write only). Applies to both the arrow writer and the legacy gRPC writer.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):