### PR TITLE
fix: logger not able to capture startup error

### DIFF
--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,6 +21,9 @@ import (
 )
 
 var logger zerolog.Logger
+var javaErrorLinePattern = regexp.MustCompile(`(?i)(ERROR|FATAL|Exception|Error:|Failed to|java\.lang\.\w+Exception|^\s*Caused by:)`)
+var javaStackTraceLinePattern = regexp.MustCompile(`^\s*at\s+[\w$.]+\([\w$]+\.java:\d+\)`)
+var startupCausePattern = regexp.MustCompile(`(?i)(failed to bind|address already in use|bindexception|eaddrinuse|caused by:|exception|error)`)
 
 // Info writes record into os.stdout with log level INFO
 func Info(v ...interface{}) {
@@ -78,24 +79,6 @@ func Warn(v ...interface{}) {
 // Warn writes record into os.stdout with log level WARN
 func Warnf(format string, v ...interface{}) {
 	logger.Warn().Msgf(format, v...)
-}
-
-func LogResponse(response *http.Response) {
-	respDump, err := httputil.DumpResponse(response, true)
-	if err != nil {
-		Fatal(err)
-	}
-
-	fmt.Println(string(respDump))
-}
-
-func LogRequest(req *http.Request) {
-	requestDump, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		Fatal(err)
-	}
-
-	fmt.Println(string(requestDump))
 }
 
 // CreateFile creates a new file or overwrites an existing one with the specified filename, path, extension,
@@ -244,12 +227,83 @@ type ProcessOutputReader struct {
 	reader    *bufio.Scanner
 	closeFn   func() error
 	closeOnce sync.Once
+	mu        sync.Mutex
 
 	// readiness detection only (do not fail on error logs)
 	readinessPattern *regexp.Regexp
 	readinessCh      chan struct{}
 	readinessOnce    sync.Once
-	errorLines       sync.Map // map[string]string → procKey -> first error line
+	tailLines        []string // rolling output lines for startup diagnostics
+	startupCauseLine string   // first meaningful startup failure line
+}
+
+func isJavaErrorLine(line string) bool {
+	return javaErrorLinePattern.MatchString(line) || javaStackTraceLinePattern.MatchString(line)
+}
+
+func (p *ProcessOutputReader) appendTail(line string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.tailLines = append(p.tailLines, line)
+	if len(p.tailLines) > 20 {
+		p.tailLines = p.tailLines[len(p.tailLines)-20:]
+	}
+}
+
+func (p *ProcessOutputReader) maybeSetStartupCauseLine(line string) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	// skip Java stacktrace frame lines like:
+	// "at io.grpc.internal...."
+	if strings.HasPrefix(trimmed, "at ") {
+		return
+	}
+
+	if !startupCausePattern.MatchString(trimmed) {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.startupCauseLine == "" {
+		p.startupCauseLine = trimmed
+	}
+}
+
+func (p *ProcessOutputReader) tailSummary() string {
+	p.mu.Lock()
+	lines := append([]string(nil), p.tailLines...) // new copy of tailLines
+	p.mu.Unlock()
+	if len(lines) == 0 {
+		return ""
+	}
+
+	filtered := make([]string, 0, len(lines))
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" {
+			continue
+		}
+		filtered = append(filtered, trimmed)
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+
+	const tailSize = 5
+	if len(filtered) > tailSize {
+		filtered = filtered[len(filtered)-tailSize:]
+	}
+	return strings.Join(filtered, " | ")
+}
+
+func (p *ProcessOutputReader) startupCause() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.startupCauseLine
 }
 
 // NewProcessOutputReader creates a new ProcessOutputReader for a given process
@@ -275,10 +329,6 @@ func NewProcessLogger(name string, isError bool) (*ProcessOutputReader, *os.File
 // StartReading starts reading from the process output in a goroutine
 // and logging each line with the appropriate log level
 func (p *ProcessOutputReader) StartReading() {
-	// Compile regex patterns for Java error detection
-	errorLinePattern := regexp.MustCompile(`(?i)(ERROR|FATAL|Exception|Error:|Failed to|java\.lang\.\w+Exception|^\s*Caused by:)`)
-	stackTraceLinePattern := regexp.MustCompile(`^\s*at\s+[\w$.]+\([\w$]+\.java:\d+\)`)
-
 	go func() {
 		defer p.Close()
 		// Track if we're in an error stack trace
@@ -287,12 +337,10 @@ func (p *ProcessOutputReader) StartReading() {
 		for p.reader.Scan() {
 			line := p.reader.Text()
 
-			// Check if this is an error line
-			isErrorLine := p.IsError || errorLinePattern.MatchString(line)
-			isStackTraceLine := stackTraceLinePattern.MatchString(line)
+			isErrorLine := isJavaErrorLine(line)
 
 			// Determine if we're starting or continuing an error
-			if isErrorLine || isStackTraceLine {
+			if isErrorLine {
 				inStackTrace = true
 			} else if inStackTrace && !strings.HasPrefix(strings.TrimSpace(line), "at ") {
 				// If this is not a stack trace line and doesn't start with "at ",
@@ -310,12 +358,18 @@ func (p *ProcessOutputReader) StartReading() {
 				})
 			}
 
-			if isErrorLine || isStackTraceLine || inStackTrace {
+			if isErrorLine || inStackTrace {
 				Error(fmt.Sprintf("%s %s", p.Name, line))
-				p.errorLines.LoadOrStore(p.Name, line)
+			} else if p.IsError {
+				// Stderr can contain informational runtime messages (e.g. JVM startup notes),
+				// so don't automatically mark all stderr lines as errors.
+				Warn(fmt.Sprintf("%s %s", p.Name, line))
 			} else {
 				Info(fmt.Sprintf("%s %s", p.Name, line))
 			}
+
+			p.maybeSetStartupCauseLine(line)
+			p.appendTail(line)
 		}
 	}()
 }
@@ -395,13 +449,6 @@ func SetupAndStartProcess(processName string, cmd *exec.Cmd) error {
 	// since they're only needed by the child process
 	stdoutWriter.Close()
 	stderrWriter.Close()
-	getFirstErrorLine := func(procKey string) string {
-		if v, ok := stderrReader.errorLines.Load(procKey); ok {
-			return v.(string)
-		}
-		return ""
-	}
-
 	timeoutSec := 600
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
@@ -432,6 +479,35 @@ func SetupAndStartProcess(processName string, cmd *exec.Cmd) error {
 	}()
 
 	// Block until ready, error, or timeout
+	getStartupOutput := func() string {
+		const maxWait = 500 * time.Millisecond
+		const step = 25 * time.Millisecond
+		deadline := time.Now().Add(maxWait)
+
+		for {
+			stderrCause := stderrReader.startupCause()
+			if stderrCause != "" {
+				return stderrCause
+			}
+			stdoutCause := stdoutReader.startupCause()
+			if stdoutCause != "" {
+				return stdoutCause
+			}
+			stderrTail := stderrReader.tailSummary()
+			if stderrTail != "" {
+				return stderrTail
+			}
+			stdoutTail := stdoutReader.tailSummary()
+			if stdoutTail != "" {
+				return stdoutTail
+			}
+			if time.Now().After(deadline) {
+				return ""
+			}
+			time.Sleep(step)
+		}
+	}
+
 	select {
 	case <-readyCh:
 		close(done)
@@ -445,21 +521,20 @@ func SetupAndStartProcess(processName string, cmd *exec.Cmd) error {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		// Include captured error tail from stderr only
-		stderrTail := getFirstErrorLine(processName)
-		if stderrTail == "" {
-			return fmt.Errorf("failed to start iceberg writer: %s", e)
+		startupOutput := getStartupOutput()
+		if startupOutput == "" {
+			return fmt.Errorf("failed to start %s: %s", processName, e)
 		}
-		return fmt.Errorf("failed to start iceberg writer: %s: %s", e, stderrTail)
+		return fmt.Errorf("failed to start %s: %s: %s", processName, e, startupOutput)
 	case <-ctx.Done():
 		close(done)
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		stderrTail := getFirstErrorLine(processName)
-		if stderrTail == "" {
-			return fmt.Errorf("iceberg writer %s did not become ready within %d seconds", processName, timeoutSec)
+		startupOutput := getStartupOutput()
+		if startupOutput == "" {
+			return fmt.Errorf("%s did not become ready within %d seconds", processName, timeoutSec)
 		}
-		return fmt.Errorf("iceberg writer %s did not become ready within %d seconds: %s", processName, timeoutSec, stderrTail)
+		return fmt.Errorf("%s did not become ready within %d seconds: %s", processName, timeoutSec, startupOutput)
 	}
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Prev:
 if user has set java tool options the first line contains that only and port retry not happen. 
Solution: 
This pr captures the error properly and decide to retry on port related issues

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Catalog Configuration failure
- [X] Passing java tool options and replicating exact same error 

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

error log : 
```
iceberg.OlakeRpcServer - Legacy writer enabled - registered OlakeRowsIngester service
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] Exception in thread "main" java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:50052
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.grpc.netty.NettyServer.start(NettyServer.java:333)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.internal.ServerImpl.start(ServerImpl.java:185)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.internal.ServerImpl.start(ServerImpl.java:94)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.debezium.server.iceberg.OlakeRpcServer.main(OlakeRpcServer.java:144)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] Caused by: java.net.BindException: Address already in use
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at java.base/sun.nio.ch.Net.bind0(Native Method)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at java.base/sun.nio.ch.Net.bind(Net.java:565)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at java.base/sun.nio.ch.ServerSocketChannelImpl.netBind(ServerSocketChannelImpl.java:344)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:301)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.socket.nio.NioServerSocketChannel.doBind(NioServerSocketChannel.java:141)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:561)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1331)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:600)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:579)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:972)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.AbstractChannel.bind(AbstractChannel.java:259)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:380)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2026-05-06T13:51:44Z ERROR Thread[public.dummy_users_min['(0,0)']-max['(32,0)']:50052] 	at java.base/java.lang.Thread.run(Thread.java:1583)
2026-05-06T13:51:45Z INFO Thread[public.dummy_users_min['(1056,0)']-max['(1088,0)']]: evolving schema in iceberg table
2026-05-06T13:51:45Z INFO Thread[public.dummy_users_min['(1056,0)']-max['(1088,0)']]: shutting down Iceberg server on port 50052
2026-05-06T13:51:45Z INFO Sync completed, wait 5 seconds cleanup in progress...
2026-05-06T13:51:50Z FATAL error occurred while reading records: error occurred while waiting for connections: failed to create new writer thread: failed to setup writer thread: failed to setup the writer thread: failed to start iceberg server: failed to start iceberg java writer and setup logger: failed to start iceberg writer: Thread[public.dummy_users_min['(1024,0)']-max['(1056,0)']:50052] exited before ready: exit status 1: Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

```
## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)
