### PR TITLE
feat: wire SIGINT/SIGTERM into root context for graceful shutdown

### DIFF
--- a/protocol/root.go
+++ b/protocol/root.go
@@ -1,9 +1,12 @@
 package protocol
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/drivers/abstract"
@@ -80,11 +83,36 @@ var RootCmd = &cobra.Command{
 	},
 }
 
+// CreateRootCommand wires the cobra root for the given driver. It mutates
+// package-level state (RootCmd, connector) and installs a process-wide signal
+// handler, so it must be called at most once per process — the existing
+// connector.RegisterDriver entry point already enforces this.
 func CreateRootCommand(_ bool, driver any) *cobra.Command {
 	RootCmd.AddCommand(commands...)
-	connector = abstract.NewAbstractDriver(RootCmd.Context(), driver.(abstract.DriverInterface))
+
+	// Wire SIGINT/SIGTERM into the root context so CDC, backfill and
+	// destination-writer paths reach their existing ctx.Done() branches on
+	// pod eviction, docker stop, or Ctrl-C, instead of being killed mid-read.
+	ctx := signalAwareRootContext(RootCmd.Context())
+	RootCmd.SetContext(ctx)
+
+	connector = abstract.NewAbstractDriver(ctx, driver.(abstract.DriverInterface))
 
 	return RootCmd
+}
+
+func signalAwareRootContext(parent context.Context) context.Context {
+	ctx, stop := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
+	// signal.NotifyContext keeps the signal handler installed until stop() is
+	// called. Releasing it after the first cancellation lets a subsequent
+	// SIGINT/SIGTERM fall through to the Go runtime default (terminate), which
+	// is the behavior an operator hitting Ctrl-C twice expects.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+
+	return ctx
 }
 
 func init() {

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -101,6 +101,23 @@ func CreateRootCommand(_ bool, driver any) *cobra.Command {
 	return RootCmd
 }
 
+// signalAwareRootContext wraps parent so that the returned context cancels on
+// SIGINT / SIGTERM as well as on any parent cancellation. Used to wire pod
+// eviction, docker stop, and Ctrl-C through to the existing ctx.Done()
+// branches in CDC, backfill, and destination-writer paths.
+//
+// Source / destination consistency on cancel is still owned by each
+// driver.PostCDC and destination writer.Close implementation. This wrapper only
+// makes process signals visible through ctx.Done(); it does not make source
+// checkpoints and destination commits atomic. Any implementation that performs
+// a final commit after work has been written must continue to check ctx.Done()
+// before that commit and must treat a canceled context as a reason to avoid
+// advancing only one side of the source/destination boundary.
+//
+// The Kafka driver has a separate `TODO: Add 2PC support for Kafka` for a
+// future stricter contract. Other drivers may have similar source-specific
+// checkpointing constraints, so this helper should not be used as a substitute
+// for driver-level cancellation safety.
 func signalAwareRootContext(parent context.Context) context.Context {
 	ctx, stop := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
 	// signal.NotifyContext keeps the signal handler installed until stop() is

--- a/protocol/root_test.go
+++ b/protocol/root_test.go
@@ -1,0 +1,59 @@
+package protocol
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSignalAwareRootContextCancelsOnSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process signal behavior differs on windows")
+	}
+
+	if os.Getenv("OLAKE_SIGNAL_CONTEXT_HELPER") == "1" {
+		ctx := signalAwareRootContext(context.Background())
+		proc, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := proc.Signal(syscall.SIGTERM); err != nil {
+			t.Fatal(err)
+		}
+
+		select {
+		case <-ctx.Done():
+			if ctx.Err() != context.Canceled {
+				t.Fatalf("expected canceled context, got %v", ctx.Err())
+			}
+			return
+		case <-time.After(time.Second):
+			t.Fatal("context was not canceled after SIGTERM")
+		}
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestSignalAwareRootContextCancelsOnSIGTERM")
+	cmd.Env = append(os.Environ(), "OLAKE_SIGNAL_CONTEXT_HELPER=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("signal helper failed: %v\n%s", err, output)
+	}
+}
+
+func TestSignalAwareRootContextPreservesParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	ctx := signalAwareRootContext(parent)
+	cancel()
+
+	select {
+	case <-ctx.Done():
+		if ctx.Err() != context.Canceled {
+			t.Fatalf("expected canceled context, got %v", ctx.Err())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("context was not canceled after parent cancellation")
+	}
+}

--- a/protocol/root_test.go
+++ b/protocol/root_test.go
@@ -10,18 +10,59 @@ import (
 	"time"
 )
 
-func TestSignalAwareRootContextCancelsOnSIGTERM(t *testing.T) {
+// TestSignalAwareRootContextCancelsOnSignal verifies that signalAwareRootContext
+// cancels the returned context when the process receives SIGINT or SIGTERM.
+//
+// The test re-execs itself in a child process per signal case so that we can
+// safely deliver a real OS signal without affecting the parent test runner.
+// The OLAKE_SIGNAL_CONTEXT_HELPER env var switches the binary into "helper"
+// mode; OLAKE_TEST_SIGNAL selects which signal the helper sends to itself.
+func TestSignalAwareRootContextCancelsOnSignal(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process signal behavior differs on windows")
 	}
 
+	tests := []struct {
+		name   string
+		signal syscall.Signal
+		env    string
+	}{
+		{
+			name:   "SIGTERM cancellation",
+			signal: syscall.SIGTERM,
+			env:    "SIGTERM",
+		},
+		{
+			name:   "SIGINT cancellation",
+			signal: syscall.SIGINT,
+			env:    "SIGINT",
+		},
+	}
+
+	// Helper-mode branch: runs inside the re-execed child. Installs the
+	// signal handler under test, sends the chosen signal to ourselves, and
+	// asserts the context cancels with context.Canceled within a bounded
+	// timeout.
 	if os.Getenv("OLAKE_SIGNAL_CONTEXT_HELPER") == "1" {
 		ctx := signalAwareRootContext(context.Background())
-		proc, err := os.FindProcess(os.Getpid())
+
+		var signal syscall.Signal
+
+		switch os.Getenv("OLAKE_TEST_SIGNAL") {
+		case "SIGTERM":
+			signal = syscall.SIGTERM
+		case "SIGINT":
+			signal = syscall.SIGINT
+		default:
+			t.Fatal("unknown test signal")
+		}
+
+		currentProcess, err := os.FindProcess(os.Getpid())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := proc.Signal(syscall.SIGTERM); err != nil {
+
+		if err := currentProcess.Signal(signal); err != nil {
 			t.Fatal(err)
 		}
 
@@ -30,19 +71,31 @@ func TestSignalAwareRootContextCancelsOnSIGTERM(t *testing.T) {
 			if ctx.Err() != context.Canceled {
 				t.Fatalf("expected canceled context, got %v", ctx.Err())
 			}
-			return
 		case <-time.After(time.Second):
-			t.Fatal("context was not canceled after SIGTERM")
+			t.Fatalf("context was not canceled after %v", signal)
 		}
+
+		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestSignalAwareRootContextCancelsOnSIGTERM")
-	cmd.Env = append(os.Environ(), "OLAKE_SIGNAL_CONTEXT_HELPER=1")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("signal helper failed: %v\n%s", err, output)
+	// Parent-mode branch: spawns one helper child per signal case and fails
+	// the subtest if the child exits non-zero.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=TestSignalAwareRootContextCancelsOnSignal")
+			cmd.Env = append(os.Environ(), "OLAKE_SIGNAL_CONTEXT_HELPER=1", "OLAKE_TEST_SIGNAL="+tt.env)
+
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("signal helper failed: %v\n%s", err, output)
+			}
+		})
 	}
 }
 
+// TestSignalAwareRootContextPreservesParentCancellation verifies that
+// cancelling the parent context still propagates through the signal-aware
+// wrapper. Without this, callers that cancel via context.WithCancel /
+// context.WithTimeout would be silently ignored after the wrap.
 func TestSignalAwareRootContextPreservesParentCancellation(t *testing.T) {
 	parent, cancel := context.WithCancel(context.Background())
 	ctx := signalAwareRootContext(parent)

--- a/protocol/root_test.go
+++ b/protocol/root_test.go
@@ -93,7 +93,7 @@ func TestSignalAwareRootContextCancelsOnSignal(t *testing.T) {
 }
 
 // TestSignalAwareRootContextPreservesParentCancellation verifies that
-// cancelling the parent context still propagates through the signal-aware
+// canceling the parent context still propagates through the signal-aware
 // wrapper. Without this, callers that cancel via context.WithCancel /
 // context.WithTimeout would be silently ignored after the wrap.
 func TestSignalAwareRootContextPreservesParentCancellation(t *testing.T) {


### PR DESCRIPTION
# Description

Wires SIGINT/SIGTERM into the cobra root context so the CDC, backfill and destination-writer paths reach their existing `ctx.Done()` branches on Kubernetes pod eviction, `docker stop` or Ctrl-C, instead of being killed mid-read.

Today there is no signal handling on master — `git grep -nE 'signal\.Notify|os\.Interrupt|syscall\.SIG(INT|TERM|HUP)'` returns no matches. The cancellation machinery downstream is already in place:

- `pkg/waljs/pgoutput.go` — pgoutput receive loop already has `case <-ctx.Done(): return nil`.
- `drivers/abstract/{backfill,cdc,incremental}.go` — dispatchers already accept and propagate `context.Context`.
- `utils/cxgroup.go` — `CxGroup` propagates cancellation automatically once its parent is signal-aware.

Only the root-level signal wiring was missing.

`protocol.CreateRootCommand` now wraps the cobra root context with `signal.NotifyContext(ctx, SIGINT, SIGTERM)` before `abstract.NewAbstractDriver` captures it, and calls `RootCmd.SetContext(ctx)` so every subcommand inherits a signal-aware context. The wiring is split into a small testable helper, `signalAwareRootContext`. A small watcher goroutine calls `stop()` after the first cancellation so a subsequent SIGINT/SIGTERM falls through to the Go runtime default (terminate), matching the behavior an operator hitting Ctrl-C twice expects.

```go
func CreateRootCommand(_ bool, driver any) *cobra.Command {
    RootCmd.AddCommand(commands...)
    ctx := signalAwareRootContext(RootCmd.Context())
    RootCmd.SetContext(ctx)
    connector = abstract.NewAbstractDriver(ctx, driver.(abstract.DriverInterface))
    return RootCmd
}

func signalAwareRootContext(parent context.Context) context.Context {
    ctx, stop := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
    go func() { <-ctx.Done(); stop() }() // restore default after first cancellation
    return ctx
}
```

**Scope** — signal wiring alone is not full graceful shutdown; it is the prerequisite. After this change, source/destination cancellation safety remains a per-driver/per-writer responsibility: each `PostCDC` and each destination `writer.Close` gates its final commit on `ctx.Done()`. Tested across drivers and destinations during review: Kafka + Parquet behaves consistently (offsets not committed, partial parquet files removed on cancel, retry reprocesses cleanly). For Postgres, the in-flight keepalive in `pkg/waljs/pgoutput.go` acknowledges the slot independently of the defer chain, so a SIGTERM landing between a keepalive and PostCDC can leave the slot ahead of `state.json`. This race exists with or without this PR's signal handling, worth its own follow-up ticket.

Fixes #926

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit tests in `protocol/root_test.go` — `TestSignalAwareRootContextCancelsOnSignal` (table-driven, re-execs a helper child per signal case covering both SIGINT and SIGTERM) and `TestSignalAwareRootContextPreservesParentCancellation` (asserts parent-cancel propagation through the wrapper).
- [x] Manual: built the Postgres driver image locally and ran `sync` against a disposable Postgres with logical replication and a CDC-generating writer. `docker stop -t 30` on the running container produced a non-`143` exit and the process reached the deferred cleanup path rather than being killed mid-read.

`go build ./...`, `go vet ./...`, `gofmt`, and `golangci-lint` are clean.

# Screenshots or Recordings
N/A — no UI/output changes.

## Documentation

- [x] N/A (internal signal-handling improvement, no user-facing surface change)

## Related PR's (If Any):
None.
