### PR TITLE
feat: add support for mssql read replica

### DIFF
--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -235,12 +235,9 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 		return nil
 	}
 
-	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table both require
-	// write access to the primary. Skip the management step and emit a clear warning so the
-	// operator is not surprised that schema-evolution handling is inactive.
-
-	// QUESTION (REMOVE BEFORE MERGE) - Should we fail or warn here if we are on a read replica?
-	if m.readReplica {
+	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table require
+	// write access to the primary.
+	if m.isReadReplica {
 		logger.Warnf("manage_capture_instances is enabled but the connection targets a read-only replica; capture instance management is skipped")
 		return nil
 	}
@@ -480,7 +477,7 @@ func operationTypeFromCDCCode(code int32) string {
 // current max LSN directly, accepting that the initial CDC window may overlap with the backfill
 // snapshot. Any resulting duplicates are handled by OLake's deduplication logic (in upsert mode).
 func (m *MSSQL) resolveInitialLSN(ctx context.Context) (string, error) {
-	if m.readReplica {
+	if m.isReadReplica {
 		logger.Infof("Skipping CDC agent catch-up wait on read replica; reading current max LSN directly")
 		return m.currentMaxLSN(ctx)
 	}

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -238,7 +238,7 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table require
 	// write access to the primary.
 	if m.isReadReplica {
-		logger.Warnf("manage_capture_instances is enabled but the connection targets a read-only replica; capture instance management is skipped")
+		logger.Debug("manage_capture_instances is enabled but the connection targets a read-only replica; capture instance management is skipped")
 		return nil
 	}
 
@@ -478,7 +478,7 @@ func operationTypeFromCDCCode(code int32) string {
 // snapshot. Any resulting duplicates are handled by OLake's deduplication logic (in upsert mode).
 func (m *MSSQL) resolveInitialLSN(ctx context.Context) (string, error) {
 	if m.isReadReplica {
-		logger.Infof("Skipping CDC agent catch-up wait on read replica; reading current max LSN directly")
+		logger.Debug("Skipping CDC agent catch-up wait on read replica; reading current max LSN directly")
 		return m.currentMaxLSN(ctx)
 	}
 

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -235,6 +235,14 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 		return nil
 	}
 
+	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table both require
+	// write access to the primary. Skip the management step and emit a clear warning so the
+	// operator is not surprised that schema-evolution handling is inactive.
+	if m.readReplica {
+		logger.Warnf("manage_capture_instances is enabled but the connection targets a read-only replica; capture instance management is skipped")
+		return nil
+	}
+
 	// Fetch DDL history for all streams in bulk
 	ddlHistoryQuery := jdbc.MSSQLCDCGetDDLHistoryBulkQuery(streamIDs)
 	rows, err := m.client.QueryContext(ctx, ddlHistoryQuery)
@@ -462,7 +470,16 @@ func operationTypeFromCDCCode(code int32) string {
 // has finished a non-throttled scan session (tran_count < maxtrans). A non-throttled session
 // means the agent fully drained the transaction log. We then read the max LSN, knowing it
 // reflects all committed transactions at that point.
+//
+// On read replicas the CDC agent does not run locally — change tables are replicated from the
+// primary. The agent catch-up race condition therefore cannot occur, so we skip the wait and
+// return the current max LSN directly.
 func (m *MSSQL) resolveInitialLSN(ctx context.Context) (string, error) {
+	if m.readReplica {
+		logger.Infof("Skipping CDC agent catch-up wait on read replica; reading current max LSN directly")
+		return m.currentMaxLSN(ctx)
+	}
+
 	var hasPermission bool
 	err := m.client.QueryRowContext(ctx, jdbc.MSSQLViewDatabaseStatePermissionQuery()).Scan(&hasPermission)
 	if err != nil {

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -238,6 +238,8 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table both require
 	// write access to the primary. Skip the management step and emit a clear warning so the
 	// operator is not surprised that schema-evolution handling is inactive.
+
+	// QUESTION (REMOVE BEFORE MERGE) - Should we fail or warn here if we are on a read replica?
 	if m.readReplica {
 		logger.Warnf("manage_capture_instances is enabled but the connection targets a read-only replica; capture instance management is skipped")
 		return nil
@@ -471,9 +473,12 @@ func operationTypeFromCDCCode(code int32) string {
 // means the agent fully drained the transaction log. We then read the max LSN, knowing it
 // reflects all committed transactions at that point.
 //
-// On read replicas the CDC agent does not run locally — change tables are replicated from the
-// primary. The agent catch-up race condition therefore cannot occur, so we skip the wait and
-// return the current max LSN directly.
+// On read replicas, the CDC agent does not run locally; change tables are replicated from the
+// primary, including any lag between the primary's base tables and its CDC change tables. The
+// detection mechanism used above (msdb.dbo.cdc_jobs, sys.dm_cdc_log_scan_sessions) is not
+// available on replicas, so we cannot wait for catch-up. We skip the wait and return the
+// current max LSN directly, accepting that the initial CDC window may overlap with the backfill
+// snapshot. Any resulting duplicates are handled by OLake's deduplication logic (in upsert mode).
 func (m *MSSQL) resolveInitialLSN(ctx context.Context) (string, error) {
 	if m.readReplica {
 		logger.Infof("Skipping CDC agent catch-up wait on read replica; reading current max LSN directly")

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/datazip-inc/olake/constants"
@@ -17,7 +18,7 @@ type Config struct {
 	Password               string            `json:"password"`
 	MaxThreads             int               `json:"max_threads"`
 	RetryCount             int               `json:"retry_count"`
-	JDBCURLParams          map[string]string `json:"jdbc_url_params,omitempty"`
+	JDBCURLParams          map[string]string `json:"jdbc_url_params"`
 	SSLConfiguration       *utils.SSLConfig  `json:"ssl"`
 	ManageCaptureInstances bool              `json:"manage_capture_instances"`
 	SSHConfig              *utils.SSHConfig  `json:"ssh_config"`
@@ -65,4 +66,43 @@ func (c *Config) Validate() error {
 	}
 
 	return utils.Validate(c)
+}
+
+// URI returns the sqlserver:// connection string for go-mssqldb.
+func (c *Config) URI() string {
+	host := c.Host
+	if !strings.Contains(host, ":") {
+		host = fmt.Sprintf("%s:%d", host, c.Port)
+	}
+
+	query := url.Values{}
+
+	for k, v := range c.JDBCURLParams {
+		query.Add(k, v)
+	}
+
+	query.Set("database", c.Database)
+
+	if c.SSLConfiguration == nil {
+		query.Set("encrypt", "disable")
+	} else {
+		switch string(c.SSLConfiguration.Mode) {
+		case utils.SSLModeDisable:
+			query.Set("encrypt", "disable")
+		case utils.SSLModeRequire:
+			query.Set("encrypt", "true")
+			query.Set("TrustServerCertificate", "true")
+		default:
+			query.Set("encrypt", "disable")
+		}
+	}
+
+	u := &url.URL{
+		Scheme:   "sqlserver",
+		User:     url.UserPassword(c.Username, c.Password),
+		Host:     host,
+		RawQuery: query.Encode(),
+	}
+
+	return u.String()
 }

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -10,16 +10,17 @@ import (
 
 // Config represents the configuration for connecting to a MSSQL database.
 type Config struct {
-	Host                   string           `json:"host"`
-	Port                   int              `json:"port"`
-	Database               string           `json:"database"`
-	Username               string           `json:"username"`
-	Password               string           `json:"password"`
-	MaxThreads             int              `json:"max_threads"`
-	RetryCount             int              `json:"retry_count"`
-	SSLConfiguration       *utils.SSLConfig `json:"ssl"`
-	ManageCaptureInstances bool             `json:"manage_capture_instances"`
-	SSHConfig              *utils.SSHConfig `json:"ssh_config"`
+	Host                   string            `json:"host"`
+	Port                   int               `json:"port"`
+	Database               string            `json:"database"`
+	Username               string            `json:"username"`
+	Password               string            `json:"password"`
+	MaxThreads             int               `json:"max_threads"`
+	RetryCount             int               `json:"retry_count"`
+	JDBCURLParams          map[string]string `json:"jdbc_url_params,omitempty"`
+	SSLConfiguration       *utils.SSLConfig  `json:"ssl"`
+	ManageCaptureInstances bool              `json:"manage_capture_instances"`
+	SSHConfig              *utils.SSHConfig  `json:"ssh_config"`
 }
 
 // Validate checks and normalises MSSQL configuration.

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -181,6 +181,7 @@ func TestConfig_URI(t *testing.T) {
 				}
 			}(),
 			expectedContains: []string{
+				"mssql-host:1433",
 				"ApplicationIntent=ReadOnly",
 				"MultiSubnetFailover=true",
 			},
@@ -198,6 +199,7 @@ func TestConfig_URI(t *testing.T) {
 				},
 			},
 			expectedContains: []string{
+				"mssql-host:1433",
 				"database=realdb",
 			},
 			notExpected: []string{
@@ -218,6 +220,7 @@ func TestConfig_URI(t *testing.T) {
 				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeDisable},
 			},
 			expectedContains: []string{
+				"mssql-host:1433",
 				"encrypt=disable",
 			},
 		},
@@ -232,6 +235,7 @@ func TestConfig_URI(t *testing.T) {
 				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
 			},
 			expectedContains: []string{
+				"mssql-host:1433",
 				"encrypt=true",
 				"TrustServerCertificate=true",
 			},

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -150,7 +150,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestConfig_ConnectionString(t *testing.T) {
+func TestConfig_URI(t *testing.T) {
 	tests := []struct {
 		name             string
 		config           *Config
@@ -184,9 +184,24 @@ func TestConfig_ConnectionString(t *testing.T) {
 				"ApplicationIntent=ReadOnly",
 				"MultiSubnetFailover=true",
 			},
+		},
+		{
+			name: "config database overrides jdbc_url_params database",
+			config: &Config{
+				Host:     "mssql-host",
+				Port:     1433,
+				Database: "realdb",
+				Username: "sa",
+				Password: "Password!123",
+				JDBCURLParams: map[string]string{
+					"database": "wrongdb",
+				},
+			},
+			expectedContains: []string{
+				"database=realdb",
+			},
 			notExpected: []string{
-				"invalid-ssl-config:0",
-				"tls=skip-verify",
+				"database=wrongdb",
 			},
 		},
 		{
@@ -206,6 +221,21 @@ func TestConfig_ConnectionString(t *testing.T) {
 				"encrypt=disable",
 			},
 		},
+		{
+			name: "ssl require sets encrypt and trust server certificate",
+			config: &Config{
+				Host:             "mssql-host",
+				Port:             1433,
+				Database:         "testdb",
+				Username:         "sa",
+				Password:         "Password!123",
+				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
+			},
+			expectedContains: []string{
+				"encrypt=true",
+				"TrustServerCertificate=true",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -222,7 +252,7 @@ func TestConfig_ConnectionString(t *testing.T) {
 				return
 			}
 
-			connStr := (&MSSQL{config: tt.config}).buildConnectionString()
+			connStr := tt.config.URI()
 
 			for _, expected := range tt.expectedContains {
 				if !strings.Contains(connStr, expected) {

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -2,9 +2,11 @@ package driver
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/testutils"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -143,6 +145,94 @@ func TestConfig_Validate(t *testing.T) {
 			}
 			if !tt.expectErr && err != nil {
 				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfig_ConnectionString(t *testing.T) {
+	tests := []struct {
+		name             string
+		config           *Config
+		expectError      bool
+		expectedContains []string
+		notExpected      []string
+	}{
+		{
+			name: "with jdbc url params",
+			config: func() *Config {
+				certs := testutils.GenerateTestCerts()
+				return &Config{
+					Host:     "mssql-host",
+					Port:     1433,
+					Database: "testdb",
+					Username: "sa",
+					Password: "Password!123",
+					JDBCURLParams: map[string]string{
+						"ApplicationIntent":   "ReadOnly",
+						"MultiSubnetFailover": "true",
+					},
+					SSLConfiguration: &utils.SSLConfig{
+						Mode:       utils.SSLModeVerifyFull,
+						ServerCA:   certs.CACert,
+						ClientCert: certs.ClientCert,
+						ClientKey:  certs.ClientKey,
+					},
+				}
+			}(),
+			expectedContains: []string{
+				"ApplicationIntent=ReadOnly",
+				"MultiSubnetFailover=true",
+			},
+			notExpected: []string{
+				"invalid-ssl-config:0",
+				"tls=skip-verify",
+			},
+		},
+		{
+			name: "ssl mode overrides jdbc_url_params encrypt",
+			config: &Config{
+				Host:     "mssql-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "sa",
+				Password: "Password!123",
+				JDBCURLParams: map[string]string{
+					"encrypt": "true",
+				},
+				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeDisable},
+			},
+			expectedContains: []string{
+				"encrypt=disable",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("failed to validate config: %v", err)
+				return
+			}
+
+			connStr := (&MSSQL{config: tt.config}).buildConnectionString()
+
+			for _, expected := range tt.expectedContains {
+				if !strings.Contains(connStr, expected) {
+					t.Errorf("expected connection string to contain %q, got %s", expected, connStr)
+				}
+			}
+			for _, notExpected := range tt.notExpected {
+				if strings.Contains(connStr, notExpected) {
+					t.Errorf("expected connection string to NOT contain %q, got %s", notExpected, connStr)
+				}
 			}
 		})
 	}

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -150,6 +150,7 @@ func (m *MSSQL) buildConnectionString() string {
 		}
 	}
 
+	// Set encrypt parameter based on SSL configuration.
 	if m.config.SSLConfiguration == nil {
 		query.Add("encrypt", "disable")
 	} else {

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -24,15 +23,15 @@ import (
 )
 
 type MSSQL struct {
-	client       *sqlx.DB
-	config       *Config
-	state        *types.State
-	capturesMap  map[string][]captureInstance
-	lsnMap       sync.Map
-	streams      []types.StreamInterface
-	cdcSupported bool
-	readReplica  bool
-	sshClient    *ssh.Client
+	client        *sqlx.DB
+	config        *Config
+	state         *types.State
+	capturesMap   map[string][]captureInstance
+	lsnMap        sync.Map
+	streams       []types.StreamInterface
+	cdcSupported  bool
+	isReadReplica bool
+	sshClient     *ssh.Client
 }
 
 // GetConfigRef implements abstract.DriverInterface.
@@ -71,7 +70,7 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 	}
 
 	var client *sqlx.DB
-	connStr := m.buildConnectionString()
+	connStr := m.config.URI()
 
 	if m.sshClient != nil {
 		logger.Info("Connecting to MSSQL via SSH tunnel")
@@ -115,8 +114,8 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 	}
 	m.cdcSupported = cdcSupported
 
-	m.readReplica = m.detectReadReplica(ctx)
-	if m.readReplica {
+	m.isReadReplica = m.detectReadReplica(ctx)
+	if m.isReadReplica {
 		logger.Warnf("Connected to a read-only MSSQL replica; CDC capture instance management is disabled and agent catch-up wait will be skipped")
 	}
 	return nil
@@ -126,56 +125,13 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 // secondary replica. If detection fails, it logs a warning and returns false
 // so the driver still behaves as on a primary.
 func (m *MSSQL) detectReadReplica(ctx context.Context) bool {
-	var isReplica bool
-	err := m.client.QueryRowContext(ctx, jdbc.MSSQLIsReadReplicaQuery()).Scan(&isReplica)
+	var isReadReplica bool
+	err := m.client.QueryRowContext(ctx, jdbc.MSSQLIsReadReplicaQuery()).Scan(&isReadReplica)
 	if err != nil {
 		logger.Warnf("could not determine read replica status - assuming primary: %s", err)
 		return false
 	}
-	return isReplica
-}
-
-func (m *MSSQL) buildConnectionString() string {
-	host := m.config.Host
-	if !strings.Contains(host, ":") {
-		host = fmt.Sprintf("%s:%d", host, m.config.Port)
-	}
-
-	query := url.Values{}
-	query.Add("database", m.config.Database)
-
-	if len(m.config.JDBCURLParams) > 0 {
-		for k, v := range m.config.JDBCURLParams {
-			query.Add(k, v)
-		}
-	}
-
-	// Set encrypt parameter based on SSL configuration.
-	if m.config.SSLConfiguration == nil {
-		query.Add("encrypt", "disable")
-	} else {
-		sslmode := string(m.config.SSLConfiguration.Mode)
-		switch sslmode {
-		case utils.SSLModeDisable:
-			query.Add("encrypt", "disable")
-		case utils.SSLModeRequire:
-			query.Add("encrypt", "true")
-			// For "require" we trust the server certificate by default.
-			query.Add("TrustServerCertificate", "true")
-		default:
-			// Fallback to disable for unsupported modes (e.g., verify-ca, verify-full).
-			query.Add("encrypt", "disable")
-		}
-	}
-
-	u := &url.URL{
-		Scheme:   "sqlserver",
-		User:     url.UserPassword(m.config.Username, m.config.Password),
-		Host:     host,
-		RawQuery: query.Encode(),
-	}
-
-	return u.String()
+	return isReadReplica
 }
 
 // Close ensures proper cleanup

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -31,6 +31,7 @@ type MSSQL struct {
 	lsnMap       sync.Map
 	streams      []types.StreamInterface
 	cdcSupported bool
+	readReplica  bool
 	sshClient    *ssh.Client
 }
 
@@ -113,7 +114,25 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 		logger.Warnf("CDC is not supported")
 	}
 	m.cdcSupported = cdcSupported
+
+	m.readReplica = m.detectReadReplica(ctx)
+	if m.readReplica {
+		logger.Warnf("Connected to a read-only MSSQL replica; CDC capture instance management is disabled and agent catch-up wait will be skipped")
+	}
 	return nil
+}
+
+// detectReadReplica reports whether this connection targets a read-only
+// secondary replica. If detection fails, it logs a warning and returns false
+// so the driver still behaves as on a primary.
+func (m *MSSQL) detectReadReplica(ctx context.Context) bool {
+	var isReplica bool
+	err := m.client.QueryRowContext(ctx, jdbc.MSSQLIsReadReplicaQuery()).Scan(&isReplica)
+	if err != nil {
+		logger.Warnf("could not determine read replica status - assuming primary: %s", err)
+		return false
+	}
+	return isReplica
 }
 
 func (m *MSSQL) buildConnectionString() string {
@@ -125,7 +144,12 @@ func (m *MSSQL) buildConnectionString() string {
 	query := url.Values{}
 	query.Add("database", m.config.Database)
 
-	// Set encrypt parameter based on SSL configuration.
+	if len(m.config.JDBCURLParams) > 0 {
+		for k, v := range m.config.JDBCURLParams {
+			query.Add(k, v)
+		}
+	}
+
 	if m.config.SSLConfiguration == nil {
 		query.Add("encrypt", "disable")
 	} else {

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -116,7 +116,7 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 
 	m.isReadReplica = m.detectReadReplica(ctx)
 	if m.isReadReplica {
-		logger.Warnf("Connected to a read-only MSSQL replica; CDC capture instance management is disabled and agent catch-up wait will be skipped")
+		logger.Info("Connected to a read-only MSSQL replica; CDC capture instance management is disabled and agent catch-up wait will be skipped")
 	}
 	return nil
 }

--- a/drivers/mssql/resources/spec.json
+++ b/drivers/mssql/resources/spec.json
@@ -62,10 +62,9 @@
         "jdbc_url_params": {
             "type": "object",
             "title": "JDBC URL Parameters",
-            "description": "Additional connection parameters passed to the go-mssqldb driver (e.g. {\"ApplicationIntent\": \"ReadOnly\"} to route to a readable Always On secondary replica)",
-            "additionalProperties": {
-                "type": "string"
-            }
+            "description": "Additional connection parameters for the Go MSSQL driver",
+            "additionalProperties": true,
+            "default": {}
         },
         "manage_capture_instances": {
             "type": "boolean",

--- a/drivers/mssql/resources/spec.json
+++ b/drivers/mssql/resources/spec.json
@@ -59,6 +59,14 @@
                 "mode"
             ]
         },
+        "jdbc_url_params": {
+            "type": "object",
+            "title": "JDBC URL Parameters",
+            "description": "Additional connection parameters passed to the go-mssqldb driver (e.g. {\"ApplicationIntent\": \"ReadOnly\"} to route to a readable Always On secondary replica)",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "manage_capture_instances": {
             "type": "boolean",
             "title": "Manage Capture Instances",

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -669,13 +669,13 @@ func MSSQLCDCSupportQuery() string {
 	`
 }
 
-// MSSQLIsReadReplicaQuery returns SQL that yields whether the current connection
-// is to a read-only secondary replica.
+// MSSQLIsReadReplicaQuery returns SQL that yields whether the current
+// database is a read-only secondary replica in an Always On AG.
 func MSSQLIsReadReplicaQuery() string {
 	return `SELECT CAST(CASE
 		WHEN EXISTS (
 			SELECT 1 FROM sys.dm_hadr_database_replica_states
-			WHERE is_local = 1 AND is_primary_replica = 0
+			WHERE is_local = 1 AND is_primary_replica = 0 AND database_id = DB_ID()
 		) THEN 1
 		ELSE 0
 	END AS BIT)`

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -669,6 +669,18 @@ func MSSQLCDCSupportQuery() string {
 	`
 }
 
+// MSSQLIsReadReplicaQuery returns SQL that yields whether the current connection
+// is to a read-only secondary replica.
+func MSSQLIsReadReplicaQuery() string {
+	return `SELECT CAST(CASE
+		WHEN EXISTS (
+			SELECT 1 FROM sys.dm_hadr_database_replica_states
+			WHERE is_local = 1 AND is_primary_replica = 0
+		) THEN 1
+		ELSE 0
+	END AS BIT)`
+}
+
 // TODO: check about `sys.fn_cdc_get_min_lsn`
 // MSSQLCDCMaxLSNQuery returns the query to fetch the current maximum LSN for CDC
 func MSSQLCDCMaxLSNQuery() string {

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -196,9 +196,9 @@ const MSSQLUISchema = `{
     { "host": 12, "database": 12 },
     { "username": 12, "password": 12 },
     { "port": 12, "max_threads": 12 },
-    { "retry_count": 12, "ssl": 12 },
-    { "update_method": 12, "manage_capture_instances": 12 },
-    { "ssh_config": 12 }
+    { "retry_count": 12, "jdbc_url_params": 12 },
+    { "ssl": 12, "manage_capture_instances": 12 },
+    { "update_method": 12, "ssh_config": 12 }
   ],
   "ssl": {
     "ui:options": {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds optional jdbc_url_params to the MSSQL source config (e.g. read intent), detects Always On read secondaries after connect, and adjusts CDC so replica-safe paths are used (skip primary-only agent/msdb logic and skip capture-instance management on replicas). Spec and tests updated accordingly.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Scenario A
- Simulated a SQL Server **primary + readable secondary** using an Always On
Availability Group with `CLUSTER_TYPE = NONE` and ran OLake with secondary instance

- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):