### PR TITLE
fix(mongodb):  SRV ReadPreference decoupling & config robustness

### DIFF
--- a/drivers/mongodb/README.md
+++ b/drivers/mongodb/README.md
@@ -36,16 +36,18 @@ Add MongoDB credentials in following format in `config.json` file. To check more
       "username": "test",
       "password": "test",
       "authdb": "admin",
-      "replica-set": "rs0",
-      "read-preference": "secondaryPreferred",
+      "replica_set": "rs0",
+      "read_preference": "secondaryPreferred",
       "srv": false,
-      "server-ram": 16,
+      "server_ram": 16,
       "database": "database",
       "max_threads": 50,
       "backoff_retry_count": 2,
       "chunking_strategy":""
    }
 ```
+
+`read_preference` applies to both SRV and replica set connections. For SRV-based connections, set `srv` to `true` and leave `replica_set` empty.
 
 ## Commands
 ### Discover Command

--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -51,10 +51,14 @@ func (c *Config) URI() string {
 
 	if c.ReplicaSet != "" {
 		query.Set("replicaSet", c.ReplicaSet)
-		if c.ReadPreference == "" {
-			c.ReadPreference = constants.DefaultReadPreference
-		}
-		query.Set("readPreference", c.ReadPreference)
+	}
+
+	readPreference := c.ReadPreference
+	if readPreference == "" && (c.ReplicaSet != "" || c.Srv) {
+		readPreference = constants.DefaultReadPreference
+	}
+	if readPreference != "" {
+		query.Set("readPreference", readPreference)
 	}
 
 	host := strings.Join(c.Hosts, ",")

--- a/drivers/mongodb/internal/config_test.go
+++ b/drivers/mongodb/internal/config_test.go
@@ -1,0 +1,102 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfig_URI(t *testing.T) {
+	tests := []struct {
+		name             string
+		config           *Config
+		expectedContains []string
+		notExpected      []string
+	}{
+		{
+			// Leaves read preference unset for standalone non-SRV connections.
+			name: "without replica set or srv",
+			config: &Config{
+				Hosts:    []string{"mongo.internal:27017"},
+				Username: "mongodb",
+				Password: "secret",
+				AuthDB:   "admin",
+			},
+			expectedContains: []string{
+				"mongodb://mongodb:secret@mongo.internal:27017/",
+				"authSource=admin",
+			},
+			notExpected: []string{
+				"readPreference=",
+				"replicaSet=",
+			},
+		},
+		{
+			// Preserves the default read preference for replica set connections.
+			name: "with replica set and default read preference",
+			config: &Config{
+				Hosts:      []string{"mongo-1.internal:27017", "mongo-2.internal:27017"},
+				Username:   "mongodb",
+				Password:   "secret",
+				AuthDB:     "admin",
+				ReplicaSet: "rs0",
+			},
+			expectedContains: []string{
+				"replicaSet=rs0",
+				"readPreference=secondaryPreferred",
+			},
+		},
+		{
+			// Applies the default read preference for SRV-based connections.
+			name: "with srv and default read preference",
+			config: &Config{
+				Hosts:    []string{"cluster0.example.mongodb.net"},
+				Username: "mongodb",
+				Password: "secret",
+				AuthDB:   "admin",
+				Srv:      true,
+			},
+			expectedContains: []string{
+				"mongodb+srv://mongodb:secret@cluster0.example.mongodb.net/",
+				"readPreference=secondaryPreferred",
+			},
+			notExpected: []string{
+				"replicaSet=",
+			},
+		},
+		{
+			// Honors an explicit read preference without requiring a replica set name.
+			name: "with explicit read preference and no replica set",
+			config: &Config{
+				Hosts:          []string{"mongo.internal:27017"},
+				Username:       "mongodb",
+				Password:       "secret",
+				AuthDB:         "admin",
+				ReadPreference: "nearest",
+			},
+			expectedContains: []string{
+				"readPreference=nearest",
+			},
+			notExpected: []string{
+				"replicaSet=",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uri := tt.config.URI()
+
+			for _, expected := range tt.expectedContains {
+				if !strings.Contains(uri, expected) {
+					t.Errorf("expected URI to contain %q, got %s", expected, uri)
+				}
+			}
+
+			for _, notExpected := range tt.notExpected {
+				if strings.Contains(uri, notExpected) {
+					t.Errorf("expected URI to not contain %q, got %s", notExpected, uri)
+				}
+			}
+		})
+	}
+}

--- a/drivers/mongodb/internal/testdata/source.json
+++ b/drivers/mongodb/internal/testdata/source.json
@@ -3,10 +3,10 @@
     "username": "mongodb",
     "password": "secure_password123",
     "authdb": "admin",
-    "replica-set": "rs0",
-    "read-preference": "secondaryPreferred",
+    "replica_set": "rs0",
+    "read_preference": "secondaryPreferred",
     "srv": false,
-    "server-ram": 16,
+    "server_ram": 16,
     "database": "olake_mongodb_test",
     "max_threads": 5,
     "backoff_retry_count": 4

--- a/drivers/mongodb/resources/spec.json
+++ b/drivers/mongodb/resources/spec.json
@@ -52,7 +52,7 @@
         "read_preference": {
             "type": "string",
             "title": "Read Preference",
-            "description": "Read preference for MongoDB (e.g., secondaryPreferred)"
+            "description": "Read preference for MongoDB (e.g., secondaryPreferred). Applies to both SRV and replica set connections."
         },
         "replica_set": {
             "type": "string",


### PR DESCRIPTION
# Description

**Fixes #682 - MongoDB SRV ReadPreference bug**

This PR decouples the `read_preference` logic from the `replica_set` field in the MongoDB driver config. Previously, `read_preference` was only set if `replica_set` was non-empty, which broke SRV/Atlas connections and caused silent misconfigurations. Now, `read_preference` is always respected if provided, regardless of `replica_set` or `srv` mode. Also fixes hyphenated JSON keys in docs/tests, and clarifies SRV/replica set usage in documentation.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit tests: Added table-driven tests for all URI scenarios in `config_test.go`
- [x] Integration: Ran end-to-end proof script  with real MongoDB replica set and SRV cluster, verified all edge/breaking cases
- [x] Manual: Confirmed correct URI construction and sync for both SRV and replica set configs

# Screenshots or Recordings

<img width="1447" height="671" alt="image" src="https://github.com/user-attachments/assets/51773e9b-4523-41e1-a8fa-d095f9701eec" />

- [x] See attached proof video and script output

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

- N/A

---

**Checklist:**
- [x] Minimal, focused diff (no unrelated changes)
- [x] All edge/breaking cases verified
- [x] Automated proof attached
- [x] Reviewer feedback from past PRs incorporated