### PR TITLE
fix: pin primary key strictly to _id to ensure deterministic olake_id deduplication

### DIFF
--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -237,22 +237,8 @@ func (m *Mongo) ProduceSchema(ctx context.Context, streamName string) (*types.St
 		// initialize stream
 		collection := db.Collection(streamName)
 		stream := types.NewStream(streamName, db.Name(), nil)
-		// find primary keys
-		indexesCursor, err := collection.Indexes().List(ctx, options.ListIndexes())
-		if err != nil {
-			return nil, err
-		}
-		defer indexesCursor.Close(ctx)
-
-		for indexesCursor.Next(ctx) {
-			var indexes bson.M
-			if err := indexesCursor.Decode(&indexes); err != nil {
-				return nil, err
-			}
-			for key := range indexes["key"].(bson.M) {
-				stream.WithPrimaryKey(key)
-			}
-		}
+		// _id is the guaranteed unique, mandatory field in every MongoDB collection.
+		stream.WithPrimaryKey(constants.MongoPrimaryID)
 
 		// Define find options for fetching documents in ascending and descending order.
 		findOpts := []*options.FindOptions{

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -230,6 +230,7 @@ func (m *Mongo) GetStreamNames(ctx context.Context) ([]string, error) {
 	return streamNames, collections.Err()
 }
 
+// TODO: Add support for time series mongodb collections
 func (m *Mongo) ProduceSchema(ctx context.Context, streamName string) (*types.Stream, error) {
 	produceCollectionSchema := func(ctx context.Context, db *mongo.Database, streamName string) (*types.Stream, error) {
 		logger.Infof("producing type schema for stream [%s]", streamName)


### PR DESCRIPTION
# Description

This change resolves a critical deduplication issue in downstream Iceberg tables when syncing MongoDB collections. 

Previously, `ProduceSchema` iterated over all indexes of a collection and registered every indexed field as a primary key. Consequently, non-unique indexed fields were included in the stream's `SourceDefinedPrimaryKey` schema. 

Because `GetKeysHash` concatenates all available primary key values to compute the `_olake_id`, any update to a non-unique indexed field caused the document's `_olake_id` hash to change. This prevented Iceberg equality-deletes from matching previous records, resulting in duplicate entries instead of correct deduplicated upserts.

By specification, MongoDB guarantees that `_id` is:
1. **Mandatory** on every document in standard collections. [ref](https://www.mongodb.com/docs/manual/core/document/#the-_id-field)
2. **Globally Unique** within a collection (enforced by an undeletable unique index).

Pinning the primary key solely to `_id` ensures highly stable, performant, and perfectly deterministic record deduplication.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Deduplication is working fine during updates and deletes for the record, non unique indexed records.

# Screenshots or Recordings

N/A — Backend driver logic update.

## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):
