### PR TITLE
fix: db2 driver download failure in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Install DB2 CLI Driver
         run: |
           go run github.com/ibmdb/go_ibm_db/installer@v0.5.4
-          echo "IBM_DB_HOME=$(go env GOPATH)/pkg/mod/github.com/ibmdb/clidriver" >> $GITHUB_ENV
-          IBM_DB_HOME=$(go env GOPATH)/pkg/mod/github.com/ibmdb/clidriver
+          cp -r "$(go env GOPATH)/pkg/mod/github.com/ibmdb/clidriver" ./clidriver
+          IBM_DB_HOME="$(pwd)/clidriver"
+          echo "IBM_DB_HOME=$IBM_DB_HOME" >> $GITHUB_ENV
           echo "CGO_CFLAGS=-I$IBM_DB_HOME/include" >> $GITHUB_ENV
           echo "CGO_LDFLAGS=-L$IBM_DB_HOME/lib -Wl,-rpath,$IBM_DB_HOME/lib" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$IBM_DB_HOME/lib" >> $GITHUB_ENV

--- a/drivers/db2/internal/db2.go
+++ b/drivers/db2/internal/db2.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// Test Run
 type DB2 struct {
 	client      *sqlx.DB
 	config      *Config

--- a/drivers/db2/internal/db2.go
+++ b/drivers/db2/internal/db2.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// Test Run
 type DB2 struct {
 	client      *sqlx.DB
 	config      *Config


### PR DESCRIPTION
# Description

DB2 integration tests run `build.sh driver-db2` inside **fresh Docker containers** that only bind-mount the **repository workspace** as `/test-olake`. The workflow already installed the DB2 CLI driver on the runner via `go run github.com/ibmdb/go_ibm_db/installer@v0.5.4`, which **includes a GitHub mirror fallback** when IBM’s CDN is unavailable. That installer places `clidriver` under `$(go env GOPATH)/pkg/mod/github.com/ibmdb/clidriver` on the host.

`build.sh` has **no** such fallback: when no clidriver is found under `/opt/clidriver`, `$HOME/clidriver`, or `$(pwd)/clidriver`, it downloads only from `public.dhe.ibm.com` with plain `curl`. Containers never see the GOPATH install (it is **not** bind-mounted), so every Discover/Sync run tried that flaky IBM URL again and failed intermittently.

This change **copies** the already-installed `clidriver` into the workspace root (`./clidriver`). The workspace is what testcontainers mount, so `setup_db2_clidriver` finds `$(pwd)/clidriver` immediately and **never** hits the IBM CDN inside CI.

Fixes # <!-- replace with issue number if applicable -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] CI: `Integration` workflow — DB2 driver step

# Screenshots or Recordings

Before : Driver install used to get triggered

<img width="1138" height="658" alt="Screenshot 2026-05-16 at 5 04 26 AM" src="https://github.com/user-attachments/assets/2b87677c-bb88-4835-83ba-bd0b25d9f2d1" />

Now 

<img width="1064" height="522" alt="Screenshot 2026-05-16 at 5 03 19 AM" src="https://github.com/user-attachments/assets/05c7dbfd-3790-44c0-9bc0-d67a6a2d78bc" />


## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

N/A

---

### References (known flaky IBM CDN + mirrors)

- [doctrine/dbal#6629](https://github.com/doctrine/dbal/issues/6629) — intermittent `public.dhe.ibm.com` failures in CI
- [ibmdb/python-ibmdb#891](https://github.com/ibmdb/python-ibmdb/issues/891) — IBM CDN 500s; newer installer uses GitHub fallback
- [go_ibm_db installer v0.5.4 (fallback URL in source)](https://github.com/ibmdb/go_ibm_db/blob/v0.5.4/installer/setup.go)