### PR TITLE
feat(mongodb): capture full document on delete via pre-images

### DIFF
--- a/drivers/mongodb/internal/cdc.go
+++ b/drivers/mongodb/internal/cdc.go
@@ -46,7 +46,7 @@ func (m *Mongo) PreCDC(cdcCtx context.Context, streams []types.StreamInterface) 
 		collection := m.client.Database(stream.Namespace(), options.Database().SetReadConcern(readconcern.Majority())).Collection(stream.Name())
 		pipeline := mongo.Pipeline{
 			{{Key: "$match", Value: bson.D{
-				{Key: "operationType", Value: bson.D{{Key: "$in", Value: bson.A{"insert", "update", "delete"}}}},
+				{Key: "operationType", Value: bson.D{{Key: "$in", Value: bson.A{"insert", "update", "replace", "delete"}}}},
 			}}},
 		}
 
@@ -96,7 +96,7 @@ func (m *Mongo) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 	}
 	pipeline := mongo.Pipeline{
 		{{Key: "$match", Value: bson.D{
-			{Key: "operationType", Value: bson.D{{Key: "$in", Value: bson.A{"insert", "update", "delete"}}}},
+			{Key: "operationType", Value: bson.D{{Key: "$in", Value: bson.A{"insert", "update", "replace", "delete"}}}},
 		}}},
 	}
 	changeStreamOpts := options.ChangeStream().SetFullDocument(options.UpdateLookup).SetFullDocumentBeforeChange(options.WhenAvailable).SetMaxAwaitTime(maxAwait)
@@ -169,6 +169,8 @@ func (m *Mongo) handleChangeDoc(ctx context.Context, cursor *mongo.ChangeStream,
 		return fmt.Errorf("error while decoding: %s", err)
 	}
 
+	record.OperationType = normalizeOperationType(record.OperationType)
+
 	switch record.OperationType {
 	case "delete":
 		if record.FullDocumentBeforeChange != nil {
@@ -176,7 +178,7 @@ func (m *Mongo) handleChangeDoc(ctx context.Context, cursor *mongo.ChangeStream,
 		} else {
 			record.FullDocument = record.DocumentKey
 		}
-	case "update", "replace":
+	case "update":
 		if record.FullDocument == nil && record.FullDocumentBeforeChange != nil {
 			record.FullDocument = record.FullDocumentBeforeChange
 		}
@@ -306,4 +308,16 @@ func GetResumeToken(cursor *mongo.ChangeStream, streamID string) (string, error)
 	}
 
 	return token, nil
+}
+
+// normalizeOperationType maps MongoDB-specific operation types to the standard
+// set understood by the abstract CDC layer (insert, update, delete).
+// "replace" swaps the full document but keeps _id unchanged, so it is treated as an update.
+func normalizeOperationType(opType string) string {
+	switch opType {
+	case "replace":
+		return "update"
+	default:
+		return opType
+	}
 }

--- a/drivers/mongodb/internal/cdc.go
+++ b/drivers/mongodb/internal/cdc.go
@@ -29,11 +29,12 @@ const (
 var ErrIdleTermination = errors.New("change stream terminated due to idle timeout")
 
 type CDCDocument struct {
-	OperationType string              `json:"operationType"`
-	FullDocument  map[string]any      `json:"fullDocument"`
-	ClusterTime   primitive.Timestamp `json:"clusterTime"`
-	WallTime      primitive.DateTime  `json:"wallTime"`
-	DocumentKey   map[string]any      `json:"documentKey"`
+	OperationType            string              `json:"operationType"`
+	FullDocument             map[string]any      `json:"fullDocument"`
+	FullDocumentBeforeChange map[string]any      `json:"fullDocumentBeforeChange"`
+	ClusterTime              primitive.Timestamp `json:"clusterTime"`
+	WallTime                 primitive.DateTime  `json:"wallTime"`
+	DocumentKey              map[string]any      `json:"documentKey"`
 }
 
 func (m *Mongo) ChangeStreamConfig() (bool, bool, bool) {
@@ -98,7 +99,7 @@ func (m *Mongo) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 			{Key: "operationType", Value: bson.D{{Key: "$in", Value: bson.A{"insert", "update", "delete"}}}},
 		}}},
 	}
-	changeStreamOpts := options.ChangeStream().SetFullDocument(options.UpdateLookup).SetMaxAwaitTime(maxAwait)
+	changeStreamOpts := options.ChangeStream().SetFullDocument(options.UpdateLookup).SetFullDocumentBeforeChange(options.WhenAvailable).SetMaxAwaitTime(maxAwait)
 	collection := m.client.Database(stream.Namespace(), options.Database().SetReadConcern(readconcern.Majority())).Collection(stream.Name())
 
 	changeStreamOpts = changeStreamOpts.SetResumeAfter(map[string]any{cdcCursorField: prevResumeToken})
@@ -168,9 +169,17 @@ func (m *Mongo) handleChangeDoc(ctx context.Context, cursor *mongo.ChangeStream,
 		return fmt.Errorf("error while decoding: %s", err)
 	}
 
-	if record.OperationType == "delete" {
-		// replace full document(null) with documentKey
-		record.FullDocument = record.DocumentKey
+	switch record.OperationType {
+	case "delete":
+		if record.FullDocumentBeforeChange != nil {
+			record.FullDocument = record.FullDocumentBeforeChange
+		} else {
+			record.FullDocument = record.DocumentKey
+		}
+	case "update", "replace":
+		if record.FullDocument == nil && record.FullDocumentBeforeChange != nil {
+			record.FullDocument = record.FullDocumentBeforeChange
+		}
 	}
 
 	filterMongoObject(record.FullDocument)


### PR DESCRIPTION
# Description

Use fullDocumentBeforeChange (whenAvailable) in change stream options to return the complete document snapshot on delete events for MongoDB 6.0+ clusters with pre-images enabled. Falls back to documentKey
(_id only) for older versions or collections without pre-images, preserving existing behaviour.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):