### PR TITLE
fix: handle-toast-updates

### DIFF
--- a/pkg/waljs/pgoutput.go
+++ b/pkg/waljs/pgoutput.go
@@ -116,6 +116,9 @@ func (p *pgoutputReplicator) processPgoutputWAL(ctx context.Context, walData []b
 
 	switch msg := logicalMsg.(type) {
 	case *pglogrepl.RelationMessage:
+		if _, relationVisited := p.relationIDToMsgMap[msg.RelationID]; !relationVisited && msg.ReplicaIdentity != 'f' {
+			logger.Warnf("table[%s.%s] replica identity is not FULL, unchanged TOAST column values may be lost during CDC UPDATE events; set REPLICA IDENTITY FULL to avoid data loss", msg.Namespace, msg.RelationName)
+		}
 		p.relationIDToMsgMap[msg.RelationID] = msg
 		return nil
 	case *pglogrepl.BeginMessage:
@@ -136,7 +139,7 @@ func (p *pgoutputReplicator) processPgoutputWAL(ctx context.Context, walData []b
 	}
 }
 
-func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tuple *pglogrepl.TupleData, oldTuple *pglogrepl.TupleData) (map[string]any, error) {
+func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tuple, oldTuple *pglogrepl.TupleData) (map[string]any, error) {
 	data := make(map[string]any)
 	if tuple == nil {
 		return data, nil

--- a/pkg/waljs/pgoutput.go
+++ b/pkg/waljs/pgoutput.go
@@ -136,7 +136,7 @@ func (p *pgoutputReplicator) processPgoutputWAL(ctx context.Context, walData []b
 	}
 }
 
-func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tuple *pglogrepl.TupleData) (map[string]any, error) {
+func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tuple *pglogrepl.TupleData, oldTuple *pglogrepl.TupleData) (map[string]any, error) {
 	data := make(map[string]any)
 	if tuple == nil {
 		return data, nil
@@ -148,6 +148,9 @@ func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tu
 		}
 		colName := rel.Columns[idx].Name
 		colType := rel.Columns[idx].DataType
+		if col.DataType == pglogrepl.TupleDataTypeToast && oldTuple != nil && idx < len(oldTuple.Columns) {
+			col = oldTuple.Columns[idx]
+		}
 		if col.Data == nil {
 			data[colName] = nil
 			continue
@@ -175,7 +178,7 @@ func (p *pgoutputReplicator) emitInsert(ctx context.Context, m *pglogrepl.Insert
 		return nil
 	}
 
-	values, err := p.tupleValuesToMap(rel, m.Tuple)
+	values, err := p.tupleValuesToMap(rel, m.Tuple, nil)
 	if err != nil {
 		return err
 	}
@@ -200,7 +203,7 @@ func (p *pgoutputReplicator) emitUpdate(ctx context.Context, m *pglogrepl.Update
 		return nil
 	}
 
-	values, err := p.tupleValuesToMap(rel, m.NewTuple)
+	values, err := p.tupleValuesToMap(rel, m.NewTuple, m.OldTuple)
 	if err != nil {
 		return err
 	}
@@ -225,7 +228,7 @@ func (p *pgoutputReplicator) emitDelete(ctx context.Context, m *pglogrepl.Delete
 		return nil
 	}
 
-	values, err := p.tupleValuesToMap(rel, m.OldTuple)
+	values, err := p.tupleValuesToMap(rel, m.OldTuple, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/waljs/pgoutput.go
+++ b/pkg/waljs/pgoutput.go
@@ -151,6 +151,9 @@ func (p *pgoutputReplicator) tupleValuesToMap(rel *pglogrepl.RelationMessage, tu
 		}
 		colName := rel.Columns[idx].Name
 		colType := rel.Columns[idx].DataType
+		// On UPDATE, unchanged TOAST columns in the new tuple are marked TupleDataTypeToast.
+		// REPLICA IDENTITY FULL includes the complete old row and allows recovery of these values.
+		// DEFAULT, INDEX, and NOTHING do not provide old TOAST values, so recovery is not possible.
 		if col.DataType == pglogrepl.TupleDataTypeToast && oldTuple != nil && idx < len(oldTuple.Columns) {
 			col = oldTuple.Columns[idx]
 		}


### PR DESCRIPTION
# Description
Previously, unchanged TOAST columns in update events could be emitted as null values when pgoutput marked the column as unchanged and did not send the actual column data.
This behavior still exists for other replica identity modes.
The fix preserves the existing value from the old tuple for REPLICA IDENTITY FULL tables, preventing unchanged TOAST columns from becoming null after updates.

Fixes #984

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Tested INSERT, UPDATE, DELETE, and TRUNCATE events on tables with REPLICA IDENTITY FULL and compared results with staging. Verified the fix correctly preserves unchanged TOAST columns.
- [x] Tested INSERT, UPDATE, DELETE, and TRUNCATE events on tables with REPLICA IDENTITY DEFAULT and compared results with staging. Behavior matched staging.
- [x] Tested INSERT, UPDATE, DELETE, and TRUNCATE events on tables with REPLICA IDENTITY USING INDEX and compared results with staging. Behavior matched staging.
- [x] Tested INSERT and TRUNCATE events on tables with REPLICA IDENTITY NOTHING and compared results with staging. Behavior matched staging.
# Screenshots or Recordings
N/A

## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):