### PR TITLE
feat: add support for capture instance management on read replica

### DIFF
--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - name: Run vulnerability checks
         run: |
           govulncheck ./... >/tmp/govuln.txt 2>&1 || VULN_EXIT=$?

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -240,7 +240,7 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 	mgmtClient := m.client
 	if m.isReadReplica {
 		if m.primaryClient == nil {
-			logger.Warn("manage_capture_instances enabled on replica but no primary_config provided; skipping")
+			logger.Warn("manage_capture_instances enabled on replica but no primary_config provided. capture instance management is skipped")
 			return nil
 		}
 		mgmtClient = m.primaryClient

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -235,11 +235,15 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 		return nil
 	}
 
-	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table require
-	// write access to the primary.
+	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table require write access to the primary.
+	// When primary_config is provided, use that connection.
+	mgmtClient := m.client
 	if m.isReadReplica {
-		logger.Debug("manage_capture_instances is enabled but the connection targets a read-only replica; capture instance management is skipped")
-		return nil
+		if m.primaryClient == nil {
+			logger.Warn("manage_capture_instances enabled on replica but no primary_config provided; skipping")
+			return nil
+		}
+		mgmtClient = m.primaryClient
 	}
 
 	// Fetch DDL history for all streams in bulk
@@ -287,7 +291,7 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 		for idx, capture := range instances {
 			if idx != activeIdx && (currentCursorLSN == "" || capture.startLSN <= currentCursorLSN) {
 				query := jdbc.MSSQLCDCDisableCaptureInstanceQuery()
-				_, err := m.client.ExecContext(ctx, query, capture.schema, capture.table, capture.instanceName)
+				_, err := mgmtClient.ExecContext(ctx, query, capture.schema, capture.table, capture.instanceName)
 				if err != nil {
 					return fmt.Errorf("failed to delete obsolete capture instance %s for %s: %w", capture.instanceName, streamID, err)
 				}
@@ -311,7 +315,7 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 				newInstanceName := fmt.Sprintf("olake_%s_%d", streamPart, time.Now().Unix())
 
 				createCaptureInstanceQuery := jdbc.MSSQLCDCCreateCaptureInstanceQuery()
-				_, err := m.client.ExecContext(ctx, createCaptureInstanceQuery, latestCapture.schema, latestCapture.table, newInstanceName)
+				_, err := mgmtClient.ExecContext(ctx, createCaptureInstanceQuery, latestCapture.schema, latestCapture.table, newInstanceName)
 				if err != nil {
 					return fmt.Errorf("failed to create new capture instance for schema drift on %s: %w", streamID, err)
 				}

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -238,12 +238,11 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 	// Read replicas are read-only; sp_cdc_enable_table / sp_cdc_disable_table require write access to the primary.
 	// When primary_config is provided, use that connection.
 	mgmtClient := m.client
-	if m.isReadReplica {
-		if m.primaryClient == nil {
-			logger.Warn("manage_capture_instances enabled on replica but no primary_config provided. capture instance management is skipped")
-			return nil
-		}
+	if m.primaryClient != nil {
 		mgmtClient = m.primaryClient
+	} else if m.isReadReplica {
+		logger.Warn("manage_capture_instances enabled on read replica but no primary_config provided. capture instance management is skipped")
+		return nil
 	}
 
 	// Fetch DDL history for all streams in bulk

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -22,25 +22,30 @@ type Config struct {
 	SSLConfiguration       *utils.SSLConfig  `json:"ssl"`
 	ManageCaptureInstances bool              `json:"manage_capture_instances"`
 	SSHConfig              *utils.SSHConfig  `json:"ssh_config"`
+	PrimaryConfig          *PrimaryConfig    `json:"primary_config,omitempty"`
+}
+
+// PrimaryConfig holds connection details for the primary replica when the main
+// connection targets a read-only secondary.
+// Used exclusively for CDC capture instance management.
+type PrimaryConfig struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (p *PrimaryConfig) Validate() error {
+	if err := validateSQLConnection(p.Host, p.Port, p.Username, p.Password, true); err != nil {
+		return err
+	}
+	return utils.Validate(p)
 }
 
 // Validate checks and normalises MSSQL configuration.
 func (c *Config) Validate() error {
-	if c.Host == "" {
-		return fmt.Errorf("empty host name")
-	} else if strings.Contains(c.Host, "https") || strings.Contains(c.Host, "http") {
-		return fmt.Errorf("host should not contain http or https")
-	}
-
-	if c.Port <= 0 || c.Port > 65535 {
-		return fmt.Errorf("invalid port number: must be between 1 and 65535")
-	}
-
-	if c.Username == "" {
-		return fmt.Errorf("username is required")
-	}
-	if c.Password == "" {
-		return fmt.Errorf("password is required")
+	if err := validateSQLConnection(c.Host, c.Port, c.Username, c.Password, false); err != nil {
+		return err
 	}
 	if c.Database == "" {
 		return fmt.Errorf("database is required")
@@ -65,14 +70,52 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate ssl config: %s", err)
 	}
 
+	if c.PrimaryConfig != nil {
+		if err := c.PrimaryConfig.Validate(); err != nil {
+			return err
+		}
+	}
+
 	return utils.Validate(c)
+}
+
+func validateSQLConnection(host string, port int, username, password string, isPrimary bool) error {
+	prefix := utils.Ternary(isPrimary, "primary_config:", "").(string)
+	if host == "" {
+		return fmt.Errorf("%sempty host name", prefix)
+	}
+	if strings.Contains(host, "https") || strings.Contains(host, "http") {
+		return fmt.Errorf("%s host should not contain http or https", prefix)
+	}
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("%s invalid port number: must be between 1 and 65535", prefix)
+	}
+	if username == "" {
+		return fmt.Errorf("%s username is required", prefix)
+	}
+	if password == "" {
+		return fmt.Errorf("%s password is required", prefix)
+	}
+	return nil
 }
 
 // URI returns the sqlserver:// connection string for go-mssqldb.
 func (c *Config) URI() string {
-	host := c.Host
+	return c.buildURI(c.Host, c.Port, c.Username, c.Password)
+}
+
+// primaryURI returns the sqlserver:// connection string for the primary replica,
+// inheriting database, SSL, and JDBC params from the main config.
+func (c *Config) primaryURI() string {
+	if c.PrimaryConfig == nil {
+		return ""
+	}
+	return c.buildURI(c.PrimaryConfig.Host, c.PrimaryConfig.Port, c.PrimaryConfig.Username, c.PrimaryConfig.Password)
+}
+
+func (c *Config) buildURI(host string, port int, username, password string) string {
 	if !strings.Contains(host, ":") {
-		host = fmt.Sprintf("%s:%d", host, c.Port)
+		host = fmt.Sprintf("%s:%d", host, port)
 	}
 
 	query := url.Values{}
@@ -99,7 +142,7 @@ func (c *Config) URI() string {
 
 	u := &url.URL{
 		Scheme:   "sqlserver",
-		User:     url.UserPassword(c.Username, c.Password),
+		User:     url.UserPassword(username, password),
 		Host:     host,
 		RawQuery: query.Encode(),
 	}

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -70,7 +70,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate ssl config: %s", err)
 	}
 
-	if c.ManageCaptureInstances && c.PrimaryConfig != nil {
+	if c.ManageCaptureInstances && c.PrimaryConfig != nil && c.PrimaryConfig.Host != "" {
 		if err := c.PrimaryConfig.Validate(); err != nil {
 			return err
 		}
@@ -80,21 +80,21 @@ func (c *Config) Validate() error {
 }
 
 func validateSQLConnection(host string, port int, username, password string, isPrimaryNode bool) error {
-	prefix := utils.Ternary(isPrimaryNode, "primary_config:", "").(string)
+	prefix := utils.Ternary(isPrimaryNode, "primary_config: ", "").(string)
 	if host == "" {
-		return fmt.Errorf("%s empty host name", prefix)
+		return fmt.Errorf("%sempty host name", prefix)
 	}
 	if strings.Contains(host, "https") || strings.Contains(host, "http") {
-		return fmt.Errorf("%s host should not contain http or https", prefix)
+		return fmt.Errorf("%shost should not contain http or https", prefix)
 	}
 	if port <= 0 || port > 65535 {
-		return fmt.Errorf("%s invalid port number: must be between 1 and 65535", prefix)
+		return fmt.Errorf("%sinvalid port number: must be between 1 and 65535", prefix)
 	}
 	if username == "" {
-		return fmt.Errorf("%s username is required", prefix)
+		return fmt.Errorf("%susername is required", prefix)
 	}
 	if password == "" {
-		return fmt.Errorf("%s password is required", prefix)
+		return fmt.Errorf("%spassword is required", prefix)
 	}
 	return nil
 }

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -29,11 +29,10 @@ type Config struct {
 // connection targets a read-only secondary.
 // Used exclusively for CDC capture instance management.
 type PrimaryConfig struct {
-	Host          string            `json:"host"`
-	Port          int               `json:"port"`
-	Username      string            `json:"username"`
-	Password      string            `json:"password"`
-	JDBCURLParams map[string]string `json:"jdbc_url_params"`
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 func (p *PrimaryConfig) Validate() error {
@@ -71,7 +70,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate ssl config: %s", err)
 	}
 
-	if c.PrimaryConfig != nil && c.PrimaryConfig.Host != "" {
+	if c.ManageCaptureInstances && c.PrimaryConfig != nil {
 		if err := c.PrimaryConfig.Validate(); err != nil {
 			return err
 		}
@@ -107,7 +106,7 @@ func (c *Config) URI() string {
 
 // primaryURI returns the sqlserver:// connection string for the primary replica.
 func (c *Config) primaryURI() string {
-	if c.PrimaryConfig.Host == "" {
+	if c.PrimaryConfig == nil || c.PrimaryConfig.Host == "" {
 		return ""
 	}
 	return c.buildURI(
@@ -115,7 +114,7 @@ func (c *Config) primaryURI() string {
 		c.PrimaryConfig.Port,
 		c.PrimaryConfig.Username,
 		c.PrimaryConfig.Password,
-		c.PrimaryConfig.JDBCURLParams,
+		nil,
 	)
 }
 

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -29,10 +29,11 @@ type Config struct {
 // connection targets a read-only secondary.
 // Used exclusively for CDC capture instance management.
 type PrimaryConfig struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Host          string            `json:"host"`
+	Port          int               `json:"port"`
+	Username      string            `json:"username"`
+	Password      string            `json:"password"`
+	JDBCURLParams map[string]string `json:"jdbc_url_params"`
 }
 
 func (p *PrimaryConfig) Validate() error {
@@ -70,7 +71,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate ssl config: %s", err)
 	}
 
-	if c.PrimaryConfig != nil {
+	if c.PrimaryConfig != nil && c.PrimaryConfig.Host != "" {
 		if err := c.PrimaryConfig.Validate(); err != nil {
 			return err
 		}
@@ -79,10 +80,10 @@ func (c *Config) Validate() error {
 	return utils.Validate(c)
 }
 
-func validateSQLConnection(host string, port int, username, password string, isPrimary bool) error {
-	prefix := utils.Ternary(isPrimary, "primary_config:", "").(string)
+func validateSQLConnection(host string, port int, username, password string, isPrimaryNode bool) error {
+	prefix := utils.Ternary(isPrimaryNode, "primary_config:", "").(string)
 	if host == "" {
-		return fmt.Errorf("%sempty host name", prefix)
+		return fmt.Errorf("%s empty host name", prefix)
 	}
 	if strings.Contains(host, "https") || strings.Contains(host, "http") {
 		return fmt.Errorf("%s host should not contain http or https", prefix)
@@ -101,26 +102,31 @@ func validateSQLConnection(host string, port int, username, password string, isP
 
 // URI returns the sqlserver:// connection string for go-mssqldb.
 func (c *Config) URI() string {
-	return c.buildURI(c.Host, c.Port, c.Username, c.Password)
+	return c.buildURI(c.Host, c.Port, c.Username, c.Password, c.JDBCURLParams)
 }
 
-// primaryURI returns the sqlserver:// connection string for the primary replica,
-// inheriting database, SSL, and JDBC params from the main config.
+// primaryURI returns the sqlserver:// connection string for the primary replica.
 func (c *Config) primaryURI() string {
-	if c.PrimaryConfig == nil {
+	if c.PrimaryConfig.Host == "" {
 		return ""
 	}
-	return c.buildURI(c.PrimaryConfig.Host, c.PrimaryConfig.Port, c.PrimaryConfig.Username, c.PrimaryConfig.Password)
+	return c.buildURI(
+		c.PrimaryConfig.Host,
+		c.PrimaryConfig.Port,
+		c.PrimaryConfig.Username,
+		c.PrimaryConfig.Password,
+		c.PrimaryConfig.JDBCURLParams,
+	)
 }
 
-func (c *Config) buildURI(host string, port int, username, password string) string {
+func (c *Config) buildURI(host string, port int, username, password string, jdbcParams map[string]string) string {
 	if !strings.Contains(host, ":") {
 		host = fmt.Sprintf("%s:%d", host, port)
 	}
 
 	query := url.Values{}
 
-	for k, v := range c.JDBCURLParams {
+	for k, v := range jdbcParams {
 		query.Add(k, v)
 	}
 

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -166,24 +166,6 @@ func TestConfig_Validate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "invalid primary_config - empty host",
-			config: &Config{
-				Host:                   "replica-host",
-				Port:                   1433,
-				Database:               "testdb",
-				Username:               "sa",
-				Password:               "Password!123",
-				ManageCaptureInstances: true,
-				PrimaryConfig: &PrimaryConfig{
-					Host:     "",
-					Port:     1433,
-					Username: "sa",
-					Password: "PrimaryPass!123",
-				},
-			},
-			expectErr: true,
-		},
-		{
 			name: "invalid primary_config - bad port",
 			config: &Config{
 				Host:                   "replica-host",
@@ -220,7 +202,7 @@ func TestConfig_Validate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "primary_config with invalid creds ignored when manage_capture_instances is false",
+			name: "primary_config ignored when manage_capture_instances is false",
 			config: &Config{
 				Host:     "replica-host",
 				Port:     1433,
@@ -233,6 +215,19 @@ func TestConfig_Validate(t *testing.T) {
 					Username: "",
 					Password: "",
 				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "empty primary_config object ignored when manage_capture_instances is true",
+			config: &Config{
+				Host:                   "mssql-primary",
+				Port:                   1433,
+				Database:               "testdb",
+				Username:               "sa",
+				Password:               "Password!123",
+				ManageCaptureInstances: true,
+				PrimaryConfig:          &PrimaryConfig{},
 			},
 			expectErr: false,
 		},

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -168,11 +168,12 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid primary_config - empty host",
 			config: &Config{
-				Host:     "replica-host",
-				Port:     1433,
-				Database: "testdb",
-				Username: "sa",
-				Password: "Password!123",
+				Host:                   "replica-host",
+				Port:                   1433,
+				Database:               "testdb",
+				Username:               "sa",
+				Password:               "Password!123",
+				ManageCaptureInstances: true,
 				PrimaryConfig: &PrimaryConfig{
 					Host:     "",
 					Port:     1433,
@@ -185,11 +186,12 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid primary_config - bad port",
 			config: &Config{
-				Host:     "replica-host",
-				Port:     1433,
-				Database: "testdb",
-				Username: "sa",
-				Password: "Password!123",
+				Host:                   "replica-host",
+				Port:                   1433,
+				Database:               "testdb",
+				Username:               "sa",
+				Password:               "Password!123",
+				ManageCaptureInstances: true,
 				PrimaryConfig: &PrimaryConfig{
 					Host:     "primary-host",
 					Port:     -1,
@@ -202,11 +204,12 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "invalid primary_config - missing password",
 			config: &Config{
-				Host:     "replica-host",
-				Port:     1433,
-				Database: "testdb",
-				Username: "sa",
-				Password: "Password!123",
+				Host:                   "replica-host",
+				Port:                   1433,
+				Database:               "testdb",
+				Username:               "sa",
+				Password:               "Password!123",
+				ManageCaptureInstances: true,
 				PrimaryConfig: &PrimaryConfig{
 					Host:     "primary-host",
 					Port:     1433,
@@ -215,6 +218,23 @@ func TestConfig_Validate(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+		{
+			name: "primary_config with invalid creds ignored when manage_capture_instances is false",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "sa",
+				Password: "Password!123",
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "",
+					Port:     -1,
+					Username: "",
+					Password: "",
+				},
+			},
+			expectErr: false,
 		},
 	}
 
@@ -390,40 +410,6 @@ func TestConfig_PrimaryURI(t *testing.T) {
 				"replica-host",
 			},
 		},
-		{
-			name: "uses primary-specific jdbc params without read-only intent",
-			config: &Config{
-				Host:     "replica-host",
-				Port:     1433,
-				Database: "testdb",
-				Username: "replica_user",
-				Password: "ReplicaPass!123",
-				JDBCURLParams: map[string]string{
-					"ApplicationIntent": "ReadOnly",
-				},
-				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
-				PrimaryConfig: &PrimaryConfig{
-					Host:     "primary-host",
-					Port:     1433,
-					Username: "primary_user",
-					Password: "PrimaryPass!123",
-					JDBCURLParams: map[string]string{
-						"MultiSubnetFailover": "true",
-					},
-				},
-			},
-			expectedContains: []string{
-				"primary-host:1433",
-				"database=testdb",
-				"MultiSubnetFailover=true",
-				"encrypt=true",
-				"TrustServerCertificate=true",
-			},
-			notExpected: []string{
-				"ApplicationIntent=ReadOnly",
-				"replica-host",
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -511,29 +497,6 @@ func TestConfig_SSHConfigDeserialization(t *testing.T) {
 			wantHost: "bastion",
 			wantPort: 22,
 		},
-		{
-			name: "with primary_config jdbc params",
-			jsonData: `{
-				"host": "replica-host",
-				"port": 1433,
-				"database": "testdb",
-				"username": "sa",
-				"password": "Password!123",
-				"jdbc_url_params": {
-					"ApplicationIntent": "ReadOnly"
-				},
-				"primary_config": {
-					"host": "primary-host",
-					"port": 1433,
-					"username": "sa",
-					"password": "PrimaryPass!123",
-					"jdbc_url_params": {
-						"MultiSubnetFailover": "true"
-					}
-				}
-			}`,
-			wantSSH: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -566,16 +529,6 @@ func TestConfig_SSHConfigDeserialization(t *testing.T) {
 				}
 				if config.PrimaryConfig.Host != "primary-host" {
 					t.Errorf("Expected primary host primary-host, got %q", config.PrimaryConfig.Host)
-				}
-			case "with primary_config jdbc params":
-				if config.PrimaryConfig == nil {
-					t.Fatal("Expected primary_config to be present")
-				}
-				if config.PrimaryConfig.Host != "primary-host" {
-					t.Errorf("Expected primary host primary-host, got %q", config.PrimaryConfig.Host)
-				}
-				if config.PrimaryConfig.JDBCURLParams["MultiSubnetFailover"] != "true" {
-					t.Errorf("Expected primary jdbc_url_params MultiSubnetFailover=true, got %v", config.PrimaryConfig.JDBCURLParams)
 				}
 			}
 		})

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -132,6 +133,86 @@ func TestConfig_Validate(t *testing.T) {
 				Database: "",
 				Username: "sa",
 				Password: "Password!123",
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid config with primary_config",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "sa",
+				Password: "Password!123",
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "primary-host",
+					Port:     1433,
+					Username: "sa",
+					Password: "PrimaryPass!123",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid config with manage_capture_instances and no primary_config",
+			config: &Config{
+				Host:                   "replica-host",
+				Port:                   1433,
+				Database:               "testdb",
+				Username:               "sa",
+				Password:               "Password!123",
+				ManageCaptureInstances: true,
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid primary_config - empty host",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "sa",
+				Password: "Password!123",
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "",
+					Port:     1433,
+					Username: "sa",
+					Password: "PrimaryPass!123",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid primary_config - bad port",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "sa",
+				Password: "Password!123",
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "primary-host",
+					Port:     -1,
+					Username: "sa",
+					Password: "PrimaryPass!123",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid primary_config - missing password",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "sa",
+				Password: "Password!123",
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "primary-host",
+					Port:     1433,
+					Username: "sa",
+					Password: "",
+				},
 			},
 			expectErr: true,
 		},
@@ -272,6 +353,46 @@ func TestConfig_URI(t *testing.T) {
 	}
 }
 
+func TestConfig_PrimaryURI(t *testing.T) {
+	config := &Config{
+		Host:     "replica-host",
+		Port:     1433,
+		Database: "testdb",
+		Username: "replica_user",
+		Password: "ReplicaPass!123",
+		JDBCURLParams: map[string]string{
+			"ApplicationIntent": "ReadOnly",
+		},
+		SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
+		PrimaryConfig: &PrimaryConfig{
+			Host:     "primary-host",
+			Port:     1433,
+			Username: "primary_user",
+			Password: "PrimaryPass!123",
+		},
+	}
+
+	require.NoError(t, config.Validate())
+
+	connStr := config.primaryURI()
+
+	for _, expected := range []string{
+		"primary-host:1433",
+		"database=testdb",
+		"ApplicationIntent=ReadOnly",
+		"encrypt=true",
+		"TrustServerCertificate=true",
+	} {
+		if !strings.Contains(connStr, expected) {
+			t.Errorf("expected primary URI to contain %q, got %s", expected, connStr)
+		}
+	}
+
+	if strings.Contains(connStr, "replica-host") {
+		t.Errorf("expected primary URI to not contain replica host, got %s", connStr)
+	}
+}
+
 func TestConfig_SSHConfigDeserialization(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -312,6 +433,31 @@ func TestConfig_SSHConfigDeserialization(t *testing.T) {
 			}`,
 			wantSSH: false,
 		},
+		{
+			name: "with primary_config",
+			jsonData: `{
+				"host": "replica-host",
+				"port": 1433,
+				"database": "testdb",
+				"username": "sa",
+				"password": "Password!123",
+				"ssh_config": {
+					"host": "bastion",
+					"port": 22,
+					"username": "sshuser",
+					"password": "sshpass"
+				},
+				"primary_config": {
+					"host": "primary-host",
+					"port": 1433,
+					"username": "sa",
+					"password": "PrimaryPass!123"
+				}
+			}`,
+			wantSSH:  true,
+			wantHost: "bastion",
+			wantPort: 22,
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,6 +480,15 @@ func TestConfig_SSHConfigDeserialization(t *testing.T) {
 			} else {
 				if config.SSHConfig != nil {
 					t.Error("Expected SSH config to be nil")
+				}
+			}
+
+			if strings.Contains(tt.name, "primary_config") {
+				if config.PrimaryConfig == nil {
+					t.Fatal("Expected primary_config to be present")
+				}
+				if config.PrimaryConfig.Host != "primary-host" {
+					t.Errorf("Expected primary host primary-host, got %q", config.PrimaryConfig.Host)
 				}
 			}
 		})

--- a/drivers/mssql/internal/config_test.go
+++ b/drivers/mssql/internal/config_test.go
@@ -354,42 +354,95 @@ func TestConfig_URI(t *testing.T) {
 }
 
 func TestConfig_PrimaryURI(t *testing.T) {
-	config := &Config{
-		Host:     "replica-host",
-		Port:     1433,
-		Database: "testdb",
-		Username: "replica_user",
-		Password: "ReplicaPass!123",
-		JDBCURLParams: map[string]string{
-			"ApplicationIntent": "ReadOnly",
+	tests := []struct {
+		name             string
+		config           *Config
+		expectedContains []string
+		notExpected      []string
+	}{
+		{
+			name: "uses ssl from main config without primary jdbc params",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "replica_user",
+				Password: "ReplicaPass!123",
+				JDBCURLParams: map[string]string{
+					"ApplicationIntent": "ReadOnly",
+				},
+				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "primary-host",
+					Port:     1433,
+					Username: "primary_user",
+					Password: "PrimaryPass!123",
+				},
+			},
+			expectedContains: []string{
+				"primary-host:1433",
+				"database=testdb",
+				"encrypt=true",
+				"TrustServerCertificate=true",
+			},
+			notExpected: []string{
+				"ApplicationIntent=ReadOnly",
+				"replica-host",
+			},
 		},
-		SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
-		PrimaryConfig: &PrimaryConfig{
-			Host:     "primary-host",
-			Port:     1433,
-			Username: "primary_user",
-			Password: "PrimaryPass!123",
+		{
+			name: "uses primary-specific jdbc params without read-only intent",
+			config: &Config{
+				Host:     "replica-host",
+				Port:     1433,
+				Database: "testdb",
+				Username: "replica_user",
+				Password: "ReplicaPass!123",
+				JDBCURLParams: map[string]string{
+					"ApplicationIntent": "ReadOnly",
+				},
+				SSLConfiguration: &utils.SSLConfig{Mode: utils.SSLModeRequire},
+				PrimaryConfig: &PrimaryConfig{
+					Host:     "primary-host",
+					Port:     1433,
+					Username: "primary_user",
+					Password: "PrimaryPass!123",
+					JDBCURLParams: map[string]string{
+						"MultiSubnetFailover": "true",
+					},
+				},
+			},
+			expectedContains: []string{
+				"primary-host:1433",
+				"database=testdb",
+				"MultiSubnetFailover=true",
+				"encrypt=true",
+				"TrustServerCertificate=true",
+			},
+			notExpected: []string{
+				"ApplicationIntent=ReadOnly",
+				"replica-host",
+			},
 		},
 	}
 
-	require.NoError(t, config.Validate())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.config.Validate())
 
-	connStr := config.primaryURI()
+			connStr := tt.config.primaryURI()
 
-	for _, expected := range []string{
-		"primary-host:1433",
-		"database=testdb",
-		"ApplicationIntent=ReadOnly",
-		"encrypt=true",
-		"TrustServerCertificate=true",
-	} {
-		if !strings.Contains(connStr, expected) {
-			t.Errorf("expected primary URI to contain %q, got %s", expected, connStr)
-		}
-	}
-
-	if strings.Contains(connStr, "replica-host") {
-		t.Errorf("expected primary URI to not contain replica host, got %s", connStr)
+			for _, expected := range tt.expectedContains {
+				if !strings.Contains(connStr, expected) {
+					t.Errorf("expected primary URI to contain %q, got %s", expected, connStr)
+				}
+			}
+			for _, notExpected := range tt.notExpected {
+				if strings.Contains(connStr, notExpected) {
+					t.Errorf("expected primary URI to not contain %q, got %s", notExpected, connStr)
+				}
+			}
+		})
 	}
 }
 
@@ -458,6 +511,29 @@ func TestConfig_SSHConfigDeserialization(t *testing.T) {
 			wantHost: "bastion",
 			wantPort: 22,
 		},
+		{
+			name: "with primary_config jdbc params",
+			jsonData: `{
+				"host": "replica-host",
+				"port": 1433,
+				"database": "testdb",
+				"username": "sa",
+				"password": "Password!123",
+				"jdbc_url_params": {
+					"ApplicationIntent": "ReadOnly"
+				},
+				"primary_config": {
+					"host": "primary-host",
+					"port": 1433,
+					"username": "sa",
+					"password": "PrimaryPass!123",
+					"jdbc_url_params": {
+						"MultiSubnetFailover": "true"
+					}
+				}
+			}`,
+			wantSSH: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -483,12 +559,23 @@ func TestConfig_SSHConfigDeserialization(t *testing.T) {
 				}
 			}
 
-			if strings.Contains(tt.name, "primary_config") {
+			switch tt.name {
+			case "with primary_config":
 				if config.PrimaryConfig == nil {
 					t.Fatal("Expected primary_config to be present")
 				}
 				if config.PrimaryConfig.Host != "primary-host" {
 					t.Errorf("Expected primary host primary-host, got %q", config.PrimaryConfig.Host)
+				}
+			case "with primary_config jdbc params":
+				if config.PrimaryConfig == nil {
+					t.Fatal("Expected primary_config to be present")
+				}
+				if config.PrimaryConfig.Host != "primary-host" {
+					t.Errorf("Expected primary host primary-host, got %q", config.PrimaryConfig.Host)
+				}
+				if config.PrimaryConfig.JDBCURLParams["MultiSubnetFailover"] != "true" {
+					t.Errorf("Expected primary jdbc_url_params MultiSubnetFailover=true, got %v", config.PrimaryConfig.JDBCURLParams)
 				}
 			}
 		})

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -91,7 +91,7 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 		logger.Info("Connected to a read-only MSSQL replica; agent catch-up wait will be skipped")
 	}
 
-	if m.config.ManageCaptureInstances && m.config.PrimaryConfig != nil {
+	if m.config.ManageCaptureInstances && m.config.PrimaryConfig != nil && m.config.PrimaryConfig.Host != "" {
 		m.primaryClient, err = setupDBConnection(
 			ctx,
 			m.config.primaryURI(),

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -62,7 +62,15 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 	}
 
 	var err error
-	m.client, m.sshClient, err = setupDBConnection(ctx, m.config.URI(), m.config.Host, nil, m.config.SSHConfig, m.config.MaxThreads)
+	m.sshClient, err = setupSSH(m.config.SSHConfig)
+	if err != nil {
+		return fmt.Errorf("failed to setup SSH connection: %s", err)
+	}
+	if m.sshClient != nil {
+		logger.Info("Connecting to MSSQL via SSH tunnel")
+	}
+
+	m.client, err = setupDBConnection(ctx, m.config.URI(), m.sshClient, m.config.Host, m.config.MaxThreads)
 	if err != nil {
 		return fmt.Errorf("failed to connect to MSSQL: %s", err)
 	}
@@ -82,18 +90,17 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 	if m.isReadReplica {
 		logger.Info("Connected to a read-only MSSQL replica; agent catch-up wait will be skipped")
 		if m.config.ManageCaptureInstances && m.config.PrimaryConfig != nil {
-			m.primaryClient, _, err = setupDBConnection(
+			m.primaryClient, err = setupDBConnection(
 				ctx,
 				m.config.primaryURI(),
-				m.config.PrimaryConfig.Host,
 				m.sshClient,
-				m.config.SSHConfig,
+				m.config.PrimaryConfig.Host,
 				1,
 			)
 			if err != nil {
-				return fmt.Errorf("failed to connect to primary for capture instance management: %w", err)
+				return fmt.Errorf("failed to connect to primary for capture instance management: %s", err)
 			}
-			logger.Info("conected to primary MSSQL connection for capture instance management")
+			logger.Info("connected to primary node successfully for capture instance management")
 		}
 	}
 	return nil
@@ -136,54 +143,38 @@ func (m *MSSQL) Close() error {
 	return nil
 }
 
-// setupDBConnection opens a *sqlx.DB to SQL Server.
-func setupDBConnection(
-	ctx context.Context,
-	uri string,
-	host string,
-	existingSSH *ssh.Client,
-	sshCfg *utils.SSHConfig,
-	maxConns int,
-) (*sqlx.DB, *ssh.Client, error) {
-	sshTunnel := existingSSH
-	if sshTunnel == nil && sshCfg != nil && sshCfg.Host != "" {
-		var err error
-		sshTunnel, err = sshCfg.SetupSSHConnection()
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to setup SSH connection: %s", err)
-		}
-		logger.Info("established SSH tunnel connection successfully")
+func setupSSH(sshCfg *utils.SSHConfig) (*ssh.Client, error) {
+	if sshCfg == nil || sshCfg.Host == "" {
+		return nil, nil
 	}
 
-	var client *sqlx.DB
-	if sshTunnel != nil {
-		connector, err := mssql.NewConnector(uri)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create MSSQL connector: %s", err)
-		}
-		connector.Dialer = &mssqlSSHDialer{sshClient: sshTunnel, host: host}
-		client = sqlx.NewDb(sql.OpenDB(connector), "sqlserver")
-	} else {
-		db, err := sql.Open("sqlserver", uri)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to open MSSQL connection: %s", err)
-		}
-		client = sqlx.NewDb(db, "sqlserver")
+	sshClient, err := sshCfg.SetupSSHConnection()
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("established SSH tunnel connection successfully")
+	return sshClient, nil
+}
+
+func setupDBConnection(ctx context.Context, uri string, sshClient *ssh.Client, host string, maxConns int) (*sqlx.DB, error) {
+	connector, err := mssql.NewConnector(uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MSSQL connector: %s", err)
+	}
+	if sshClient != nil {
+		connector.Dialer = &mssqlSSHDialer{sshClient: sshClient, host: host}
 	}
 
+	client := sqlx.NewDb(sql.OpenDB(connector), "sqlserver")
 	client.SetMaxOpenConns(maxConns)
 
 	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := client.PingContext(pingCtx); err != nil {
-		return nil, nil, fmt.Errorf("failed to ping database: %s", err)
+		return nil, fmt.Errorf("failed to ping database: %s", err)
 	}
 
-	var newSSH *ssh.Client
-	if existingSSH == nil {
-		newSSH = sshTunnel
-	}
-	return client, newSSH, nil
+	return client, nil
 }
 
 type mssqlSSHDialer struct {

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -89,19 +89,20 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 	m.isReadReplica = m.detectReadReplica(ctx)
 	if m.isReadReplica {
 		logger.Info("Connected to a read-only MSSQL replica; agent catch-up wait will be skipped")
-		if m.config.ManageCaptureInstances && m.config.PrimaryConfig != nil {
-			m.primaryClient, err = setupDBConnection(
-				ctx,
-				m.config.primaryURI(),
-				m.sshClient,
-				m.config.PrimaryConfig.Host,
-				1,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to connect to primary for capture instance management: %s", err)
-			}
-			logger.Info("connected to primary node successfully for capture instance management")
+	}
+
+	if m.config.ManageCaptureInstances && m.config.PrimaryConfig != nil {
+		m.primaryClient, err = setupDBConnection(
+			ctx,
+			m.config.primaryURI(),
+			m.sshClient,
+			m.config.PrimaryConfig.Host,
+			1,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to connect to primary for capture instance management: %s", err)
 		}
+		logger.Info("connected to primary node successfully for capture instance management")
 	}
 	return nil
 }

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -32,6 +32,7 @@ type MSSQL struct {
 	cdcSupported  bool
 	isReadReplica bool
 	sshClient     *ssh.Client
+	primaryClient *sqlx.DB
 }
 
 // GetConfigRef implements abstract.DriverInterface.
@@ -60,49 +61,12 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 		return fmt.Errorf("failed to validate config: %s", err)
 	}
 
-	if m.config.SSHConfig != nil && m.config.SSHConfig.Host != "" {
-		logger.Info("Found SSH Configuration")
-		var err error
-		m.sshClient, err = m.config.SSHConfig.SetupSSHConnection()
-		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
-		}
+	var err error
+	m.client, m.sshClient, err = setupDBConnection(ctx, m.config.URI(), m.config.Host, nil, m.config.SSHConfig, m.config.MaxThreads)
+	if err != nil {
+		return fmt.Errorf("failed to connect to MSSQL: %s", err)
 	}
 
-	var client *sqlx.DB
-	connStr := m.config.URI()
-
-	if m.sshClient != nil {
-		logger.Info("Connecting to MSSQL via SSH tunnel")
-
-		connector, err := mssql.NewConnector(connStr)
-		if err != nil {
-			return fmt.Errorf("failed to create MSSQL connector: %s", err)
-		}
-
-		connector.Dialer = &mssqlSSHDialer{sshClient: m.sshClient, host: m.config.Host}
-
-		db := sql.OpenDB(connector)
-		client = sqlx.NewDb(db, "sqlserver")
-	} else {
-		db, err := sql.Open("sqlserver", connStr)
-		if err != nil {
-			return fmt.Errorf("failed to open MSSQL connection: %s", err)
-		}
-		client = sqlx.NewDb(db, "sqlserver")
-	}
-
-	// Set connection pool size
-	client.SetMaxOpenConns(m.config.MaxThreads)
-
-	// Test connection
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if err := client.PingContext(ctx); err != nil {
-		return fmt.Errorf("failed to ping database: %s", err)
-	}
-
-	m.client = client
 	m.config.RetryCount = utils.Ternary(m.config.RetryCount <= 0, 1, m.config.RetryCount+1).(int)
 	// Enable CDC support if database-level CDC is enabled
 	cdcSupported, err := m.isDatabaseCDCEnabled(ctx)
@@ -116,7 +80,21 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 
 	m.isReadReplica = m.detectReadReplica(ctx)
 	if m.isReadReplica {
-		logger.Info("Connected to a read-only MSSQL replica; CDC capture instance management is disabled and agent catch-up wait will be skipped")
+		logger.Info("Connected to a read-only MSSQL replica; agent catch-up wait will be skipped")
+		if m.config.ManageCaptureInstances && m.config.PrimaryConfig != nil {
+			m.primaryClient, _, err = setupDBConnection(
+				ctx,
+				m.config.primaryURI(),
+				m.config.PrimaryConfig.Host,
+				m.sshClient,
+				m.config.SSHConfig,
+				1,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to connect to primary for capture instance management: %w", err)
+			}
+			logger.Info("conected to primary MSSQL connection for capture instance management")
+		}
 	}
 	return nil
 }
@@ -143,6 +121,12 @@ func (m *MSSQL) Close() error {
 		}
 	}
 
+	if m.primaryClient != nil {
+		if err := m.primaryClient.Close(); err != nil {
+			logger.Errorf("failed to close primary MSSQL connection: %s", err)
+		}
+	}
+
 	if m.sshClient != nil {
 		if err := m.sshClient.Close(); err != nil {
 			logger.Errorf("failed to close SSH client: %s", err)
@@ -150,6 +134,56 @@ func (m *MSSQL) Close() error {
 	}
 
 	return nil
+}
+
+// setupDBConnection opens a *sqlx.DB to SQL Server.
+func setupDBConnection(
+	ctx context.Context,
+	uri string,
+	host string,
+	existingSSH *ssh.Client,
+	sshCfg *utils.SSHConfig,
+	maxConns int,
+) (*sqlx.DB, *ssh.Client, error) {
+	sshTunnel := existingSSH
+	if sshTunnel == nil && sshCfg != nil && sshCfg.Host != "" {
+		var err error
+		sshTunnel, err = sshCfg.SetupSSHConnection()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to setup SSH connection: %s", err)
+		}
+		logger.Info("established SSH tunnel connection successfully")
+	}
+
+	var client *sqlx.DB
+	if sshTunnel != nil {
+		connector, err := mssql.NewConnector(uri)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create MSSQL connector: %s", err)
+		}
+		connector.Dialer = &mssqlSSHDialer{sshClient: sshTunnel, host: host}
+		client = sqlx.NewDb(sql.OpenDB(connector), "sqlserver")
+	} else {
+		db, err := sql.Open("sqlserver", uri)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to open MSSQL connection: %s", err)
+		}
+		client = sqlx.NewDb(db, "sqlserver")
+	}
+
+	client.SetMaxOpenConns(maxConns)
+
+	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := client.PingContext(pingCtx); err != nil {
+		return nil, nil, fmt.Errorf("failed to ping database: %s", err)
+	}
+
+	var newSSH *ssh.Client
+	if existingSSH == nil {
+		newSSH = sshTunnel
+	}
+	return client, newSSH, nil
 }
 
 type mssqlSSHDialer struct {

--- a/drivers/mssql/resources/spec.json
+++ b/drivers/mssql/resources/spec.json
@@ -171,6 +171,55 @@
             ]
         }
     },
+    "dependencies": {
+        "manage_capture_instances": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "manage_capture_instances": {
+                            "const": true
+                        },
+                        "primary_config": {
+                            "type": "object",
+                            "title": "Primary Configuration",
+                            "description": "Connection details for the Always On primary replica. Required when the main connection targets a read-only secondary and capture instance management is enabled. Uses the same SSH tunnel as the main connection.",
+                            "properties": {
+                                "host": {
+                                    "type": "string",
+                                    "title": "Primary Host",
+                                    "description": "Host address of the primary replica"
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "title": "Primary Port",
+                                    "description": "Port number of the primary replica"
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "title": "Primary Username",
+                                    "description": "Username for connecting to the primary replica"
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "title": "Primary Password",
+                                    "description": "Password for connecting to the primary replica",
+                                    "format": "password",
+                                    "minLength": 1
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "manage_capture_instances": {
+                            "const": false
+                        }
+                    }
+                }
+            ]
+        }
+    },
     "required": [
         "host",
         "port",

--- a/drivers/mssql/resources/spec.json
+++ b/drivers/mssql/resources/spec.json
@@ -205,6 +205,13 @@
                                     "description": "Password for connecting to the primary replica",
                                     "format": "password",
                                     "minLength": 1
+                                },
+                                "jdbc_url_params": {
+                                    "type": "object",
+                                    "title": "Primary JDBC URL Parameters",
+                                    "description": "Additional connection parameters for the primary replica. Independent from the main connection JDBC URL parameters. Uses the same SSL settings as the main connection.",
+                                    "additionalProperties": true,
+                                    "default": {}
                                 }
                             }
                         }

--- a/drivers/mssql/resources/spec.json
+++ b/drivers/mssql/resources/spec.json
@@ -205,13 +205,6 @@
                                     "description": "Password for connecting to the primary replica",
                                     "format": "password",
                                     "minLength": 1
-                                },
-                                "jdbc_url_params": {
-                                    "type": "object",
-                                    "title": "Primary JDBC URL Parameters",
-                                    "description": "Additional connection parameters for the primary replica. Independent from the main connection JDBC URL parameters. Uses the same SSL settings as the main connection.",
-                                    "additionalProperties": true,
-                                    "default": {}
                                 }
                             }
                         }

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -713,14 +713,11 @@ func MSSQLCDCSupportQuery() string {
 	`
 }
 
-// MSSQLIsReadReplicaQuery returns SQL that yields whether the current
-// database is a read-only secondary replica in an Always On AG.
+// MSSQLIsReadReplicaQuery returns SQL that yields whether the current database
+// is read-only based on DATABASEPROPERTYEX Updateability.
 func MSSQLIsReadReplicaQuery() string {
 	return `SELECT CAST(CASE
-		WHEN EXISTS (
-			SELECT 1 FROM sys.dm_hadr_database_replica_states
-			WHERE is_local = 1 AND is_primary_replica = 0 AND database_id = DB_ID()
-		) THEN 1
+		WHEN DATABASEPROPERTYEX(DB_NAME(), 'Updateability') = N'READ_ONLY' THEN 1
 		ELSE 0
 	END AS BIT)`
 }

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -198,6 +198,7 @@ const MSSQLUISchema = `{
     { "port": 12, "max_threads": 12 },
     { "retry_count": 12, "jdbc_url_params": 12 },
     { "ssl": 12, "manage_capture_instances": 12 },
+    { "primary_config": 24 },
     { "update_method": 12, "ssh_config": 12 }
   ],
   "ssl": {
@@ -215,6 +216,19 @@ const MSSQLUISchema = `{
   },
   "manage_capture_instances": {
     "ui:widget": "boolean"
+  },
+  "primary_config": {
+    "ui:options": {
+      "title": false,
+      "description": false
+    },
+    "ui:grid": [
+      { "host": 12, "port": 12 },
+      { "username": 12, "password": 12 }
+    ],
+    "password": {
+      "ui:widget": "password"
+    }
   },
   "ssh_config": {
     "ui:options": {

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -224,7 +224,8 @@ const MSSQLUISchema = `{
     },
     "ui:grid": [
       { "host": 12, "port": 12 },
-      { "username": 12, "password": 12 }
+      { "username": 12, "password": 12 },
+      { "jdbc_url_params": 12 }
     ],
     "password": {
       "ui:widget": "password"

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -224,8 +224,7 @@ const MSSQLUISchema = `{
     },
     "ui:grid": [
       { "host": 12, "port": 12 },
-      { "username": 12, "password": 12 },
-      { "jdbc_url_params": 12 }
+      { "username": 12, "password": 12 }
     ],
     "password": {
       "ui:widget": "password"


### PR DESCRIPTION
# Description

## What
Adds optional `primary_config` to the MSSQL driver so capture instance management `(sp_cdc_enable_table / sp_cdc_disable_table)` can run against the Always On primary while ingestion stays on the read-only secondary.

## Why 
Read replicas cannot execute CDC write operations. When `manage_capture_instances` is enabled on a secondary, those calls were skipped entirely. This lets users connect to a readable replica for CDC reads while still managing capture instances on the primary.


## How
- Introduced `PrimaryConfig` (host, port, username, password) on the main config; database, SSL, and JDBC params are inherited from the main connection.
- Refactored connection setup into `setupDBConnection`; when on a replica with `manage_capture_instances + primary_config`, opens a second connection to the primary.
- Reuses the existing `ssh_config` tunnel for both connections (one bastion, two DB dials).
- Routes `sp_cdc_*` writes through primaryClient in manageCaptureInstances; DDL reads remain on the secondary.
- Updated `spec.json` and UI schema to expose `primary_config` when `manage_capture_instances` is enabled.

## Assumptions
- The primary and secondary nodes are accessible through the same ssh tunnel
- The primary and secondary nodes will have same ssl modes
- For primary node in ci mgmnt jdbc params are not required.


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #966

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Happy scenario , only host node provided (which happens to be primary). so capture instance is getting  created from main host and everything is working fine for fr+cdc and subsequent cdc sync.
- [x] only host node provided and it happens to be secondary , no primary node provided. sync runs for fr+cdc and cdc as well, but when alter table happens no ci management is done.
- [x] secondary is provided as main host and capture instance management is toggled on , and primary node is also provided there , in this case as well sync runs perfectly for fr+cdc, and subsequent cdc sync , also if alter table happens the ci is getting managed.
- [x] if both main host and ci mgmnt host are given , and we give the primary node in main host and the secondary in ci mgmnt host then too sync is running fine and capture instance is getting managed.
- [x] Tested it for ssh tunnel for both primary and secondary.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->
<img width="2412" height="346" alt="image" src="https://github.com/user-attachments/assets/384d3bfe-6935-47b6-908c-b1426e61008f" />

<img  height="300" alt="image" src="https://github.com/user-attachments/assets/e6088278-bd4f-4f4a-836a-5ad1a6061344" />


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):