### PR TITLE
fix(postgres): lsn mismatch validation when slot already matches metadata-committed LSN

### DIFF
--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -144,9 +144,11 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 	p.replicator = replicator
 
 	// validateGlobalState ensures slot and state agree before WAL replay begins.
-	// Skip it when remainingStreams is empty: all streams are already committed in
-	// Iceberg, so no WAL will be replayed and the slot/state relationship is irrelevant.
-	if len(remainingStreams) > 0 {
+	// Skip when remainingStreams is empty (all streams already committed in Iceberg), or
+	// when slot.confirmed_flush_lsn already equals the metadata-committed recovery LSN —
+	// the prior sync ack'd the slot but crashed before saving state, so all syncs were already committed
+	slotAtMetadataLSN := recoveryLSN != nil && slot.LSN == *recoveryLSN
+	if len(remainingStreams) > 0 && !slotAtMetadataLSN {
 		if err := validateGlobalState(postgresGlobalState, slot.LSN); err != nil {
 			return nil, fmt.Errorf("%s: invalid global state: %s", constants.ErrNonRetryable, err)
 		}


### PR DESCRIPTION
# Description

Fixes a Postgres CDC 2PC recovery failure that produces a non-retryable `lsn mismatch` error when the prior sync successfully committed data to Iceberg and acknowledged the replication slot, but crashed before writing `state.json`.

**Root cause:**

In a multi-stream CDC sync, Iceberg metadata is only updated for streams that actually wrote data files. If only one of several streams receives CDC changes, only that stream's Iceberg table metadata advances to the new LSN. The other streams have no rows to commit, so their metadata stays at the previous LSN.

On the next run, `StreamChanges` reads Iceberg metadata for all streams and classifies them:
- The stream whose metadata is ahead of `state.json` → added to `finishedStreams`, `recoveryLSN` is set to its metadata LSN (Y)
- The other streams whose metadata matches `state.json` → added to `remainingStreams` for WAL replay

Since `remainingStreams` is non-empty, `validateGlobalState` is called. It compares the LSN saved in `state.json` (X, stale : the crash happened after `PostCDC` acked the slot but before `state.json` was saved) against the live `confirmed_flush_lsn` read from `pg_replication_slots` (Y). Because X ≠ Y, it fails with:

```
lsn mismatch, please proceed with clear destination. lsn saved in state [X] current lsn [Y]
```

This is incorrect behaviour: the slot is at Y because the previous `PostCDC` acked it correctly (and `AcknowledgeLSN` only returns after polling `confirmed_flush_lsn` to confirm it reached Y). The remaining streams had no data in the X→Y window, so WAL replay for them is a no-op.


**Fix:**
After reading the slot, check whether `slot.confirmed_flush_lsn` already equals `recoveryLSN` (the metadata-committed LSN). If it does, the prior sync already acked everything skip `validateGlobalState` and let recovery proceed through the normal no-op WAL replay path. 
This mirrors the existing skip that already fires when `remainingStreams` is empty.


## Tests which have been considered

- [x] Metadata update But LSN not acknowledged in state 
In this case recovery sync will run and it will go through this loop 
```
for streamID, rawMtState := range metadataStates {
		if rawMtState == nil {
			// No previous CDC state for this stream (fresh run), skip recovery check.
			continue
		}
		if stMtState, ok := rawMtState.(string); ok {
			var mtState waljs.WALState
			if err := json.Unmarshal([]byte(stMtState), &mtState); err != nil {
				return nil, fmt.Errorf("failed to unmarshal metadata state: %s", err)
			}

			// Recovery is only needed when metadata is strictly AHEAD of state .
			parsedMetaLSN, err := pglogrepl.ParseLSN(mtState.LSN)
			if err != nil {
				return nil, fmt.Errorf("failed to parse metadata LSN %q: %s", mtState.LSN, err)
			}
			parsedStateLSN, err := pglogrepl.ParseLSN(postgresGlobalState.LSN)
			if err != nil {
				return nil, fmt.Errorf("failed to parse global state LSN %q: %s", postgresGlobalState.LSN, err)
			}
			if parsedMetaLSN > parsedStateLSN {
				// metadata ahead of state: genuine crash-recovery path
				metadataCommittedLSN = mtState.LSN
				finishedStreams = append(finishedStreams, streamID)
			}
			// state >= metadata: blank sync scenario — stream forward normally
		} else {
			return nil, fmt.Errorf("failed to typecast metadata state of type[%T] to string", rawMtState)
		}
	}
```

and identify the lsn upto which a sync should run , later on this condition will verify that slot lsn != recovery lsn that means the acknowledgment didn't happen earlier 


```
slotAtMetadataLSN := recoveryLSN != nil && slot.LSN == *recoveryLSN
	if len(remainingStreams) > 0 && !slotAtMetadataLSN {
 ```
and bounded sync will run for remaining streams if any 



- [x] metadata is behind the slot and state because of 0 records

there is this check in for loop to check what streams are finished or not 

```
if parsedMetaLSN > parsedStateLSN {
				// metadata ahead of state: genuine crash-recovery path
				metadataCommittedLSN = mtState.LSN
				finishedStreams = append(finishedStreams, streamID)
			}
``` 

as state is ahead of metadata all streams will be classified under remaining


- [x] some streams got committed but others have old metadata , acknowledgment didn't happen 
again the same condition will be helpful which check meta lsn Is ahead of state lsn , the bounded sync will run for remaining streams

- [x] some streams got committed but others have old metadata , acknowledgment also happened
again the same condition will be helpful which check meta lsn Is ahead of state lsn , but this time the following condition will return false so only state update will happen

```
slotAtMetadataLSN := recoveryLSN != nil && slot.LSN == *recoveryLSN
	if len(remainingStreams) > 0 && !slotAtMetadataLSN {
```



## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Scenario A: Reproduced the failure on old code with multi-stream Postgres CDC + Iceberg 2PC , prior sync committed/ack’d for one stream, state save failed, next sync hit `lsn mismatch`
- [x] Scenario B: Verified the same flow on new code : recovery sync completes successfully, state is persisted via `PostCDC`, and subsequent sync continues normally without duplicate data or clear-destination error

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

N/A

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

N/A