### PR TITLE
fix: guard nil shutdown in DropStreams to prevent clear-destination panic

### DIFF
--- a/destination/writers.go
+++ b/destination/writers.go
@@ -294,7 +294,11 @@ func DropStreams(ctx context.Context, config *types.WriterConfig, dropStreams []
 	if err != nil {
 		return fmt.Errorf("failed to initialize destination: %s", err)
 	}
-	defer shutdown(context.Background())
+	defer func() {
+		if shutdown != nil {
+			shutdown(context.Background())
+		}
+	}()
 
 	if err := adapter.DropStreams(ctx, dropStreams); err != nil {
 		return fmt.Errorf("failed to drop streams: %s", err)


### PR DESCRIPTION
# Description
- Fix nil pointer panic in `destination.DropStreams` when the writer returns no shutdown callback (e.g. Parquet)
- Affects `clear-destination` and any path that calls `DropStreams`

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):