### PR TITLE
fix: cdc insert failure during gcp

### DIFF
--- a/.cursor/rules/olake.mdc
+++ b/.cursor/rules/olake.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 
 OLake is an open-source, high-performance **EL (Extract-Load)** tool that replicates data from databases, Kafka, and S3 into **Apache Iceberg** tables or **plain Parquet** files.
 
-- **Languages:** Go 1.25.11 (primary) + Java 17 (Iceberg writer)
+- **Languages:** Go 1.25.12 (primary) + Java 17 (Iceberg writer)
 - **Go workspace:** `go.work` links the root module with 8 driver sub-modules
 - **CLI:** Cobra-based commands: `spec`, `check`, `discover`, `sync`, `clear`
 - **Sources:** Postgres, MongoDB, MySQL, Oracle, MSSQL, DB2, Kafka, S3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.25.11-bookworm AS builder
+FROM golang:1.25.12-bookworm AS builder
 
 WORKDIR /home/app
 COPY . .

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -21,6 +21,9 @@ import (
 // defaultServerPort is the port the single shared JVM listens on.
 const defaultServerPort = 50051
 
+// Java class implementing Iceberg's AwsClientFactory
+const olakeAwsClientFactoryClass = "io.debezium.server.iceberg.OlakeAwsClientFactory"
+
 type serverInstance struct {
 	port            int
 	cmd             *exec.Cmd
@@ -55,7 +58,7 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool) ([]b
 		serverConfig["catalog-impl"] = "org.apache.iceberg.aws.glue.GlueCatalog"
 		// if custom glue endpoint creds are passed
 		if config.UseGlueAdditionalConfig {
-			addMapKeyIfNotEmpty("client.factory", "io.debezium.server.iceberg.OlakeAwsClientFactory")
+			addMapKeyIfNotEmpty("client.factory", olakeAwsClientFactoryClass)
 			addMapKeyIfNotEmpty("glue.access-key-id", config.GlueAccessKey)
 			addMapKeyIfNotEmpty("glue.secret-access-key", config.GlueSecretKey)
 			addMapKeyIfNotEmpty("glue.endpoint", config.GlueEndpoint)
@@ -103,6 +106,9 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool) ([]b
 
 	if config.S3Endpoint != "" {
 		serverConfig["s3.endpoint"] = config.S3Endpoint
+		// GCS's S3-interop returns 404 when deleting a missing key; AWS returns 204.
+		// Iceberg expects the AWS behavior, so use our factory, whose S3 client treats NoSuchKey-on-delete as success.
+		serverConfig["client.factory"] = olakeAwsClientFactoryClass
 	}
 	serverConfig["io-impl"] = "org.apache.iceberg.io.ResolvingFileIO"
 	serverConfig["s3.ssl-enabled"] = utils.Ternary(config.S3UseSSL, "true", "false").(string)

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -18,11 +18,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// defaultServerPort is the port the single shared JVM listens on.
-const defaultServerPort = 50051
-
-// Java class implementing Iceberg's S3FileIOAwsClientFactory
-const olakeS3ClientFactoryClass = "io.debezium.server.iceberg.OlakeS3ClientFactory"
+const (
+	// defaultServerPort is the port the single shared JVM listens on.
+	defaultServerPort = 50051
+	// Java class implementing Iceberg's S3FileIOAwsClientFactory
+	olakeS3ClientFactoryClass = "io.debezium.server.iceberg.OlakeS3ClientFactory"
+)
 
 type serverInstance struct {
 	port            int
@@ -106,10 +107,11 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool) ([]b
 
 	if config.S3Endpoint != "" {
 		serverConfig["s3.endpoint"] = config.S3Endpoint
-		// GCS's S3-interop returns 404 when deleting a missing key; AWS returns 204.
-		// Iceberg expects the AWS behavior, so use our S3-only factory, whose client treats NoSuchKey-on-delete as success.
-		serverConfig["s3.client-factory-impl"] = olakeS3ClientFactoryClass
 	}
+	// Some s3-compatible stores (GCS's S3-interop) return 404 when deleting a
+	// missing key where AWS returns 204, and Iceberg expects the AWS behavior.
+	// The wrapper is a no-op on stores with AWS semantics.
+	serverConfig["s3.client-factory-impl"] = olakeS3ClientFactoryClass
 	serverConfig["io-impl"] = "org.apache.iceberg.io.ResolvingFileIO"
 	serverConfig["s3.ssl-enabled"] = utils.Ternary(config.S3UseSSL, "true", "false").(string)
 	// Marshal the config to JSON

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -21,8 +21,8 @@ import (
 // defaultServerPort is the port the single shared JVM listens on.
 const defaultServerPort = 50051
 
-// Java class implementing Iceberg's AwsClientFactory
-const olakeAwsClientFactoryClass = "io.debezium.server.iceberg.OlakeAwsClientFactory"
+// Java class implementing Iceberg's S3FileIOAwsClientFactory
+const olakeS3ClientFactoryClass = "io.debezium.server.iceberg.OlakeS3ClientFactory"
 
 type serverInstance struct {
 	port            int
@@ -58,7 +58,7 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool) ([]b
 		serverConfig["catalog-impl"] = "org.apache.iceberg.aws.glue.GlueCatalog"
 		// if custom glue endpoint creds are passed
 		if config.UseGlueAdditionalConfig {
-			addMapKeyIfNotEmpty("client.factory", olakeAwsClientFactoryClass)
+			addMapKeyIfNotEmpty("client.factory", "io.debezium.server.iceberg.OlakeAwsClientFactory")
 			addMapKeyIfNotEmpty("glue.access-key-id", config.GlueAccessKey)
 			addMapKeyIfNotEmpty("glue.secret-access-key", config.GlueSecretKey)
 			addMapKeyIfNotEmpty("glue.endpoint", config.GlueEndpoint)
@@ -107,8 +107,8 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool) ([]b
 	if config.S3Endpoint != "" {
 		serverConfig["s3.endpoint"] = config.S3Endpoint
 		// GCS's S3-interop returns 404 when deleting a missing key; AWS returns 204.
-		// Iceberg expects the AWS behavior, so use our factory, whose S3 client treats NoSuchKey-on-delete as success.
-		serverConfig["client.factory"] = olakeAwsClientFactoryClass
+		// Iceberg expects the AWS behavior, so use our S3-only factory, whose client treats NoSuchKey-on-delete as success.
+		serverConfig["s3.client-factory-impl"] = olakeS3ClientFactoryClass
 	}
 	serverConfig["io-impl"] = "org.apache.iceberg.io.ResolvingFileIO"
 	serverConfig["s3.ssl-enabled"] = utils.Ternary(config.S3UseSSL, "true", "false").(string)

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
@@ -14,12 +14,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.s3.DelegatingS3Client;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 
 // for custom glue endpoint credentials
 public class OlakeAwsClientFactory implements AwsClientFactory {
@@ -45,50 +40,13 @@ public class OlakeAwsClientFactory implements AwsClientFactory {
 
     @Override
     public S3Client s3() {
-        return new DeleteTolerantS3Client(delegate.s3());
-    }
-
-    /**
-     * Treats NoSuchKey-on-delete as success: AWS returns 204 for deletes of
-     * missing keys, GCS's S3-interop returns 404, and Iceberg expects the AWS
-     * behavior (e.g. its cleanup of empty writer files that were never uploaded) .
-     */
-    private static class DeleteTolerantS3Client extends DelegatingS3Client {
-        DeleteTolerantS3Client(S3Client delegate) {
-            super(delegate);
-        }
-
-        @Override
-        public DeleteObjectResponse deleteObject(DeleteObjectRequest request) {
-            try {
-                return super.deleteObject(request);
-            } catch (S3Exception e) {
-                if (isNoSuchKey(e)) {
-                    return DeleteObjectResponse.builder().build();
-                }
-                throw e;
-            }
-        }
-
-        private static boolean isNoSuchKey(S3Exception e) {
-            if (e instanceof NoSuchKeyException) {
-                return true;
-            }
-            return e.statusCode() == 404 && e.awsErrorDetails() != null && "NoSuchKey".equals(e.awsErrorDetails().errorCode());
-        }
+        return delegate.s3();
     }
 
     @Override
     public GlueClient glue() {
         String glueAccessKey = props.get("glue.access-key-id");
         String glueSecretKey = props.get("glue.secret-access-key");
-
-        // This factory can be registered purely for its S3 client (custom
-        // s3.endpoint). Without explicit glue.* overrides, keep Iceberg's default
-        // Glue client rather than building one from S3-oriented settings.
-        if (isBlank(glueAccessKey) && isBlank(glueSecretKey) && isBlank(props.get("glue.endpoint")) && isBlank(props.get("glue.region"))) {
-            return delegate.glue();
-        }
 
         GlueClientBuilder builder = GlueClient.builder();
         if (!isBlank(glueAccessKey) && !isBlank(glueSecretKey)) {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeAwsClientFactory.java
@@ -14,7 +14,12 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.s3.DelegatingS3Client;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 // for custom glue endpoint credentials
 public class OlakeAwsClientFactory implements AwsClientFactory {
@@ -40,13 +45,50 @@ public class OlakeAwsClientFactory implements AwsClientFactory {
 
     @Override
     public S3Client s3() {
-        return delegate.s3();
+        return new DeleteTolerantS3Client(delegate.s3());
+    }
+
+    /**
+     * Treats NoSuchKey-on-delete as success: AWS returns 204 for deletes of
+     * missing keys, GCS's S3-interop returns 404, and Iceberg expects the AWS
+     * behavior (e.g. its cleanup of empty writer files that were never uploaded) .
+     */
+    private static class DeleteTolerantS3Client extends DelegatingS3Client {
+        DeleteTolerantS3Client(S3Client delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public DeleteObjectResponse deleteObject(DeleteObjectRequest request) {
+            try {
+                return super.deleteObject(request);
+            } catch (S3Exception e) {
+                if (isNoSuchKey(e)) {
+                    return DeleteObjectResponse.builder().build();
+                }
+                throw e;
+            }
+        }
+
+        private static boolean isNoSuchKey(S3Exception e) {
+            if (e instanceof NoSuchKeyException) {
+                return true;
+            }
+            return e.statusCode() == 404 && e.awsErrorDetails() != null && "NoSuchKey".equals(e.awsErrorDetails().errorCode());
+        }
     }
 
     @Override
     public GlueClient glue() {
         String glueAccessKey = props.get("glue.access-key-id");
         String glueSecretKey = props.get("glue.secret-access-key");
+
+        // This factory can be registered purely for its S3 client (custom
+        // s3.endpoint). Without explicit glue.* overrides, keep Iceberg's default
+        // Glue client rather than building one from S3-oriented settings.
+        if (isBlank(glueAccessKey) && isBlank(glueSecretKey) && isBlank(props.get("glue.endpoint")) && isBlank(props.get("glue.region"))) {
+            return delegate.glue();
+        }
 
         GlueClientBuilder builder = GlueClient.builder();
         if (!isBlank(glueAccessKey) && !isBlank(glueSecretKey)) {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeS3ClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeS3ClientFactory.java
@@ -14,17 +14,16 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-/**
- * S3-only client factory, registered via the "s3.client-factory-impl" property.
- * Iceberg consults it exclusively for S3FileIO's client, so Glue/KMS/DynamoDB
- * client construction is never affected.
- *
- * It builds the standard S3 client and wraps it to treat NoSuchKey-on-delete as
- * success: AWS reports deletes of missing keys as successful, while GCS's
- * S3-interop returns 404 NoSuchKey, and Iceberg expects the AWS behaviour (e.g.
- * its cleanup of empty writer files that were never uploaded). Other errors,
- * including NoSuchBucket, still propagate.
- */
+// S3-only client factory, registered via the "s3.client-factory-impl" property.
+// Iceberg consults it exclusively for S3FileIO's client, so Glue/KMS/DynamoDB
+// client construction is never affected.
+
+// It builds the standard S3 client and wraps it to treat NoSuchKey-on-delete as
+// success: AWS reports deletes of missing keys as successful, while GCS's
+// S3-interop returns 404 NoSuchKey, and Iceberg expects the AWS behaviour (e.g.
+// its cleanup of empty writer files that were never uploaded). Other errors,
+// including NoSuchBucket, still propagate.
+
 public class OlakeS3ClientFactory implements S3FileIOAwsClientFactory {
 
     private AwsClientFactory delegate;

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeS3ClientFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeS3ClientFactory.java
@@ -1,0 +1,66 @@
+
+package io.debezium.server.iceberg;
+
+import java.util.Map;
+
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
+
+import software.amazon.awssdk.services.s3.DelegatingS3Client;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * S3-only client factory, registered via the "s3.client-factory-impl" property.
+ * Iceberg consults it exclusively for S3FileIO's client, so Glue/KMS/DynamoDB
+ * client construction is never affected.
+ *
+ * It builds the standard S3 client and wraps it to treat NoSuchKey-on-delete as
+ * success: AWS reports deletes of missing keys as successful, while GCS's
+ * S3-interop returns 404 NoSuchKey, and Iceberg expects the AWS behaviour (e.g.
+ * its cleanup of empty writer files that were never uploaded). Other errors,
+ * including NoSuchBucket, still propagate.
+ */
+public class OlakeS3ClientFactory implements S3FileIOAwsClientFactory {
+
+    private AwsClientFactory delegate;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        this.delegate = AwsClientFactories.from(properties);
+    }
+
+    @Override
+    public S3Client s3() {
+        return new DeleteTolerantS3Client(delegate.s3());
+    }
+
+    private static class DeleteTolerantS3Client extends DelegatingS3Client {
+        DeleteTolerantS3Client(S3Client delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public DeleteObjectResponse deleteObject(DeleteObjectRequest request) {
+            try {
+                return super.deleteObject(request);
+            } catch (S3Exception e) {
+                if (isNoSuchKey(e)) {
+                    return DeleteObjectResponse.builder().build();
+                }
+                throw e;
+            }
+        }
+
+        private static boolean isNoSuchKey(S3Exception e) {
+            if (e instanceof NoSuchKeyException) {
+                return true;
+            }
+            return e.statusCode() == 404 && e.awsErrorDetails() != null && "NoSuchKey".equals(e.awsErrorDetails().errorCode());
+        }
+    }
+}

--- a/drivers/db2/go.mod
+++ b/drivers/db2/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/db2
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/drivers/kafka/go.mod
+++ b/drivers/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/kafka
 
-go 1.25.11
+go 1.25.12
 
 replace github.com/datazip-inc/olake => ../../
 

--- a/drivers/mongodb/go.mod
+++ b/drivers/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mongodb
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/drivers/mssql/go.mod
+++ b/drivers/mssql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mssql
 
-go 1.25.11
+go 1.25.12
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/mysql/go.mod
+++ b/drivers/mysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mysql
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/datazip-inc/olake v0.0.0-20250312070222-ed705d25bc0c

--- a/drivers/oracle/go.mod
+++ b/drivers/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/oracle
 
-go 1.25.11
+go 1.25.12
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/postgres
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/drivers/s3/go.mod
+++ b/drivers/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/s3
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/apache/spark-connect-go/v35 v35.0.0-20250317154112-ffd832059443

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.11
+go 1.25.12
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 use (
 	.

--- a/utils/testutils/test_utils.go
+++ b/utils/testutils/test_utils.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// golangTestImage must match the `go` version in go.mod / go.work (integration tests build via build.sh inside this container).
-	golangTestImage     = "golang:1.25.11-bookworm"
+	golangTestImage     = "golang:1.25.12-bookworm"
 	icebergCatalog      = "olake_iceberg"
 	sparkConnectAddress = "sc://localhost:15002"
 	installCmd          = "apt-get update && apt-get install -y openjdk-17-jre-headless maven default-mysql-client postgresql postgresql-client wget gnupg iproute2 dnsutils iputils-ping netcat-openbsd nodejs npm jq && wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg && echo 'deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main' | tee /etc/apt/sources.list.d/mongodb-org-8.0.list && apt-get update && apt-get install -y mongodb-mongosh && npm install -g chalk-cli"


### PR DESCRIPTION

# Description

CDC syncs to Iceberg on **GCS via the s3-compat flavor (HMAC keys)** fail at commit with:

```
software.amazon.awssdk.services.s3.model.NoSuchKeyException: The specified key does not exist. (Service: S3, Status Code: 404, Request ID: null)
  at org.apache.iceberg.aws.s3.S3FileIO.deleteFile(S3FileIO.java:162)
  at org.apache.iceberg.io.BaseTaskWriter$BaseRollingWriter.closeCurrent(BaseTaskWriter.java:348)
```

**Root cause**:
Iceberg opens the equality-delete writer, but Parquet only materializes the object on GCS when the writer receives rows.
 On close, Iceberg deletes the "empty file" , which was never uploaded. AWS returns 204 for delete-of-missing-key (so this is invisible on AWS/MinIO); **GCS's S3-interop returns 404 NoSuchKey**, which escapes Iceberg's `catch (UncheckedIOException)` and kills the sync.
The failure starts only from the **second** CDC sync after full refresh (the `dedup_inserts` overlap window makes sync 1 write eq-deletes for inserts), matching the reported "first few CDC syncs worked" timeline.

**Fix:** restore AWS delete semantics at the S3-client boundary, using Iceberg's S3-scoped hook.

- New `OlakeS3ClientFactory` (implements Iceberg's `S3FileIOAwsClientFactory`): builds the standard S3 client via `AwsClientFactories.from(properties)`, wrapped so that `deleteObject` treats `NoSuchKey` as success. All other operations and errors (`NoSuchBucket`, `AccessDenied`, timeouts) propagate unchanged.
- `java_client.go` registers it via `s3.client-factory-impl` whenever a custom `s3_endpoint` is configured. This property is consumed only by `S3FileIO`, other things continues to work unchanged alongside this fix.
- Native-AWS configs (no custom endpoint) register nothing and behave identically to before.


Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reproduced and validated end-to-end on a local Lakekeeper

- [x] **Repro before fix** : 
full refresh → CDC sync 1 with inserts  (dedup window) → **insert-only CDC sync 2 `NoSuchKeyException`**, stack identical to the customer incident, state not advanced, pod exit 1.
- [x] Tested same after changes , sync completes without errors
- [x] tested with jdbc minio setup, and local parquet sync  
- [x] test on lakekeeper (with and without partitions)
- [x]  jdbc minio setup as destination
- [x]  glue without s3 endpoint
- [x]  glue with  custom endpoint of gcp bucket also partitions
- [x] arrow_write: true , syncing to lakekeeper gcp setup (with and without partition)
- [x] arrow_writes : true, syncing to glue for backward compatability test  

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):