### PR TITLE
fix(iceberg): use resolved destination column names for partition

### DIFF
--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -88,7 +88,7 @@ func (i *Iceberg) Setup(ctx context.Context, stream types.StreamInterface, _ any
 	icebergPartFields := make([]*proto.IcebergPayload_PartitionField, 0, len(i.partitionInfo))
 	for _, p := range i.partitionInfo {
 		icebergPartFields = append(icebergPartFields, &proto.IcebergPayload_PartitionField{
-			Field:     p.Field,
+			Field:     p.SchemaField,
 			Transform: p.Transform,
 		})
 	}


### PR DESCRIPTION
# Description
Fixes Iceberg table creation failures by ensuring partition specification column names match the resolved destination schema casing.
 When `"use_source_column_names"` is disabled, table schema columns are normalized/resolved to lowercase (e.g., source  column `ID` becomes `id`). However, the partition specification GRPC payload was still being populated with the original source column name (`p.Field`), causing a mismatch when the Java writer attempted to build the Iceberg `PartitionSpec` against the lowercased schema.
Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Verified by syncing a source table with mixed-case partition columns (ID, Last_Login_Time) while use_source_column_names is disabled.

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):