### PR TITLE
feat: log OLake version on startup

### DIFF
--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -11,6 +11,7 @@ import (
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/telemetry"
+	"github.com/datazip-inc/olake/utils/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -36,6 +37,10 @@ var discoverCmd = &cobra.Command{
 				return fmt.Errorf("failed to read streams from %s: %s", streamsPath, err)
 			}
 		}
+
+		//version
+		logger.Infof("Ruuning OLake sync with version %s", version.GetOlakeCLIVersion())
+
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/telemetry"
 	"github.com/datazip-inc/olake/utils/typeutils"
+	"github.com/datazip-inc/olake/utils/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -78,6 +79,10 @@ var syncCmd = &cobra.Command{
 		constants.LoadedStateVersion = state.Version
 
 		state.RWMutex = &sync.RWMutex{}
+
+		//version
+		logger.Infof("Ruuning OLake sync with version %s", version.GetOlakeCLIVersion())
+
 		stateBytes, _ := state.MarshalJSON()
 		logger.Infof("Running sync with state: %s", stateBytes)
 		return nil

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
+	"github.com/datazip-inc/olake/utils/version"
 	"github.com/spf13/viper"
 )
 
@@ -66,7 +67,7 @@ func Init() {
 			platform: platformInfo{
 				OS:           runtime.GOOS,
 				Arch:         runtime.GOARCH,
-				OlakeVersion: getOlakeCLIVersion(),
+				OlakeVersion: version.GetOlakeCLIVersion(),
 				DeviceCPU:    fmt.Sprintf("%d cores", runtime.NumCPU()),
 			},
 			ipAddress: ip,
@@ -294,13 +295,4 @@ func countPartitionedStreams(catalog *types.Catalog) int {
 		return nil
 	})
 	return count
-}
-
-// getOlakeCLIVersion() extracts the olake version from the ENV embedded in the olake image
-func getOlakeCLIVersion() string {
-	version := os.Getenv("DRIVER_VERSION")
-	if version == "" {
-		return "Not Available"
-	}
-	return version
 }

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -1,0 +1,12 @@
+package version
+
+import "os"
+
+// GetOlakeCLIVersion() extracts the olake version from the ENV embedded in the olake image
+func GetOlakeCLIVersion() string {
+	version := os.Getenv("DRIVER_VERSION")
+	if version == "" {
+		return "Not Available"
+	}
+	return version
+}


### PR DESCRIPTION
# Description

Adds OLake version to startup logs so that running version is visible when an application starts.
- Added a shared version utility under utils/version.
- Updated protocol/sync.go to log the OLake version during startup.

OL-2972

## Type of change

<!--
Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Executed the sync command and verified that OLake version is logged during startup.

# Screenshots or Recordings

<!-- Attach related screenshots or recordings here -->
### Discover:
<img width="2585" height="794" alt="image" src="https://github.com/user-attachments/assets/2e979597-3984-40eb-b4c8-0f92a73b86cb" />

### Sync:
<img width="2581" height="1772" alt="image" src="https://github.com/user-attachments/assets/ada37c9f-0ca6-4aa0-8a88-c800e0b481b2" />

