### PR TITLE
feat(ci): add Java dependency CVE scanning with Trivy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,13 @@ version: 2
 # updates always open against the repository default branch; that is a
 # Dependabot limitation and cannot be configured.
 updates:
-  # Go modules: root module plus every driver module (go.work workspace).
+  # Go modules: root module plus every driver, lib and test module (go.work workspace).
   - package-ecosystem: "gomod"
     directories:
       - "/"
       - "/drivers/*"
+      - "/lib"
+      - "/tests/*"
     target-branch: "staging"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Java writer — direct pom.xml dependencies. Security updates fire regardless
+  # of schedule; weekly window covers routine version bumps.
+  - package-ecosystem: "maven"
+    directory: "/destination/iceberg/olake-iceberg-java-writer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    ignore:
+      # Skip risky major bumps; keep security + minor/patch. Security advisories
+      # still open PRs even for majors.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Keep GitHub Actions pinned versions current + patched.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,51 @@
 version: 2
+
+# Note: target-branch applies to VERSION updates only. Dependabot security
+# updates always open against the repository default branch; that is a
+# Dependabot limitation and cannot be configured.
 updates:
-  # Java writer — direct pom.xml dependencies. Security updates fire regardless
-  # of schedule; weekly window covers routine version bumps.
-  - package-ecosystem: "maven"
-    directory: "/destination/iceberg/olake-iceberg-java-writer"
+  # Go modules: root module plus every driver module (go.work workspace).
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/drivers/*"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      # One PR per module for routine bumps; security updates stay separate.
+      go-dependencies:
+        update-types: ["minor", "patch"]
     ignore:
-      # Skip risky major bumps; keep security + minor/patch. Security advisories
-      # still open PRs even for majors.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  # Keep GitHub Actions pinned versions current + patched.
+  # Java Iceberg writer. Dependabot cannot fix a transitive Maven dependency,
+  # so keeping the parents current is the whole mechanism here.
+  - package-ecosystem: "maven"
+    directory: "/destination/iceberg/olake-iceberg-java-writer"
+    target-branch: "staging"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "java"
+    ignore:
+      # Majors are reviewed by hand: this module has no test suite, so a green
+      # build does not prove runtime behaviour is intact.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -129,3 +129,6 @@ jobs:
           scanners: 'vuln'
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
+          # Suppresses only CVEs verified unfixable from pom.xml (stale copies
+          # shaded inside third-party fat jars). Each entry documents why.
+          trivyignores: './destination/iceberg/olake-iceberg-java-writer/.trivyignore'

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -8,6 +8,8 @@ on:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
+      - '**/*.yml'
+      - '**/*.yaml'
   pull_request:
     branches:
       - "*"
@@ -15,6 +17,8 @@ on:
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
+      - '**/*.yml'
+      - '**/*.yaml'
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -93,19 +93,38 @@ jobs:
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
 
-  # TODO: Add Java Dependency Trivy (removed because trivy getting stuck or run for hours)
-  # trivy-java:
-  #   name: trivy-java
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v3
-  #     - name: Run Trivy Java vulnerability scanner in repo mode
-  #       uses: aquasecurity/trivy-action@master
-  #       with:
-  #         exit-code: '1'
-  #         scan-type: 'fs'
-  #         scan-ref: './destination/iceberg/olake-iceberg-java-writer'
-  #         scanners: 'vuln'
-  #         severity: 'HIGH,CRITICAL'
+  trivy-java:
+    name: trivy-java
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      # Build the shaded uber-jar so Trivy scans the real, resolved & shipped
+      # dependencies baked into the artifact. No pom re-resolution at scan time
+      # -> no Maven Central rate-limit hangs.
+      - name: Build shaded jar
+        working-directory: ./destination/iceberg/olake-iceberg-java-writer
+        run: mvn -B -q clean package -DskipTests
+      - name: Prepare scan directory
+        run: |
+          mkdir -p /tmp/cve-scan
+          cp ./destination/iceberg/olake-iceberg-java-writer/target/olake-iceberg-java-writer-*.jar /tmp/cve-scan/
+      - name: Run Trivy Java vulnerability scanner on built jar
+        uses: aquasecurity/trivy-action@master
+        with:
+          exit-code: '1'
+          scan-type: 'rootfs'
+          scan-ref: '/tmp/cve-scan'
+          scanners: 'vuln'
+          severity: 'HIGH,CRITICAL'
+          ignore-unfixed: true
+          # Suppress CVEs from stale deps shaded inside third-party bundle jars
+          # (cannot be fixed from our pom). See file header for rationale.
+          trivyignores: './destination/iceberg/olake-iceberg-java-writer/.trivyignore'

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -129,6 +129,3 @@ jobs:
           scanners: 'vuln'
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
-          # Suppress CVEs from stale deps shaded inside third-party bundle jars
-          # (cannot be fixed from our pom). See file header for rationale.
-          trivyignores: './destination/iceberg/olake-iceberg-java-writer/.trivyignore'

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     make dev.${DRIVER_NAME}.build OVERLAY_DIR=/runtime-overlay
 
-FROM debian:bookworm-slim
+FROM eclipse-temurin:17-jre-noble
 
-# Install runtime dependencies
+# Install runtime dependencies. The JRE comes from the base image: installing
+# Debian's openjdk-*-jre-headless pulls ca-certificates-java, whose postinst is
+# a perl script, which drags in perl (2 CRITICAL CVEs with no fix in any Debian
+# release) plus libnss3. Temurin ships the JRE directly and avoids both.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    openjdk-17-jre-headless \
     libxml2 \
     ca-certificates \
     libpam-modules \

--- a/destination/iceberg/olake-iceberg-java-writer/.trivyignore
+++ b/destination/iceberg/olake-iceberg-java-writer/.trivyignore
@@ -1,30 +1,17 @@
-# Trivy suppressions -- validated 2026-07-29.
-# All of these are vulnerable copies SHADED inside a third-party fat jar (or
-# have no published fix). Our resolved versions are already patched -- netty
-# 4.1.136, jackson-databind 2.22.1, jetty 9.4.58 -- so no pin, BOM or exclusion
-# can reach them. Fix an entry by exclusion or a parent upgrade, never a pin.
-
-# iceberg-aws-bundle 1.10.2 shades netty 4.1.124 (needs 4.1.135).
-# Upstream: https://github.com/apache/iceberg/issues/16286
-CVE-2026-44249
-CVE-2026-45416
-CVE-2026-50010
-
-# iceberg-azure-bundle 1.10.2 shades netty 4.1.112 (needs 4.1.133/4.1.135).
-CVE-2026-42579
-CVE-2026-45674
-CVE-2026-47691
-
-# parquet-jackson 1.16.0 shades jackson 2.19.2 (needs 2.21.4).
+# Trivy suppressions -- validated 2026-07-30.
+#
+# Both entries come from parquet-jackson, which ships its own copy of
+# jackson-databind relocated under shaded.parquet.*. Being a renamed package it
+# is not a Maven coordinate, so no pin, BOM or exclusion can reach it, and
+# Parquet is not removable (it is our primary file format). Our own resolved
+# jackson-databind is 2.22.1 and is patched.
+#
+# Upgrading Parquet does not help: 1.16.0 shades jackson 2.19.2 and the latest
+# 1.17.1 still shades 2.21.3, while the fix requires >= 2.21.4.
+#
+# Apache Iceberg suppresses these same CVEs for the same reason, see
+# https://github.com/apache/iceberg/blob/main/.github/trivyignore/kafka-connect-runtime.trivyignore
+#
+# Clears when Apache Parquet re-shades jackson >= 2.21.4.
 CVE-2026-54512
 CVE-2026-54513
-
-# jetty 9.4.58 is the newest 9.4.x published. jetty-http is fixed only in 12.x,
-# which breaks hadoop/hive/gcsio; jetty-security's 9.4.63 fix was never released.
-# Jetty here backs only hadoop/hive internal endpoints; our RPC surface is gRPC.
-CVE-2026-2332
-CVE-2026-10050
-
-# hadoop-aws 3.5.0 pins awssdk bundle 2.35.4, which shades a vulnerable
-# cloudfront (fixed in 2.41.30). Revisit when hadoop-aws ships a newer SDK.
-GHSA-443w-3rq3-5m5h

--- a/destination/iceberg/olake-iceberg-java-writer/.trivyignore
+++ b/destination/iceberg/olake-iceberg-java-writer/.trivyignore
@@ -1,0 +1,120 @@
+# Trivy ignore list for olake-iceberg-java-writer
+#
+# These CVEs live in OLD dependency versions that are SHADED (re-packaged)
+# inside third-party fat/bundle jars we pull transitively — mainly the
+# hadoop3 gcs-connector and the iceberg-*-bundle artifacts. We cannot bump
+# these directly from our pom.xml because they are baked inside the bundle
+# jar, not resolved as normal dependencies.
+#
+# NOTE: our pom.xml already pins CURRENT versions of jackson-databind (2.16.1),
+# protobuf-java (3.25.5) and netty (4.1.118) for the DIRECTLY-resolved graph.
+# The entries below are the stale copies bundled inside those fat jars.
+#
+# Fix path (do not just leave forever): bump the offending bundle/iceberg
+# version when upstream re-shades fixed deps, or exclude the bundle and pull
+# the unbundled artifact. Re-review this file every release.
+#
+# Directly-fixable CVEs (zookeeper, jose4j, jetty, quarkus) are intentionally
+# NOT listed here — those are handled via pom bumps / Dependabot.
+
+# --- com.cedarsoftware:json-io @ 2.5.1 (shaded) ---
+CVE-2023-34610
+
+# --- com.fasterxml.jackson.core:jackson-databind @ 2.4.0 (shaded; pom pins 2.16.1) ---
+CVE-2017-15095
+CVE-2017-17485
+CVE-2017-7525
+CVE-2018-11307
+CVE-2018-12022
+CVE-2018-14718
+CVE-2018-14719
+CVE-2018-19362
+CVE-2018-5968
+CVE-2018-7489
+CVE-2019-12086
+CVE-2019-14379
+CVE-2019-14439
+CVE-2019-14540
+CVE-2019-14892
+CVE-2019-16335
+CVE-2019-16942
+CVE-2019-16943
+CVE-2019-17267
+CVE-2019-17531
+CVE-2019-20330
+CVE-2020-10650
+CVE-2020-10673
+CVE-2020-24616
+CVE-2020-24750
+CVE-2020-35490
+CVE-2020-35491
+CVE-2020-35728
+CVE-2020-36179
+CVE-2020-36180
+CVE-2020-36181
+CVE-2020-36182
+CVE-2020-36183
+CVE-2020-36184
+CVE-2020-36185
+CVE-2020-36186
+CVE-2020-36187
+CVE-2020-36188
+CVE-2020-36189
+CVE-2020-36518
+CVE-2020-8840
+CVE-2020-9547
+CVE-2020-9548
+CVE-2021-20190
+CVE-2022-42003
+CVE-2022-42004
+
+# --- com.google.protobuf:protobuf-java @ 3.3.1 (shaded; pom pins 3.25.5) ---
+CVE-2021-22569
+CVE-2022-3509
+CVE-2022-3510
+CVE-2024-7254
+
+# --- io.airlift:aircompressor @ 0.27 (shaded) ---
+CVE-2025-67721
+
+# --- io.netty:netty-all @ 4.1.12.Final (shaded) ---
+CVE-2019-16869
+
+# --- io.netty:netty-codec @ 4.1.114.Final (shaded; pom pins 4.1.118) ---
+CVE-2026-42583
+
+# --- io.netty:netty-codec-dns @ 4.1.109.Final (shaded) ---
+CVE-2026-42579
+
+# --- io.netty:netty-codec-haproxy @ 4.1.94.Final (shaded) ---
+CVE-2026-44893
+CVE-2026-48059
+
+# --- io.netty:netty-codec-http @ 4.1.114.Final (shaded) ---
+CVE-2026-33870
+CVE-2026-42584
+CVE-2026-42587
+
+# --- io.netty:netty-codec-http2 @ 4.1.114.Final (shaded) ---
+CVE-2025-55163
+CVE-2026-33871
+
+# --- io.netty:netty-handler @ 4.1.114.Final (shaded) ---
+CVE-2025-24970
+CVE-2026-44249
+CVE-2026-45416
+CVE-2026-50010
+
+# --- io.netty:netty-resolver-dns @ 4.1.109.Final (shaded) ---
+CVE-2026-45674
+CVE-2026-47691
+
+# --- net.minidev:json-smart @ 2.5.1 (shaded) ---
+CVE-2024-57699
+
+# --- org.codehaus.plexus:plexus-utils @ 3.5.1 (shaded; build-time) ---
+CVE-2025-67030
+
+# --- org.jline:jline-remote-telnet @ 3.9.0 (shaded) ---
+GHSA-2r2c-cx56-8933
+GHSA-47qp-hqvx-6r3f

--- a/destination/iceberg/olake-iceberg-java-writer/.trivyignore
+++ b/destination/iceberg/olake-iceberg-java-writer/.trivyignore
@@ -1,120 +1,30 @@
-# # Trivy ignore list for olake-iceberg-java-writer
-# #
-# # These CVEs live in OLD dependency versions that are SHADED (re-packaged)
-# # inside third-party fat/bundle jars we pull transitively — mainly the
-# # hadoop3 gcs-connector and the iceberg-*-bundle artifacts. We cannot bump
-# # these directly from our pom.xml because they are baked inside the bundle
-# # jar, not resolved as normal dependencies.
-# #
-# # NOTE: our pom.xml already pins CURRENT versions of jackson-databind (2.16.1),
-# # protobuf-java (3.25.5) and netty (4.1.118) for the DIRECTLY-resolved graph.
-# # The entries below are the stale copies bundled inside those fat jars.
-# #
-# # Fix path (do not just leave forever): bump the offending bundle/iceberg
-# # version when upstream re-shades fixed deps, or exclude the bundle and pull
-# # the unbundled artifact. Re-review this file every release.
-# #
-# # Directly-fixable CVEs (zookeeper, jose4j, jetty, quarkus) are intentionally
-# # NOT listed here — those are handled via pom bumps / Dependabot.
+# Trivy suppressions -- validated 2026-07-29.
+# All of these are vulnerable copies SHADED inside a third-party fat jar (or
+# have no published fix). Our resolved versions are already patched -- netty
+# 4.1.136, jackson-databind 2.22.1, jetty 9.4.58 -- so no pin, BOM or exclusion
+# can reach them. Fix an entry by exclusion or a parent upgrade, never a pin.
 
-# # --- com.cedarsoftware:json-io @ 2.5.1 (shaded) ---
-# CVE-2023-34610
+# iceberg-aws-bundle 1.10.2 shades netty 4.1.124 (needs 4.1.135).
+# Upstream: https://github.com/apache/iceberg/issues/16286
+CVE-2026-44249
+CVE-2026-45416
+CVE-2026-50010
 
-# # --- com.fasterxml.jackson.core:jackson-databind @ 2.4.0 (shaded; pom pins 2.16.1) ---
-# CVE-2017-15095
-# CVE-2017-17485
-# CVE-2017-7525
-# CVE-2018-11307
-# CVE-2018-12022
-# CVE-2018-14718
-# CVE-2018-14719
-# CVE-2018-19362
-# CVE-2018-5968
-# CVE-2018-7489
-# CVE-2019-12086
-# CVE-2019-14379
-# CVE-2019-14439
-# CVE-2019-14540
-# CVE-2019-14892
-# CVE-2019-16335
-# CVE-2019-16942
-# CVE-2019-16943
-# CVE-2019-17267
-# CVE-2019-17531
-# CVE-2019-20330
-# CVE-2020-10650
-# CVE-2020-10673
-# CVE-2020-24616
-# CVE-2020-24750
-# CVE-2020-35490
-# CVE-2020-35491
-# CVE-2020-35728
-# CVE-2020-36179
-# CVE-2020-36180
-# CVE-2020-36181
-# CVE-2020-36182
-# CVE-2020-36183
-# CVE-2020-36184
-# CVE-2020-36185
-# CVE-2020-36186
-# CVE-2020-36187
-# CVE-2020-36188
-# CVE-2020-36189
-# CVE-2020-36518
-# CVE-2020-8840
-# CVE-2020-9547
-# CVE-2020-9548
-# CVE-2021-20190
-# CVE-2022-42003
-# CVE-2022-42004
+# iceberg-azure-bundle 1.10.2 shades netty 4.1.112 (needs 4.1.133/4.1.135).
+CVE-2026-42579
+CVE-2026-45674
+CVE-2026-47691
 
-# # --- com.google.protobuf:protobuf-java @ 3.3.1 (shaded; pom pins 3.25.5) ---
-# CVE-2021-22569
-# CVE-2022-3509
-# CVE-2022-3510
-# CVE-2024-7254
+# parquet-jackson 1.16.0 shades jackson 2.19.2 (needs 2.21.4).
+CVE-2026-54512
+CVE-2026-54513
 
-# # --- io.airlift:aircompressor @ 0.27 (shaded) ---
-# CVE-2025-67721
+# jetty 9.4.58 is the newest 9.4.x published. jetty-http is fixed only in 12.x,
+# which breaks hadoop/hive/gcsio; jetty-security's 9.4.63 fix was never released.
+# Jetty here backs only hadoop/hive internal endpoints; our RPC surface is gRPC.
+CVE-2026-2332
+CVE-2026-10050
 
-# # --- io.netty:netty-all @ 4.1.12.Final (shaded) ---
-# CVE-2019-16869
-
-# # --- io.netty:netty-codec @ 4.1.114.Final (shaded; pom pins 4.1.118) ---
-# CVE-2026-42583
-
-# # --- io.netty:netty-codec-dns @ 4.1.109.Final (shaded) ---
-# CVE-2026-42579
-
-# # --- io.netty:netty-codec-haproxy @ 4.1.94.Final (shaded) ---
-# CVE-2026-44893
-# CVE-2026-48059
-
-# # --- io.netty:netty-codec-http @ 4.1.114.Final (shaded) ---
-# CVE-2026-33870
-# CVE-2026-42584
-# CVE-2026-42587
-
-# # --- io.netty:netty-codec-http2 @ 4.1.114.Final (shaded) ---
-# CVE-2025-55163
-# CVE-2026-33871
-
-# # --- io.netty:netty-handler @ 4.1.114.Final (shaded) ---
-# CVE-2025-24970
-# CVE-2026-44249
-# CVE-2026-45416
-# CVE-2026-50010
-
-# # --- io.netty:netty-resolver-dns @ 4.1.109.Final (shaded) ---
-# CVE-2026-45674
-# CVE-2026-47691
-
-# # --- net.minidev:json-smart @ 2.5.1 (shaded) ---
-# CVE-2024-57699
-
-# # --- org.codehaus.plexus:plexus-utils @ 3.5.1 (shaded; build-time) ---
-# CVE-2025-67030
-
-# # --- org.jline:jline-remote-telnet @ 3.9.0 (shaded) ---
-# GHSA-2r2c-cx56-8933
-# GHSA-47qp-hqvx-6r3f
+# hadoop-aws 3.5.0 pins awssdk bundle 2.35.4, which shades a vulnerable
+# cloudfront (fixed in 2.41.30). Revisit when hadoop-aws ships a newer SDK.
+GHSA-443w-3rq3-5m5h

--- a/destination/iceberg/olake-iceberg-java-writer/.trivyignore
+++ b/destination/iceberg/olake-iceberg-java-writer/.trivyignore
@@ -1,120 +1,120 @@
-# Trivy ignore list for olake-iceberg-java-writer
-#
-# These CVEs live in OLD dependency versions that are SHADED (re-packaged)
-# inside third-party fat/bundle jars we pull transitively — mainly the
-# hadoop3 gcs-connector and the iceberg-*-bundle artifacts. We cannot bump
-# these directly from our pom.xml because they are baked inside the bundle
-# jar, not resolved as normal dependencies.
-#
-# NOTE: our pom.xml already pins CURRENT versions of jackson-databind (2.16.1),
-# protobuf-java (3.25.5) and netty (4.1.118) for the DIRECTLY-resolved graph.
-# The entries below are the stale copies bundled inside those fat jars.
-#
-# Fix path (do not just leave forever): bump the offending bundle/iceberg
-# version when upstream re-shades fixed deps, or exclude the bundle and pull
-# the unbundled artifact. Re-review this file every release.
-#
-# Directly-fixable CVEs (zookeeper, jose4j, jetty, quarkus) are intentionally
-# NOT listed here — those are handled via pom bumps / Dependabot.
+# # Trivy ignore list for olake-iceberg-java-writer
+# #
+# # These CVEs live in OLD dependency versions that are SHADED (re-packaged)
+# # inside third-party fat/bundle jars we pull transitively — mainly the
+# # hadoop3 gcs-connector and the iceberg-*-bundle artifacts. We cannot bump
+# # these directly from our pom.xml because they are baked inside the bundle
+# # jar, not resolved as normal dependencies.
+# #
+# # NOTE: our pom.xml already pins CURRENT versions of jackson-databind (2.16.1),
+# # protobuf-java (3.25.5) and netty (4.1.118) for the DIRECTLY-resolved graph.
+# # The entries below are the stale copies bundled inside those fat jars.
+# #
+# # Fix path (do not just leave forever): bump the offending bundle/iceberg
+# # version when upstream re-shades fixed deps, or exclude the bundle and pull
+# # the unbundled artifact. Re-review this file every release.
+# #
+# # Directly-fixable CVEs (zookeeper, jose4j, jetty, quarkus) are intentionally
+# # NOT listed here — those are handled via pom bumps / Dependabot.
 
-# --- com.cedarsoftware:json-io @ 2.5.1 (shaded) ---
-CVE-2023-34610
+# # --- com.cedarsoftware:json-io @ 2.5.1 (shaded) ---
+# CVE-2023-34610
 
-# --- com.fasterxml.jackson.core:jackson-databind @ 2.4.0 (shaded; pom pins 2.16.1) ---
-CVE-2017-15095
-CVE-2017-17485
-CVE-2017-7525
-CVE-2018-11307
-CVE-2018-12022
-CVE-2018-14718
-CVE-2018-14719
-CVE-2018-19362
-CVE-2018-5968
-CVE-2018-7489
-CVE-2019-12086
-CVE-2019-14379
-CVE-2019-14439
-CVE-2019-14540
-CVE-2019-14892
-CVE-2019-16335
-CVE-2019-16942
-CVE-2019-16943
-CVE-2019-17267
-CVE-2019-17531
-CVE-2019-20330
-CVE-2020-10650
-CVE-2020-10673
-CVE-2020-24616
-CVE-2020-24750
-CVE-2020-35490
-CVE-2020-35491
-CVE-2020-35728
-CVE-2020-36179
-CVE-2020-36180
-CVE-2020-36181
-CVE-2020-36182
-CVE-2020-36183
-CVE-2020-36184
-CVE-2020-36185
-CVE-2020-36186
-CVE-2020-36187
-CVE-2020-36188
-CVE-2020-36189
-CVE-2020-36518
-CVE-2020-8840
-CVE-2020-9547
-CVE-2020-9548
-CVE-2021-20190
-CVE-2022-42003
-CVE-2022-42004
+# # --- com.fasterxml.jackson.core:jackson-databind @ 2.4.0 (shaded; pom pins 2.16.1) ---
+# CVE-2017-15095
+# CVE-2017-17485
+# CVE-2017-7525
+# CVE-2018-11307
+# CVE-2018-12022
+# CVE-2018-14718
+# CVE-2018-14719
+# CVE-2018-19362
+# CVE-2018-5968
+# CVE-2018-7489
+# CVE-2019-12086
+# CVE-2019-14379
+# CVE-2019-14439
+# CVE-2019-14540
+# CVE-2019-14892
+# CVE-2019-16335
+# CVE-2019-16942
+# CVE-2019-16943
+# CVE-2019-17267
+# CVE-2019-17531
+# CVE-2019-20330
+# CVE-2020-10650
+# CVE-2020-10673
+# CVE-2020-24616
+# CVE-2020-24750
+# CVE-2020-35490
+# CVE-2020-35491
+# CVE-2020-35728
+# CVE-2020-36179
+# CVE-2020-36180
+# CVE-2020-36181
+# CVE-2020-36182
+# CVE-2020-36183
+# CVE-2020-36184
+# CVE-2020-36185
+# CVE-2020-36186
+# CVE-2020-36187
+# CVE-2020-36188
+# CVE-2020-36189
+# CVE-2020-36518
+# CVE-2020-8840
+# CVE-2020-9547
+# CVE-2020-9548
+# CVE-2021-20190
+# CVE-2022-42003
+# CVE-2022-42004
 
-# --- com.google.protobuf:protobuf-java @ 3.3.1 (shaded; pom pins 3.25.5) ---
-CVE-2021-22569
-CVE-2022-3509
-CVE-2022-3510
-CVE-2024-7254
+# # --- com.google.protobuf:protobuf-java @ 3.3.1 (shaded; pom pins 3.25.5) ---
+# CVE-2021-22569
+# CVE-2022-3509
+# CVE-2022-3510
+# CVE-2024-7254
 
-# --- io.airlift:aircompressor @ 0.27 (shaded) ---
-CVE-2025-67721
+# # --- io.airlift:aircompressor @ 0.27 (shaded) ---
+# CVE-2025-67721
 
-# --- io.netty:netty-all @ 4.1.12.Final (shaded) ---
-CVE-2019-16869
+# # --- io.netty:netty-all @ 4.1.12.Final (shaded) ---
+# CVE-2019-16869
 
-# --- io.netty:netty-codec @ 4.1.114.Final (shaded; pom pins 4.1.118) ---
-CVE-2026-42583
+# # --- io.netty:netty-codec @ 4.1.114.Final (shaded; pom pins 4.1.118) ---
+# CVE-2026-42583
 
-# --- io.netty:netty-codec-dns @ 4.1.109.Final (shaded) ---
-CVE-2026-42579
+# # --- io.netty:netty-codec-dns @ 4.1.109.Final (shaded) ---
+# CVE-2026-42579
 
-# --- io.netty:netty-codec-haproxy @ 4.1.94.Final (shaded) ---
-CVE-2026-44893
-CVE-2026-48059
+# # --- io.netty:netty-codec-haproxy @ 4.1.94.Final (shaded) ---
+# CVE-2026-44893
+# CVE-2026-48059
 
-# --- io.netty:netty-codec-http @ 4.1.114.Final (shaded) ---
-CVE-2026-33870
-CVE-2026-42584
-CVE-2026-42587
+# # --- io.netty:netty-codec-http @ 4.1.114.Final (shaded) ---
+# CVE-2026-33870
+# CVE-2026-42584
+# CVE-2026-42587
 
-# --- io.netty:netty-codec-http2 @ 4.1.114.Final (shaded) ---
-CVE-2025-55163
-CVE-2026-33871
+# # --- io.netty:netty-codec-http2 @ 4.1.114.Final (shaded) ---
+# CVE-2025-55163
+# CVE-2026-33871
 
-# --- io.netty:netty-handler @ 4.1.114.Final (shaded) ---
-CVE-2025-24970
-CVE-2026-44249
-CVE-2026-45416
-CVE-2026-50010
+# # --- io.netty:netty-handler @ 4.1.114.Final (shaded) ---
+# CVE-2025-24970
+# CVE-2026-44249
+# CVE-2026-45416
+# CVE-2026-50010
 
-# --- io.netty:netty-resolver-dns @ 4.1.109.Final (shaded) ---
-CVE-2026-45674
-CVE-2026-47691
+# # --- io.netty:netty-resolver-dns @ 4.1.109.Final (shaded) ---
+# CVE-2026-45674
+# CVE-2026-47691
 
-# --- net.minidev:json-smart @ 2.5.1 (shaded) ---
-CVE-2024-57699
+# # --- net.minidev:json-smart @ 2.5.1 (shaded) ---
+# CVE-2024-57699
 
-# --- org.codehaus.plexus:plexus-utils @ 3.5.1 (shaded; build-time) ---
-CVE-2025-67030
+# # --- org.codehaus.plexus:plexus-utils @ 3.5.1 (shaded; build-time) ---
+# CVE-2025-67030
 
-# --- org.jline:jline-remote-telnet @ 3.9.0 (shaded) ---
-GHSA-2r2c-cx56-8933
-GHSA-47qp-hqvx-6r3f
+# # --- org.jline:jline-remote-telnet @ 3.9.0 (shaded) ---
+# GHSA-2r2c-cx56-8933
+# GHSA-47qp-hqvx-6r3f

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -17,8 +17,13 @@
     <packaging>jar</packaging>
 
     <properties>
-        <!-- Debezium Version -->
-        <version.debezium>2.5.2.Final</version.debezium>
+        <!--
+          Dependency policy: declare only what we use; do not pin transitive
+          versions. Clear CVEs by upgrading the parent that ships them; when the
+          vulnerable copy is shaded inside a third-party jar no pin can reach it,
+          so record it in .trivyignore. netty-bom/jackson-bom are deliberate
+          exceptions that keep each family on a single version.
+        -->
 
         <!-- Instruct the build to use only UTF-8 encoding for source code -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,45 +34,32 @@
         
         <!-- Iceberg -->
         <version.iceberg>1.10.2</version.iceberg>
-        <version.hadoop>3.3.6</version.hadoop>
+        <version.hadoop>3.5.0</version.hadoop>
         <version.hive>3.1.3</version.hive>
-        <version.googlebigdataoss>2.2.20</version.googlebigdataoss>
+        <version.googlebigdataoss>2.2.28</version.googlebigdataoss>
         <version.testcontainers>1.20.4</version.testcontainers>
         <version.protobuf>3.25.5</version.protobuf>
-        <version.netty>4.1.118.Final</version.netty>
-        <version.log4j2>2.21.1</version.log4j2>
-        <version.quarkus>3.19.1</version.quarkus>
-        <version.commons.io>2.14.0</version.commons.io>
-        <version.avro>1.12.1</version.avro>
-        <version.snappy>1.1.10.4</version.snappy>
-        <version.jackson>2.16.1</version.jackson>
-        <version.commons.compress>1.26.0</version.commons.compress>
-        <version.commons.configuration>2.10.1</version.commons.configuration>
-        <version.ant>1.10.14</version.ant>
-        <version.jose4j>0.9.4</version.jose4j>
-        <version.zookeeper>3.9.3</version.zookeeper>
-        <version.vertx>4.5.3</version.vertx>
-        <version.jetty>9.4.57.v20241219</version.jetty>
-        <version.logback>1.5.13</version.logback>
-        <version.kafka>3.7.1</version.kafka>
-        <version.httpclient5>5.4.3</version.httpclient5>
-        <version.commons.beanutils>1.11.0</version.commons.beanutils>
+        <version.log4j2>2.26.1</version.log4j2>
+        <!-- deliberate family pins; see DEPENDENCY POLICY above -->
+        <version.netty>4.1.136.Final</version.netty>
+        <version.jackson>2.22.1</version.jackson>
+        <!-- keep all grpc artifacts on one version; see warning on grpc-netty -->
+        <version.grpc>1.69.0</version.grpc>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- debezium server -->
             <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-server-bom</artifactId>
-                <version>${version.debezium}</version>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${version.netty}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-bom</artifactId>
-                <version>${version.debezium}</version>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${version.jackson}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -83,85 +75,12 @@
                 <artifactId>testcontainers-bom</artifactId>
                 <version>${version.testcontainers}</version>
                 <type>pom</type>
-                <scope>test</scope>
-            </dependency>
-            <!-- Fix for CVE-2025-27820 vulnerability in httpclient5 -->
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${version.httpclient5}</version>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <!-- Debezium  -->
-        <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-server-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.slf4j</groupId>
-                    <artifactId>slf4j-jboss-logmanager</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.logmanager</groupId>
-                    <artifactId>jboss-logmanager</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-smallrye-health</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-resteasy</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-kubernetes-config</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-resteasy-jackson</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        
-        <!-- Quarkus dependencies with fixed versions -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-core</artifactId>
-            <version>${version.quarkus}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-health</artifactId>
-            <version>${version.quarkus}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-            <version>${version.quarkus}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-config</artifactId>
-            <version>${version.quarkus}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
-            <version>${version.quarkus}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-http</artifactId>
-            <version>${version.quarkus}</version>
-        </dependency>
         
         <!-- Log4j2 implementation -->
         <dependency>
@@ -185,13 +104,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.11</version>
-        </dependency>
-        <!-- Exclude JBoss logger from all other dependencies -->
-        <dependency>
-            <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logmanager</artifactId>
-            <scope>provided</scope>
+            <version>2.0.18</version>
         </dependency>
         
         <!-- Iceberg  -->
@@ -219,11 +132,17 @@
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-hive-metastore</artifactId>
         </dependency>
-        <!-- gRPC core dependencies -->
+        <!--
+          gRPC: do NOT upgrade past 1.69.x without testing server startup.
+          iceberg-gcp-bundle bundles grpc-netty-shaded classes; with grpc 1.82+
+          that stale SPI transport provider wins and ServerBuilder.build()
+          throws AbstractMethodError, so the server never starts. An exclusion
+          cannot reach it (classes are shaded in). Verified: 1.69.0 OK, 1.82.2 fails.
+        -->
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>1.69.0</version>
+            <version>${version.grpc}</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -234,17 +153,17 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>1.69.0</version>
+            <version>${version.grpc}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
-            <version>1.69.0</version>
+            <version>${version.grpc}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>1.69.0</version>
+            <version>${version.grpc}</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
@@ -257,6 +176,42 @@
             <artifactId>hive-metastore</artifactId>
             <version>${version.hive}</version>
             <exclusions>
+                <!--
+                  hive 3.1.3 drags hadoop-yarn-server 3.1.0, which pulls
+                  fst -> java-util -> json-io 2.5.1 (CVE-2023-34610) and old
+                  jetty. We only use the metastore client, never YARN.
+                -->
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
+                </exclusion>
+                <!--
+                  hive 3.1.3 pulls hbase-client 2.0.0-alpha4 (a 2017 alpha),
+                  which drags hbase-shaded-protobuf (protobuf 3.3.1) and
+                  hbase-shaded-netty (netty-all 4.1.12) = 5 HIGH CVEs.
+                  We never touch HBase; this is metastore-only usage.
+                -->
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+                <!-- HBase transaction manager, unused; drags old zookeeper -->
+                <exclusion>
+                    <groupId>co.cask.tephra</groupId>
+                    <artifactId>tephra-core</artifactId>
+                </exclusion>
+                <!--
+                  orc-core 1.5.1 drags hadoop-hdfs 2.2.0 (a 2013 release),
+                  which pulls jersey-core 1.9. We write to S3/GCS, never HDFS.
+                -->
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-hdfs</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.parquet</groupId>
                     <artifactId>parquet-hadoop-bundle</artifactId>
@@ -268,10 +223,6 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.derby</groupId>
-                    <artifactId>derby</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.jackson</groupId>
@@ -329,6 +280,32 @@
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcsio</artifactId>
             <version>${version.googlebigdataoss}</version>
+            <exclusions>
+                <!--
+                  gcsio pulls a standalone grpc-netty-shaded 1.67.1 while we
+                  use grpc 1.69.0. It is redundant: iceberg-gcp-bundle already
+                  bundles the same shaded classes, so dropping the artifact
+                  leaves exactly one source and removes a stale grpc version
+                  from the tree. Note this does NOT guard against the grpc
+                  upgrade hazard documented on the grpc-netty dependency; that
+                  copy is bundled inside iceberg-gcp-bundle and is unreachable.
+                -->
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty-shaded</artifactId>
+                </exclusion>
+                <!--
+                  jline is an interactive-console library pulled in by the
+                  hadoop shell classes. This process is a headless gRPC server
+                  and never reads from a terminal. org.jline:jline was
+                  discontinued at 3.9.0 (CVE-2026-56740/56741) and the fix
+                  ships under different coordinates, so exclude rather than pin.
+                -->
+                <exclusion>
+                    <groupId>org.jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -370,10 +347,6 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>dnsjava</groupId>
-                    <artifactId>dnsjava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -381,6 +354,25 @@
             <artifactId>hadoop-client</artifactId>
             <version>${version.hadoop}</version>
             <exclusions>
+                <!--
+                  DO NOT exclude hadoop-mapreduce-client-core. We never run
+                  MapReduce, but parquet's ParquetReadOptions$Builder loads
+                  org.apache.hadoop.mapreduce.lib.input.FileInputFormat, which
+                  lives there. Excluding it compiles and starts fine, then
+                  throws NoClassDefFoundError on the write-commit path
+                  (IcebergTableOperator.registerDataFiles -> ParquetUtil
+                  .fileMetrics -> ParquetFileReader.open).
+                  It only drags netty-all, so exclude that instead.
+                -->
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+                <!-- interactive console lib, unused by this headless server -->
+                <exclusion>
+                    <groupId>org.jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
@@ -397,21 +389,6 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-yarn-server-common</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-yarn-server-common</artifactId>
-            <version>3.3.6</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 
@@ -420,12 +397,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${version.jackson}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
-            <version>${version.quarkus}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -453,6 +424,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -481,165 +453,11 @@
             <version>3.12.14</version>
             <scope>test</scope>
         </dependency>
-        <!-- Explicitly manage vulnerable dependencies -->
+        
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${version.protobuf}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>${version.netty}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-            <version>${version.netty}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${version.netty}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${version.netty}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-core</artifactId>
-            <version>${version.vertx}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${version.commons.io}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${version.avro}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.37.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${version.snappy}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.parsson</groupId>
-            <artifactId>parsson</artifactId>
-            <version>1.1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>dnsjava</groupId>
-            <artifactId>dnsjava</artifactId>
-            <version>3.6.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${version.commons.compress}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-configuration2</artifactId>
-            <version>${version.commons.configuration}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>${version.ant}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bitbucket.b_c</groupId>
-            <artifactId>jose4j</artifactId>
-            <version>${version.jose4j}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${version.zookeeper}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        
-        <!-- Fix Jetty vulnerabilities -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-http</artifactId>
-            <version>${version.jetty}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${version.jetty}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-            <version>${version.jetty}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-xml</artifactId>
-            <version>${version.jetty}</version>
-        </dependency>
-        
-        <!-- Fix Logback vulnerabilities -->
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${version.logback}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${version.logback}</version>
-            <scope>provided</scope>
-        </dependency>
-        
-        <!-- Fix Kafka vulnerabilities -->
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${version.kafka}</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>10.17.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jettison</groupId>
-            <artifactId>jettison</artifactId>
-            <version>1.5.4</version>
-        </dependency>
-        
-        <!-- Fix for CVE-2025-27820 vulnerability -->
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${version.httpclient5}</version>
-        </dependency>
-        
-        <!-- Fix for CVE-2025-48734 vulnerability in commons-beanutils -->
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>${version.commons.beanutils}</version>
         </dependency>
     </dependencies>
     <build>

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -45,6 +45,8 @@
         <version.jackson>2.22.1</version.jackson>
         <!-- keep all grpc artifacts on one version; see warning on grpc-netty -->
         <version.grpc>1.69.0</version.grpc>
+        <!-- AWS SDK v2, managed by its BOM (AWS's documented pattern). -->
+        <version.awssdk>2.49.6</version.awssdk>
     </properties>
 
     <dependencyManagement>
@@ -60,6 +62,13 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${version.jackson}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${version.awssdk}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -172,10 +181,68 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            </dependency>
+        <!-- S3AFileSystem (hadoop-aws) uses the transfer manager -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>kms</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>glue</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>lakeformation</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssooidc</artifactId>
+            </dependency>
+        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
             <version>${version.hive}</version>
             <exclusions>
+                <!--
+                  jetty backs hadoop's HttpServer2 and hive's web UI. This is a
+                  headless gRPC writer: no web UI, no namenode, no YARN. Both
+                  remaining CVEs live here and have no obtainable fix on 9.4.x.
+                -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
                 <!--
                   hive 3.1.3 drags hadoop-yarn-server 3.1.0, which pulls
                   fst -> java-util -> json-io 2.5.1 (CVE-2023-34610) and old
@@ -258,31 +325,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-gcp-bundle</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-aws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-aws-bundle</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-dell</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-aliyun</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-azure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-azure-bundle</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.iceberg</groupId>
@@ -330,6 +373,17 @@
             <artifactId>hadoop-aws</artifactId>
             <version>${version.hadoop}</version>
             <exclusions>
+                <!--
+                  software.amazon.awssdk:bundle is the "every AWS service" fat
+                  jar (689 MB, 400+ services) and it shades its own netty.
+                  hadoop-aws only references s3/sts/kms; iceberg-aws adds
+                  dynamodb/glue/lakeformation. We declare those modules
+                  explicitly instead: far smaller, and no shaded netty copy.
+                -->
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>bundle</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>
                     <artifactId>aws-java-sdk-bundle</artifactId>
@@ -349,6 +403,19 @@
             <artifactId>hadoop-common</artifactId>
             <version>${version.hadoop}</version>
             <exclusions>
+                <!--
+                  jetty backs hadoop's HttpServer2 and hive's web UI. This is a
+                  headless gRPC writer: no web UI, no namenode, no YARN. Both
+                  remaining CVEs live here and have no obtainable fix on 9.4.x.
+                -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -372,6 +439,15 @@
             <artifactId>hadoop-client</artifactId>
             <version>${version.hadoop}</version>
             <exclusions>
+                <!-- yarn-client's ContainerShellWebSocket drags jetty; we never run YARN -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
                 <!--
                   DO NOT exclude hadoop-mapreduce-client-core. We never run
                   MapReduce, but parquet's ParquetReadOptions$Builder loads

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -212,6 +212,24 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-hdfs</artifactId>
                 </exclusion>
+                <!--
+                  hive-metastore pulls derby 10.14.1.0 (embedded SQL DB, 2017)
+                  for its own metastore-db-in-a-jar mode. We only ever talk to
+                  an external metastore/catalog; this JVM never opens a derby DB.
+                -->
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+                <!--
+                  hive-common (via hive-serde) pulls jline:jline 2.12 (old
+                  groupId, 2014) for its interactive CLI. This process is a
+                  headless gRPC server and never reads from a terminal.
+                -->
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.parquet</groupId>
                     <artifactId>parquet-hadoop-bundle</artifactId>

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -43,7 +43,8 @@
         <!-- deliberate family pins; see DEPENDENCY POLICY above -->
         <version.netty>4.1.136.Final</version.netty>
         <version.jackson>2.22.1</version.jackson>
-        <!-- keep all grpc artifacts on one version; see warning on grpc-netty -->
+        <!-- keeps the grpc artifacts we declare on one version; gcsio brings its
+             own 1.67.x grpc modules that this does not reach -->
         <version.grpc>1.69.0</version.grpc>
         <!-- AWS SDK v2, managed by its BOM (AWS's documented pattern). -->
         <version.awssdk>2.49.6</version.awssdk>
@@ -142,11 +143,11 @@
             <artifactId>iceberg-hive-metastore</artifactId>
         </dependency>
         <!--
-          gRPC: do NOT upgrade past 1.69.x without testing server startup.
-          iceberg-gcp-bundle bundles grpc-netty-shaded classes; with grpc 1.82+
-          that stale SPI transport provider wins and ServerBuilder.build()
-          throws AbstractMethodError, so the server never starts. An exclusion
-          cannot reach it (classes are shaded in). Verified: 1.69.0 OK, 1.82.2 fails.
+          grpc-netty-shaded must stay off the classpath. When present it registers
+          a second SPI transport provider that can win over this one and make
+          ServerBuilder.build() throw AbstractMethodError, so the server never
+          starts. Keep the exclusions that hold it out (here and on gcsio), and
+          re-test server startup after any grpc upgrade.
         -->
         <dependency>
             <groupId>io.grpc</groupId>
@@ -232,8 +233,8 @@
             <exclusions>
                 <!--
                   jetty backs hadoop's HttpServer2 and hive's web UI. This is a
-                  headless gRPC writer: no web UI, no namenode, no YARN. Both
-                  remaining CVEs live here and have no obtainable fix on 9.4.x.
+                  headless gRPC writer: no web UI, no namenode, no YARN. The
+                  jetty CVEs it carries have no obtainable fix on 9.4.x.
                 -->
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
@@ -343,13 +344,10 @@
             <version>${version.googlebigdataoss}</version>
             <exclusions>
                 <!--
-                  gcsio pulls a standalone grpc-netty-shaded 1.67.1 while we
-                  use grpc 1.69.0. It is redundant: iceberg-gcp-bundle already
-                  bundles the same shaded classes, so dropping the artifact
-                  leaves exactly one source and removes a stale grpc version
-                  from the tree. Note this does NOT guard against the grpc
-                  upgrade hazard documented on the grpc-netty dependency; that
-                  copy is bundled inside iceberg-gcp-bundle and is unreachable.
+                  gcsio pulls grpc-netty-shaded 1.67.1, the only remaining source
+                  of the shaded transport described on the grpc-netty dependency
+                  above. GCS reaches storage over the HTTP/JSON transport, which
+                  does not need it.
                 -->
                 <exclusion>
                     <groupId>io.grpc</groupId>
@@ -405,8 +403,8 @@
             <exclusions>
                 <!--
                   jetty backs hadoop's HttpServer2 and hive's web UI. This is a
-                  headless gRPC writer: no web UI, no namenode, no YARN. Both
-                  remaining CVEs live here and have no obtainable fix on 9.4.x.
+                  headless gRPC writer: no web UI, no namenode, no YARN. The
+                  jetty CVEs it carries have no obtainable fix on 9.4.x.
                 -->
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/IcebergUtil.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/IcebergUtil.java
@@ -10,8 +10,6 @@ package io.debezium.server.iceberg;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.Ints;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.literal.NamedLiteral;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -26,9 +24,6 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.ConfigValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +31,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.List;
 import java.util.Map;
@@ -57,59 +51,6 @@ public class IcebergUtil {
   protected static final ObjectMapper jsonObjectMapper = new ObjectMapper();
   protected static final DateTimeFormatter dtFormater = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC);
 
-
-  public static Map<String, String> getConfigSubset(Config config, String prefix) {
-    final Map<String, String> ret = new HashMap<>();
-
-    for (String propName : config.getPropertyNames()) {
-      if (propName.startsWith(prefix)) {
-        final String newPropName = propName.substring(prefix.length());
-        ret.put(newPropName, config.getValue(propName, String.class));
-      }
-    }
-
-    return ret;
-  }
-
-
-  public static boolean configIncludesUnwrapSmt() {
-    return configIncludesUnwrapSmt(ConfigProvider.getConfig());
-  }
-
-  //@TestingOnly
-  static boolean configIncludesUnwrapSmt(Config config) {
-    // first lets find the config value for debezium statements
-    ConfigValue stms = config.getConfigValue("debezium.transforms");
-    if (stms == null || stms.getValue() == null || stms.getValue().isEmpty() || stms.getValue().isBlank()) {
-      return false;
-    }
-
-    String[] stmsList = stms.getValue().split(",");
-    final String regexVal = "^io\\.debezium\\..*transforms\\.ExtractNew.*State$";
-    // we have debezium statements configured! let's check if we have event flattening config is set.
-    for (String stmName : stmsList) {
-      ConfigValue stmVal = config.getConfigValue("debezium.transforms." + stmName + ".type");
-      if (stmVal != null && stmVal.getValue() != null && !stmVal.getValue().isEmpty() && !stmVal.getValue().isBlank() && stmVal.getValue().matches(regexVal)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-
-  public static <T> T selectInstance(Instance<T> instances, String name) {
-
-    Instance<T> instance = instances.select(NamedLiteral.of(name));
-    if (instance.isAmbiguous()) {
-      throw new RuntimeException("Multiple batch size wait class named '" + name + "' were found");
-    } else if (instance.isUnsatisfied()) {
-      throw new RuntimeException("No batch size wait class named '" + name + "' is available");
-    }
-
-    LOGGER.info("Using {}", instance.getClass().getName());
-    return instance.get();
-  }
 
   /** Creates the namespace if it does not already exist, ignoring transient catalog conflicts. */
   private static void ensureNamespace(Catalog icebergCatalog, TableIdentifier tableIdentifier) {

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -1,6 +1,5 @@
 package io.debezium.server.iceberg;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -8,22 +7,17 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serde;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.debezium.serde.DebeziumSerdes;
 import io.debezium.server.iceberg.rpc.OlakeArrowIngester;
 import io.debezium.server.iceberg.rpc.OlakeRowsIngester;
 import io.debezium.server.iceberg.rpc.IcebergSession;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
-import jakarta.enterprise.context.Dependent;
 
 /**
  * Shared-JVM entry point. Catalog config is parsed once at startup; per-stream
@@ -31,17 +25,12 @@ import jakarta.enterprise.context.Dependent;
  * on every gRPC request, so a single JVM can serve all streams and chunks of an
  * OLake sync.
  */
-@Dependent
 public class OlakeRpcServer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OlakeRpcServer.class);
-    protected static final Serde<JsonNode> valSerde = DebeziumSerdes.payloadJson(JsonNode.class);
-    protected static final Serde<JsonNode> keySerde = DebeziumSerdes.payloadJson(JsonNode.class);
     final static Configuration hadoopConf = new Configuration();
     final static Map<String, String> icebergProperties = new ConcurrentHashMap<>();
     static Catalog icebergCatalog;
-    static Deserializer<JsonNode> valDeserializer;
-    static Deserializer<JsonNode> keyDeserializer;
 
     public static void main(String[] args) throws Exception {
         if (args.length < 1) {
@@ -70,11 +59,6 @@ public class OlakeRpcServer {
         String catalogName = stringConfigMap.getOrDefault("catalog-name", "iceberg");
 
         icebergCatalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergProperties, hadoopConf);
-
-        valSerde.configure(Collections.emptyMap(), false);
-        valDeserializer = valSerde.deserializer();
-        keySerde.configure(Collections.emptyMap(), true);
-        keyDeserializer = keySerde.deserializer();
 
         boolean arrowWriterEnabled = Boolean.parseBoolean(
             stringConfigMap.getOrDefault("arrow-writer-enabled", "false"));

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeArrowIngester.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeArrowIngester.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.server.iceberg.rpc.RecordIngest.ArrowPayload;
 import io.grpc.stub.StreamObserver;
-import jakarta.enterprise.context.Dependent;
 
 /**
  * Multi-Thread-Session gRPC service for the Arrow Iceberg write path.
@@ -31,7 +30,6 @@ import jakarta.enterprise.context.Dependent;
  * from the JSONSCHEMA payload that creates the session; every later payload
  * (FILEPATH / UPLOAD_FILE / REGISTER_AND_COMMIT) carries only the thread_id.
  */
-@Dependent
 public class OlakeArrowIngester extends ArrowIngestServiceGrpc.ArrowIngestServiceImplBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(OlakeArrowIngester.class);
     private static final String FILE_TYPE_DATA = "data";

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
@@ -13,13 +13,11 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.DebeziumException;
 import io.debezium.server.iceberg.IcebergUtil;
 import io.debezium.server.iceberg.SchemaConvertor;
 import io.debezium.server.iceberg.rpc.RecordIngest.IcebergPayload;
 import io.debezium.server.iceberg.tableoperator.RecordWrapper;
 import io.grpc.stub.StreamObserver;
-import jakarta.enterprise.context.Dependent;
 
 /**
  * Multi-Thread-Session gRPC service for the legacy (rows-based) Iceberg write path.
@@ -37,7 +35,6 @@ import jakarta.enterprise.context.Dependent;
  * session; later payloads carry only thread_id (+ evolving schema), so the JVM
  * still needs no global config.
  */
-@Dependent
 public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServiceImplBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(OlakeRowsIngester.class);
 
@@ -217,7 +214,7 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
                 String errorMessage = String.format("Failed to create table from debezium event schema: %s Error: %s",
                                                     tableId, e.getMessage());
                 LOGGER.error(errorMessage, e);
-                throw new DebeziumException(errorMessage, e);
+                throw new RuntimeException(errorMessage, e);
             }
         });
     }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperator.java
@@ -46,14 +46,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.debezium.server.iceberg.rpc.RecordIngest.ArrowPayload;
-import jakarta.enterprise.context.Dependent;
 
 /**
  * Wrapper to perform operations on iceberg tables
  *
  * @author Rafael Acevedo
  */
-@Dependent
 public class IcebergTableOperator {
 
   IcebergTableWriterFactory writerFactory2;

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableWriterFactory.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/tableoperator/IcebergTableWriterFactory.java
@@ -1,7 +1,6 @@
 package io.debezium.server.iceberg.tableoperator;
 
 import io.debezium.server.iceberg.IcebergUtil;
-import jakarta.enterprise.context.Dependent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.Table;
@@ -27,7 +26,6 @@ import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DE
  * Fields are plain (no @ConfigProperty) because the shared JVM hosts many operators
  * with possibly different upsert flags; each operator sets these explicitly.
  */
-@Dependent
 public class IcebergTableWriterFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(IcebergTableWriterFactory.class);
   public boolean upsert = true;

--- a/drivers/mongodb/go.mod
+++ b/drivers/mongodb/go.mod
@@ -7,10 +7,7 @@ replace (
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80
 )
 
-require (
-	github.com/datazip-inc/olake v0.0.0-20241104091615-994075730612
-	github.com/jackc/pgx/v4 v4.18.3
-)
+require github.com/datazip-inc/olake v0.0.0-20241104091615-994075730612
 
 require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
@@ -40,11 +37,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.14.3 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
-	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
@@ -106,8 +98,6 @@ require (
 	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect

--- a/drivers/mongodb/main.go
+++ b/drivers/mongodb/main.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/datazip-inc/olake"
 	driver "github.com/datazip-inc/olake/drivers/mongodb/internal"
-	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 func main() {

--- a/drivers/mysql/go.mod
+++ b/drivers/mysql/go.mod
@@ -10,8 +10,6 @@ replace (
 require (
 	github.com/datazip-inc/olake v0.0.0-20250312070222-ed705d25bc0c
 	github.com/go-sql-driver/mysql v1.8.1
-	github.com/jackc/pgproto3/v2 v2.3.3 // indirect; Added explicit requirement
-	github.com/jackc/pgx/v4 v4.18.3 // Updated from v4.15.0
 )
 
 require github.com/jmoiron/sqlx v1.4.0
@@ -37,10 +35,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.14.3 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
-	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/linkedin/goavro/v2 v2.15.0 // indirect
@@ -110,8 +104,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/drivers/mysql/main.go
+++ b/drivers/mysql/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/datazip-inc/olake"
 	driver "github.com/datazip-inc/olake/drivers/mysql/internal"
-	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 func main() {

--- a/drivers/oracle/go.mod
+++ b/drivers/oracle/go.mod
@@ -9,7 +9,6 @@ replace (
 
 require (
 	github.com/datazip-inc/olake v0.0.0-00010101000000-000000000000
-	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/sijms/go-ora/v2 v2.8.24
 	golang.org/x/crypto v0.53.0
@@ -49,13 +48,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.14.3 // indirect
-	github.com/jackc/pgio v1.0.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect

--- a/drivers/oracle/main.go
+++ b/drivers/oracle/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/datazip-inc/olake"
 	driver "github.com/datazip-inc/olake/drivers/oracle/internal"
-	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 func main() {

--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -48,13 +48,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.14.3 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
@@ -112,7 +108,6 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/drivers/postgres/main.go
+++ b/drivers/postgres/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/datazip-inc/olake"
 	driver "github.com/datazip-inc/olake/drivers/postgres/internal"
-	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-playground/validator/v10 v10.25.0
 	github.com/goccy/go-json v0.10.5
 	github.com/jackc/pglogrepl v0.0.0-20250322012620-f1e2b1498ed6
-	github.com/jackc/pgtype v1.14.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/linkedin/goavro/v2 v2.15.0
@@ -36,7 +35,6 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
-	github.com/jackc/pgx/v4 v4.18.3 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect

--- a/pkg/waljs/bytes.go
+++ b/pkg/waljs/bytes.go
@@ -3,7 +3,7 @@ package waljs
 import (
 	"strings"
 
-	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // NumericBinaryBytes returns the size (in bytes) of a PostgreSQL NUMERIC value from

--- a/pkg/waljs/pgoutput.go
+++ b/pkg/waljs/pgoutput.go
@@ -13,8 +13,8 @@ import (
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/jackc/pglogrepl"
-	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jmoiron/sqlx"
 )
 


### PR DESCRIPTION
# Description
Adds a `trivy-java` job to the security CI that scans the Java Iceberg writer for known HIGH/CRITICAL vulnerabilities. Replaces the long-disabled TODO block that was removed because raw `pom.xml` filesystem scans hung for hours.


Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):