### PR TITLE
feat: emit bytes read stats in telemetry

### DIFF
--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -144,7 +144,8 @@ var syncCmd = &cobra.Command{
 		// Sync Telemetry tracking
 		telemetry.TrackSyncStarted(syncID, selectedStreamsMetadata.SelectedStreams, selectedStreamsMetadata.FullLoadStreams, selectedStreamsMetadata.CDCStreams, connector.Type(), destinationConfig, catalog)
 		defer func() {
-			telemetry.TrackSyncCompleted(syncID, err == nil, pool.GetStats().ReadCount.Load())
+			stats := pool.GetStats()
+			telemetry.TrackSyncCompleted(syncID, err == nil, stats.ReadCount.Load(), stats.BytesRead.Load())
 			logger.Infof("Sync completed, wait 5 seconds cleanup in progress...")
 			time.Sleep(5 * time.Second)
 		}()

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -135,7 +135,7 @@ func TrackSyncStarted(syncID string, selectedStreams []string, fullLoadStreams, 
 	}()
 }
 
-func TrackSyncCompleted(syncID string, status bool, records int64) {
+func TrackSyncCompleted(syncID string, status bool, records, bytesRead int64) {
 	go func() {
 		if telemetry == nil {
 			return
@@ -145,6 +145,7 @@ func TrackSyncCompleted(syncID string, status bool, records int64) {
 			"sync_end":       time.Now(),
 			"sync_status":    utils.Ternary(status, "SUCCESS", "FAILED").(string),
 			"records_synced": records,
+			"bytes_read":     bytesRead,
 		}
 
 		if err := telemetry.sendEvent("Sync Completed - CLI", props); err != nil {


### PR DESCRIPTION
# Description

bytes read by olake has been added in stats.json , this pr adds support to emit this stat through telemetry as well.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Emitted events by running mysql and postgres sync

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):