### PR TITLE
feat(iceberg): add gcp_project_id for BigLake request routing header

### DIFF
--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	// GCP auth for GoogleAuthManager (e.g. BigLake). Inline SA key JSON;
 	GCPServiceAccountJSON string `json:"gcp_service_account_json,omitempty"`
 	GCPAuthScopes         string `json:"gcp_auth_scopes,omitempty"`
+	// Required by BigLake for request routing/billing (sent as the x-goog-user-project header).
+	GCPProjectID string `json:"gcp_project_id,omitempty"`
 
 	UseArrowWrites bool `json:"arrow_writes,omitempty"`
 }

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -91,6 +91,8 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool, gcpC
 		addMapKeyIfNotEmpty("scope", config.RestScope)
 		addMapKeyIfNotEmpty("gcp.auth.credentials-path", gcpCredsTemp)
 		addMapKeyIfNotEmpty("gcp.auth.scopes", config.GCPAuthScopes)
+		// BigLake requires this header for request routing/billing.
+		addMapKeyIfNotEmpty("header.x-goog-user-project", config.GCPProjectID)
 	default:
 		return nil, fmt.Errorf("unsupported catalog type: %s", config.CatalogType)
 	}

--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -215,6 +215,11 @@
                   "title": "GCP Auth Scopes",
                   "description": "Comma-separated OAuth2 scopes for GoogleAuthManager. Defaults to https://www.googleapis.com/auth/cloud-platform if left empty"
                 },
+                "gcp_project_id": {
+                  "type": "string",
+                  "title": "GCP Project ID",
+                  "description": "Required by BigLake for request routing/billing (sent as the x-goog-user-project header)"
+                },
                 "no_identifier_fields": {
                   "type": "boolean",
                   "default": false,

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -461,6 +461,7 @@ const IcebergUISchema = `{
       { "rest_signing_name": 12, "rest_signing_region": 12 },
       { "rest_signing_v_4": 12, "scope": 12, "s3_endpoint": 12 },
       { "gcp_service_account_json": 12, "gcp_auth_scopes": 12 },
+      { "gcp_project_id": 12 },
       { "aws_access_key": 12, "aws_secret_key": 12 },
       { "aws_region": 12, "glue_additional_config": 12 },
 	 { "glue_catalog_id": 12, "glue_access_key": 12, "glue_secret_key": 12 },


### PR DESCRIPTION
# Description

BigLake's REST catalog rejects requests with "missing x-goog-user-project header" unless the GCP project is explicitly sent. Add gcp_project_id config field

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):