### PR TITLE
fix(docker): keep the JVM trust store in sync with the OS on Temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,24 @@ FROM eclipse-temurin:17-jre-noble
 # Debian's openjdk-*-jre-headless pulls ca-certificates-java, whose postinst is
 # a perl script, which drags in perl (2 CRITICAL CVEs with no fix in any Debian
 # release) plus libnss3. Temurin ships the JRE directly and avoids both.
+#
+# ca-certificates-java + the symlink keep the OS trust store and the JVM's in
+# sync. Debian's openjdk did this for us; Temurin instead bakes a static cacerts,
+# so a private CA added to the OS store would never reach the JVM and TLS to an
+# internal REST catalog, Hive metastore or self-signed S3 endpoint would fail with
+# "PKIX path building failed" while the Go side (which reads /etc/ssl/certs) kept
+# working. Ubuntu's ca-certificates-java, unlike Debian's, needs no perl.
+# update-ca-certificates must run here: the symlink dangles until it materializes
+# the keystore, and a dangling cacerts means the JVM trusts nothing at all.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     libxml2 \
     ca-certificates \
+    ca-certificates-java \
     libpam-modules \
     libcrypt1 \
+    && ln -sf /etc/ssl/certs/java/cacerts "$JAVA_HOME/lib/security/cacerts" \
+    && update-ca-certificates -f \
     && rm -rf /var/lib/apt/lists/*
 
 # Driver metadata


### PR DESCRIPTION
# Description

Temurin bakes a static cacerts instead of symlinking the OS-managed one the way Debian's openjdk did. A private CA added to the OS trust store therefore never reached the JVM, so TLS to an internal REST catalog, Hive metastore or self-signed S3 endpoint failed with "PKIX path building failed" while the Go drivers, which read /etc/ssl/certs directly, kept working.

Install ca-certificates-java and symlink cacerts to restore the sync.Ubuntu's package, unlike Debian's, has no perl postinst, so the CVE reduction from switching to Temurin is preserved.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):