### PR TITLE
chore: gitignore local Claude Code tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tests/*/testdata/**/logs
 tests/*/testdata/**/state.json
 tests/*/testdata/**/stats.json
 tests/*/testdata/**/streams.json
+.cocoindex_code/
+CLAUDE.local.md


### PR DESCRIPTION
Adds .cocoindex_code/ and CLAUDE.local.md to .gitignore. Machine-local Claude Code tooling artifacts, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)