### PR TITLE
chore: added size based batching

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -53,6 +53,9 @@ const (
 
 	// CdcTimestamp is the column name olake writes the CDC event timestamp into.
 	CdcTimestamp = "_cdc_timestamp"
+
+	// MaxDestinationBatchBytes is the maximum source bytes held in a writer thread buffer before flush.
+	MaxDestinationBatchBytes = int64(1) * 1024 * 1024 * 1024 // 1 GB
 )
 
 // DriverType identifies a source/destination driver.

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -65,7 +65,7 @@ public class OlakeRpcServer {
 
         int port = Integer.parseInt(stringConfigMap.getOrDefault("port", "50051"));
         int maxMessageSize = Integer.parseInt(
-            stringConfigMap.getOrDefault("max-message-size", "" + (1024 * 1024 * 1024)));
+            stringConfigMap.getOrDefault("max-message-size", String.valueOf(Integer.MAX_VALUE)));
 
         ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port)
                     .maxInboundMessageSize(maxMessageSize);

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -64,6 +64,9 @@ public class OlakeRpcServer {
             stringConfigMap.getOrDefault("arrow-writer-enabled", "false"));
 
         int port = Integer.parseInt(stringConfigMap.getOrDefault("port", "50051"));
+        // Set the gRPC message size to the maximum value supported by an int (2 GB - 1),
+        // while the writer buffer is limited to 1 GB, allowing the server to handle the
+        // entire contents of the writer buffer as a single message.
         int maxMessageSize = Integer.parseInt(
             stringConfigMap.getOrDefault("max-message-size", String.valueOf(Integer.MAX_VALUE)));
 

--- a/destination/writers.go
+++ b/destination/writers.go
@@ -208,17 +208,16 @@ func (wt *WriterThread) Push(ctx context.Context, record types.RawRecord, source
 	default:
 		wt.stats.ReadCount.Add(1)
 		wt.recordsPushed.Add(1)
+		if sourceBytes != 0 {
+			wt.stats.BytesRead.Add(sourceBytes)
+			wt.bytesPushed.Add(sourceBytes)
+		}
 		if len(wt.buffer) > 0 && wt.bufferBytes+sourceBytes > constants.MaxDestinationBatchBytes {
 			wt.pushBufferFlush()
 		}
 
 		wt.buffer = append(wt.buffer, record)
 		wt.bufferBytes += sourceBytes
-		if sourceBytes != 0 {
-			wt.stats.BytesRead.Add(sourceBytes)
-			wt.bytesPushed.Add(sourceBytes)
-		}
-
 		if len(wt.buffer) >= int(wt.batchSize) || wt.bufferBytes >= constants.MaxDestinationBatchBytes {
 			wt.pushBufferFlush()
 		}

--- a/destination/writers.go
+++ b/destination/writers.go
@@ -212,27 +212,19 @@ func (wt *WriterThread) Push(ctx context.Context, record types.RawRecord, source
 			wt.stats.BytesRead.Add(sourceBytes)
 			wt.bytesPushed.Add(sourceBytes)
 		}
-		if len(wt.buffer) > 0 && wt.bufferBytes+sourceBytes > constants.MaxDestinationBatchBytes {
-			wt.pushBufferFlush()
-		}
-
 		wt.buffer = append(wt.buffer, record)
 		wt.bufferBytes += sourceBytes
 		if len(wt.buffer) >= int(wt.batchSize) || wt.bufferBytes >= constants.MaxDestinationBatchBytes {
-			wt.pushBufferFlush()
+			buf := make([]types.RawRecord, len(wt.buffer))
+			copy(buf, wt.buffer)
+			wt.buffer = wt.buffer[:0]
+			wt.bufferBytes = 0
+			wt.group.Add(func(ctx context.Context) error {
+				return wt.flush(ctx, buf)
+			})
 		}
 		return nil
 	}
-}
-
-func (wt *WriterThread) pushBufferFlush() {
-	buf := make([]types.RawRecord, len(wt.buffer))
-	copy(buf, wt.buffer)
-	wt.buffer = wt.buffer[:0]
-	wt.bufferBytes = 0
-	wt.group.Add(func(ctx context.Context) error {
-		return wt.flush(ctx, buf)
-	})
 }
 
 func (wt *WriterThread) flush(ctx context.Context, buf []types.RawRecord) (err error) {

--- a/destination/writers.go
+++ b/destination/writers.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
@@ -59,6 +60,7 @@ type (
 		recordsPushed   atomic.Int64
 		recordsFiltered atomic.Int64
 		bytesPushed     atomic.Int64
+		bufferBytes     int64 // source bytes currently held in buffer (for byte-based flush)
 	}
 )
 
@@ -193,8 +195,9 @@ func (w *WriterPool) NewWriter(ctx context.Context, stream types.StreamInterface
 }
 
 // Push appends a record to the thread buffer and updates the live stats. sourceBytes
-// is the record's source read size (0 if the driver does not report it). Both the read
-// count and the bytes-read count are added live and rolled back by Close if the chunk/run fails (see rollbackStats).
+// is the record's source read size (0 if the driver does not report it). Buffer batching
+// flushes when buffered source bytes would exceed MaxDestinationBatchBytes. sourceBytes
+// is added live to stats and rolled back by Close if the chunk/run fails (see rollbackStats).
 func (wt *WriterThread) Push(ctx context.Context, record types.RawRecord, sourceBytes int64) error {
 	select {
 	case <-ctx.Done():
@@ -205,21 +208,32 @@ func (wt *WriterThread) Push(ctx context.Context, record types.RawRecord, source
 	default:
 		wt.stats.ReadCount.Add(1)
 		wt.recordsPushed.Add(1)
+		if len(wt.buffer) > 0 && wt.bufferBytes+sourceBytes > constants.MaxDestinationBatchBytes {
+			wt.pushBufferFlush()
+		}
+
+		wt.buffer = append(wt.buffer, record)
+		wt.bufferBytes += sourceBytes
 		if sourceBytes != 0 {
 			wt.stats.BytesRead.Add(sourceBytes)
 			wt.bytesPushed.Add(sourceBytes)
 		}
-		wt.buffer = append(wt.buffer, record)
-		if len(wt.buffer) >= int(wt.batchSize) {
-			buf := make([]types.RawRecord, len(wt.buffer))
-			copy(buf, wt.buffer)
-			wt.buffer = wt.buffer[:0]
-			wt.group.Add(func(ctx context.Context) error {
-				return wt.flush(ctx, buf)
-			})
+
+		if len(wt.buffer) >= int(wt.batchSize) || wt.bufferBytes >= constants.MaxDestinationBatchBytes {
+			wt.pushBufferFlush()
 		}
 		return nil
 	}
+}
+
+func (wt *WriterThread) pushBufferFlush() {
+	buf := make([]types.RawRecord, len(wt.buffer))
+	copy(buf, wt.buffer)
+	wt.buffer = wt.buffer[:0]
+	wt.bufferBytes = 0
+	wt.group.Add(func(ctx context.Context) error {
+		return wt.flush(ctx, buf)
+	})
 }
 
 func (wt *WriterThread) flush(ctx context.Context, buf []types.RawRecord) (err error) {


### PR DESCRIPTION
# Description

Added a variable sized grpc such that based on size batches will be formed

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] i reduced the grpc max size to 20mb ,setted constant MaxDestinationBatchBytes to 10mb and than ran a sync on staging as well as on current branch and as expected it failed on staging and passed here.
- [ ] Scenario B

# Screenshots or Recordings
N/A

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):