### PR TITLE
chore: remove default values in rest_auth_type for Iceberg Catalogs

### DIFF
--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -316,9 +316,6 @@
                     "OAuth2",
                     "Token"
                   ],
-                  "default": [
-                    "None"
-                  ],
                   "description": "Authentication types supported by the catalog"
                 },
                 "rest_catalog_url": {
@@ -414,9 +411,6 @@
                     "None",
                     "OAuth2",
                     "Token"
-                  ],
-                  "default": [
-                    "None"
                   ],
                   "description": "Authentication types supported by the catalog"
                 },
@@ -527,9 +521,6 @@
                   "type": "string",
                   "title": "Authentication Type",
                   "enum": [
-                    "sigv4"
-                  ],
-                  "default": [
                     "sigv4"
                   ],
                   "description": "Authentication types supported by the catalog"
@@ -825,9 +816,6 @@
                   "type": "string",
                   "title": "Authentication Type",
                   "enum": [
-                    "GCP"
-                  ],
-                  "default": [
                     "GCP"
                   ],
                   "description": "Authentication types supported by the catalog"


### PR DESCRIPTION
# Description

Remove default values for `rest_auth_type` on Iceberg catalogs - Lakekeeper, Nessie, S3Tables, Biglake

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] locally tested

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->
N/A
## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

