### PR TITLE
fix: issue with flush last batch

### DIFF
--- a/destination/writers.go
+++ b/destination/writers.go
@@ -302,7 +302,7 @@ func (wt *WriterThread) Close(closeCtx context.Context, finalMetadataState any) 
 	default:
 		defer wt.stats.ThreadCount.Add(-1)
 
-		// for cancelling on flush error
+		// for canceling on flush error
 		ctx, cancel := context.WithCancel(closeCtx)
 		defer cancel()
 

--- a/destination/writers.go
+++ b/destination/writers.go
@@ -286,28 +286,38 @@ func (wt *WriterThread) rollbackStats() {
 	wt.stats.BytesRead.Add(-wt.bytesPushed.Load())
 }
 
-func (wt *WriterThread) Close(ctx context.Context, finalMetadataState any) (err error) {
+func (wt *WriterThread) Close(closeCtx context.Context, finalMetadataState any) (err error) {
 	select {
-	case <-ctx.Done():
+	case <-closeCtx.Done():
 		// Wait for in-flight flushes so rollback below can't race their stat updates.
 		// Block's error is ctx cancellation that brought us here, so ignored.
 		_ = wt.group.Block()
 		// Aborted before commit: writer.Close releases resources without committing,
 		// so nothing this thread pushed reaches the destination — roll its stats back.
 		wt.rollbackStats()
-		if closeErr := wt.writer.Close(ctx, finalMetadataState); closeErr != nil {
+		if closeErr := wt.writer.Close(closeCtx, finalMetadataState); closeErr != nil {
 			return fmt.Errorf("failed to close writer: %s", closeErr)
 		}
 		return nil
 	default:
 		defer wt.stats.ThreadCount.Add(-1)
+
+		// for cancelling on flush error
+		ctx, cancel := context.WithCancel(closeCtx)
+		defer cancel()
+
 		defer func() {
+			if err != nil {
+				cancel()
+			}
+
 			wt.streamArtifact.mu.Lock()
 			defer wt.streamArtifact.mu.Unlock()
 
 			if closeErr := wt.writer.Close(ctx, finalMetadataState); closeErr != nil {
 				err = utils.Ternary(err == nil, closeErr, fmt.Errorf("%s: flush error: %w", closeErr, err)).(error)
 			}
+
 			// Commit is successful only when both the final flush and writer.Close (dest
 			// COMMIT) returned no error. All source bytes were already added live via
 			// Push, so success needs no action; on any failure roll back this thread's
@@ -324,6 +334,7 @@ func (wt *WriterThread) Close(ctx context.Context, finalMetadataState any) (err 
 		if err := wt.group.Block(); err != nil {
 			return fmt.Errorf("failed to flush data while closing: %s", err)
 		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
# Description
Fixing an issue in the flush writer
  - a bug that is not stopping commits on error in the last batch flush
  - the error message gets overridden by other errors. 

Blast Radius of bug:
 - if there is an error in schema evolution that is thrown by the Go side (e.g. int to string conversion), it might miss the records.
Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):