### PR TITLE
fix(iceberg): bump httpclient5 to 5.6.3 to fix CVE-2026-54399

### DIFF
--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "master"
-    paths:
+    paths: &security-paths
       - '**/*.go'
       - '**/*.java'
       - '**/go.mod'
@@ -15,14 +15,7 @@ on:
   pull_request:
     branches:
       - "*"
-    paths:
-      - '**/*.go'
-      - '**/*.java'
-      - '**/go.mod'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '**/pom.xml'
-      - '**/.trivyignore'
+    paths: *security-paths
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/security-ci.yaml
+++ b/.github/workflows/security-ci.yaml
@@ -10,6 +10,8 @@ on:
       - '**/go.mod'
       - '**/*.yml'
       - '**/*.yaml'
+      - '**/pom.xml'
+      - '**/.trivyignore'
   pull_request:
     branches:
       - "*"
@@ -19,6 +21,8 @@ on:
       - '**/go.mod'
       - '**/*.yml'
       - '**/*.yaml'
+      - '**/pom.xml'
+      - '**/.trivyignore'
   workflow_dispatch:
     inputs:
       logLevel:

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -43,6 +43,11 @@
     <version.grpc>1.69.0</version.grpc>
     <!-- AWS SDK v2, managed by its BOM (AWS's documented pattern). -->
     <version.awssdk>2.49.6</version.awssdk>
+    <!-- iceberg-core 1.10.2 ships httpclient5 5.5, whose httpcore5 5.3.4 has
+             CVE-2026-54399 (fixed in httpcore5 5.4.3). Bumping the parent client
+             pulls the fixed core transitively; Apache Iceberg main pins this same
+             5.6.3. Drop when Iceberg itself ships httpclient5 >= 5.6.2. -->
+    <version.httpclient5>5.6.3</version.httpclient5>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -80,6 +85,11 @@
         <version>${version.testcontainers}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Description

iceberg-core 1.10.2 ships httpclient5 5.5, whose httpcore5 5.3.4 is vulnerable to a DoS via excessive HTTP headers (fixed in 5.4.3). Managing the parent client at 5.6.3 pulls the fixed core transitively; this is the same version Apache Iceberg pins on main. Drop the pin once Iceberg ships a release with httpclient5 >= 5.6.2.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):