### PR TITLE
chore: bump go version 1.25.12 -> 1.25.13

### DIFF
--- a/.cursor/rules/olake.mdc
+++ b/.cursor/rules/olake.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 
 OLake is an open-source, high-performance **EL (Extract-Load)** tool that replicates data from databases, Kafka, and S3 into **Apache Iceberg** tables or **plain Parquet** files.
 
-- **Languages:** Go 1.25.12 (primary) + Java 17 (Iceberg writer)
+- **Languages:** Go 1.25.13 (primary) + Java 17 (Iceberg writer)
 - **Go workspace:** `go.work` links the root module with 8 driver sub-modules
 - **CLI:** Cobra-based commands: `spec`, `check`, `discover`, `sync`, `clear`
 - **Sources:** Postgres, MongoDB, MySQL, Oracle, MSSQL, DB2, Kafka, S3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.25.12-bookworm AS makefiles
+FROM golang:1.25.13-bookworm AS makefiles
 WORKDIR /home/app
 COPY . .
 RUN mkdir /out && cp --parents Makefile $(find drivers -maxdepth 2 -name driver.mk) /out
 
 # Build Stage
-FROM golang:1.25.12-bookworm AS builder
+FROM golang:1.25.13-bookworm AS builder
 
 WORKDIR /home/app
 

--- a/drivers/db2/go.mod
+++ b/drivers/db2/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/db2
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	cloud.google.com/go/compute => cloud.google.com/go/compute v1.23.3

--- a/drivers/kafka/go.mod
+++ b/drivers/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/kafka
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/mongodb/go.mod
+++ b/drivers/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mongodb
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/mssql/go.mod
+++ b/drivers/mssql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mssql
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/mysql/go.mod
+++ b/drivers/mysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/mysql
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/oracle/go.mod
+++ b/drivers/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/oracle
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/postgres
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../../

--- a/drivers/s3/go.mod
+++ b/drivers/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/drivers/s3
 
-go 1.25.12
+go 1.25.13
 
 replace (
 	github.com/datazip-inc/olake => ../..

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.17

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.12
+go 1.25.13
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 use (
 	.

--- a/tests/db2/go.mod
+++ b/tests/db2/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/db2
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/go.work
+++ b/tests/go.work
@@ -1,6 +1,6 @@
-go 1.25.12
+go 1.25.13
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 use (
 	./db2

--- a/tests/kafka/go.mod
+++ b/tests/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/kafka
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/mongodb/go.mod
+++ b/tests/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/mongodb
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/mssql/go.mod
+++ b/tests/mssql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/mssql
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/mysql/go.mod
+++ b/tests/mysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/mysql
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/oracle/go.mod
+++ b/tests/oracle/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/oracle
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/postgres/go.mod
+++ b/tests/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/postgres
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/s3/go.mod
+++ b/tests/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/s3
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0

--- a/tests/testutils/go.mod
+++ b/tests/testutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake/tests/testutils
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/apache/arrow-go/v18 v18.2.0


### PR DESCRIPTION
# Description

`govulncheck` fails on every PR with 5 vulnerabilities, all in the Go standard library and all fixed in **go1.25.13** (released 2026-08-13).

| ID | Package |
|---|---|
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` — quadratic complexity in `resolvePath` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` — unbounded post-handshake messages |
| [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088) | `encoding/xml` — `DecodeElement` bypasses the recursion-depth guard |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` — unbounded recursion depth |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` — `x/net/idna` accepts ASCII-only Punycode labels |

The security CI job resolves its toolchain from `go.mod` (`setup-go` with `go-version-file: "go.mod"`), which pinned `1.25.12` — so the scan evaluated a 1.25.12 standard library and flagged all five as reachable.

This bumps every Go version pin `1.25.12 -> 1.25.13` (25 occurrences, 22 files):
- `go.mod`, 8 `drivers/*/go.mod`, 9 `tests/*/go.mod`
- `go.work` and `tests/go.work` (`go` and `toolchain` directiv
- `Dockerfile` (both `golang:1.25.13-bookworm` stages)
- `.cursor/rules/olake.mdc` (documented toolchain version)

Patch-level bump only — no language version change and no sour

### Breaking-change review

Every fix in the [Go1.25.13 milestone](https://github.com/golaAGo1.25.13+label%3ACherryPickApproved) was checked against our usage. Nothing in the release changes an API or a language semantic

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Integration Tests

# Screenshots or Recordings
This upgrade doesn't have any breaking change for us
<img width="1084" height="414" alt="image" src="https://github.com/user-attachments/assets/fe41109d-a6cc-49ae-a9c8-6509629a413b" />

## Documentation
- [x] N/A (dependency/toolchain bump, no user-facing change)
