### PR TITLE
chore(iceberg): remove unused test-scope dependencies from java write

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,3 +22,20 @@ jobs:
 
       - name: Run All Unit Tests
         run: make test.unit
+
+  java-unit-tests:
+    name: Run Java Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run Java Unit Tests
+        working-directory: destination/iceberg/olake-iceberg-java-writer
+        run: mvn -B --no-transfer-progress test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 olake
 .vscode
 test
+# `test` matches any depth; keep the Iceberg writer's Maven test sources.
+!destination/iceberg/olake-iceberg-java-writer/src/test/
 .DS_Store
 __debug_bin*
 go.sum

--- a/connector.go
+++ b/connector.go
@@ -17,6 +17,7 @@ func RegisterDriver(driver abstract.DriverInterface) {
 	// Execute the root command
 	err := protocol.CreateRootCommand(true, driver).Execute()
 	if err != nil {
+		protocol.ReportFailure(err)
 		logger.Fatal(err)
 	}
 

--- a/destination/errors.go
+++ b/destination/errors.go
@@ -1,0 +1,28 @@
+package destination
+
+import "errors"
+
+// codeDestinationTypeInvalid names a destination type the config asked for and no writer serves.
+const codeDestinationTypeInvalid = "destination.type_invalid"
+
+// writeFailure marks an error raised by the writer itself — a record that could not be encoded,
+// flushed or committed. It carries no category on purpose: classification takes the innermost
+// answer, so each writer's classifier checks this marker last, after its own vendor rules.
+type writeFailure struct{ err error }
+
+func (w writeFailure) Error() string { return w.err.Error() }
+func (w writeFailure) Unwrap() error { return w.err }
+
+// WriteFailure marks err as raised by the writer itself.
+func WriteFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	return writeFailure{err: err}
+}
+
+// IsWriteFailure reports whether err was marked by WriteFailure.
+func IsWriteFailure(err error) bool {
+	var marker writeFailure
+	return errors.As(err, &marker)
+}

--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, options *destination.Options, partitionInfo []inte
 	}
 
 	if err := writer.initialize(ctx); err != nil {
-		return nil, fmt.Errorf("failed to initialize: %s", err)
+		return nil, fmt.Errorf("failed to initialize: %w", err)
 	}
 
 	return writer, nil
@@ -209,7 +209,7 @@ func (w *ArrowWriter) Write(ctx context.Context, records []types.RawRecord) erro
 	var err error
 
 	if err := w.extract(ctx, records); err != nil {
-		return fmt.Errorf("failed to partition data: %s", err)
+		return fmt.Errorf("failed to partition data: %w", err)
 	}
 
 	for pKey, writer := range w.writers {
@@ -294,7 +294,7 @@ func (w *ArrowWriter) checkAndFlush(ctx context.Context, rw *RollingWriter, part
 
 	newFilePath, err := w.allocateFilePath(ctx, partitionKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate new file path after flush: %s", err)
+		return nil, fmt.Errorf("failed to allocate new file path after flush: %w", err)
 	}
 	newWriter.filePath = newFilePath
 
@@ -312,7 +312,7 @@ func (w *ArrowWriter) flush(ctx context.Context, rw *RollingWriter, partitionKey
 	}
 
 	if err := w.uploadFile(ctx, rw, partitionKey); err != nil {
-		return fmt.Errorf("failed to upload parquet during flush: %s", err)
+		return fmt.Errorf("failed to upload parquet during flush: %w", err)
 	}
 
 	return nil
@@ -320,13 +320,13 @@ func (w *ArrowWriter) flush(ctx context.Context, rw *RollingWriter, partitionKey
 
 func (w *ArrowWriter) EvolveSchema(ctx context.Context, newSchema map[string]string) error {
 	if err := w.completeWriters(ctx); err != nil {
-		return fmt.Errorf("failed to flush writers during schema evolution: %s", err)
+		return fmt.Errorf("failed to flush writers during schema evolution: %w", err)
 	}
 
 	w.schema = newSchema
 
 	if err := w.initialize(ctx); err != nil {
-		return fmt.Errorf("failed to reinitialize with evolved schema: %s", err)
+		return fmt.Errorf("failed to reinitialize with evolved schema: %w", err)
 	}
 
 	return nil
@@ -335,7 +335,7 @@ func (w *ArrowWriter) EvolveSchema(ctx context.Context, newSchema map[string]str
 // Close flushes all writers and commits files to Iceberg.
 func (w *ArrowWriter) Close(ctx context.Context, finalMetadataState any) error {
 	if err := w.completeWriters(ctx); err != nil {
-		return fmt.Errorf("failed to close arrow writers: %s", err)
+		return fmt.Errorf("failed to close arrow writers: %w", err)
 	}
 
 	// Build ordered file list: equality deletes → data → positional deletes
@@ -364,7 +364,7 @@ func (w *ArrowWriter) Close(ctx context.Context, finalMetadataState any) error {
 	defer cancel()
 
 	if _, err := w.server.SendClientRequest(commitCtx, commitRequest); err != nil {
-		return fmt.Errorf("failed to commit arrow files: %s", err)
+		return fmt.Errorf("failed to commit arrow files: %w", err)
 	}
 
 	return nil
@@ -483,7 +483,7 @@ func (w *ArrowWriter) initializeDeleteSchemas() error {
 func (w *ArrowWriter) createWriter(ctx context.Context, pKey string, values []any, schema arrow.Schema, fileType string) (*RollingWriter, error) {
 	filePath, err := w.allocateFilePath(ctx, pKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate file path: %s", err)
+		return nil, fmt.Errorf("failed to allocate file path: %w", err)
 	}
 
 	rw, err := w.newRollingWriter(ctx, schema, fileType, values, filePath)
@@ -534,7 +534,7 @@ func (w *ArrowWriter) allocateFilePath(ctx context.Context, partitionKey string)
 
 	resp, err := w.server.SendClientRequest(reqCtx, request)
 	if err != nil {
-		return "", fmt.Errorf("failed to allocate file path: %s", err)
+		return "", fmt.Errorf("failed to allocate file path: %w", err)
 	}
 
 	basePath := resp.(*proto.ArrowIngestResponse).GetResult()
@@ -564,7 +564,7 @@ func (w *ArrowWriter) uploadFile(ctx context.Context, rw *RollingWriter, partiti
 	defer cancel()
 
 	if _, err := w.server.SendClientRequest(uploadCtx, request); err != nil {
-		return fmt.Errorf("failed to upload %s file: %s", rw.fileType, err)
+		return fmt.Errorf("failed to upload %s file: %w", rw.fileType, err)
 	}
 
 	protoPartitionValues, err := toProtoPartitionValues(rw.partitionValues)
@@ -611,7 +611,7 @@ func (w *ArrowWriter) fetchFileSchemaJSON(ctx context.Context) error {
 
 	resp, err := w.server.SendClientRequest(schemaCtx, request)
 	if err != nil {
-		return fmt.Errorf("failed to fetch schema JSON from server: %s", err)
+		return fmt.Errorf("failed to fetch schema JSON from server: %w", err)
 	}
 
 	w.fileschemajson = resp.(*proto.ArrowIngestResponse).GetIcebergSchemas()

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 )
 
@@ -90,7 +91,8 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c.IcebergS3Path == "" {
-		return fmt.Errorf("s3_path is required")
+		return errs.Precondition(errs.ConfigInvalid, codeCatalogConfigInvalid,
+			fmt.Errorf("s3_path is required"))
 	}
 
 	// Set defaults for catalog type
@@ -144,27 +146,31 @@ func (c *Config) Validate() error {
 	switch c.CatalogType {
 	case JDBCCatalog:
 		if c.JDBCUrl == "" {
-			return fmt.Errorf("jdbc_url is required when using JDBC catalog")
+			return errs.Precondition(errs.ConfigInvalid, codeCatalogConfigInvalid,
+				fmt.Errorf("jdbc_url is required when using JDBC catalog"))
 		}
 	case RestCatalog:
 		if c.RestCatalogURL == "" {
-			return fmt.Errorf("rest_catalog_url is required when using REST catalog")
+			return errs.Precondition(errs.ConfigInvalid, codeCatalogConfigInvalid,
+				fmt.Errorf("rest_catalog_url is required when using REST catalog"))
 		}
 	case HiveCatalog:
 		if c.HiveURI == "" {
-			return fmt.Errorf("hive_uri is required when using Hive catalog")
+			return errs.Precondition(errs.ConfigInvalid, codeCatalogConfigInvalid,
+				fmt.Errorf("hive_uri is required when using Hive catalog"))
 		}
 	case GlueCatalog:
 		// No additional validation required for Glue catalog
 	default:
-		return fmt.Errorf("unsupported catalog_type: %s", c.CatalogType)
+		return errs.Precondition(errs.ConfigInvalid, codeUnsupportedCatalogType,
+			fmt.Errorf("unsupported catalog_type: %s", c.CatalogType))
 	}
 
 	if c.JarPath == "" {
 		// Set JarPath based on file existence in two possible locations
 		execDir, err := os.Getwd()
 		if err != nil {
-			return fmt.Errorf("failed to get current directory for searching jar file: %s", err)
+			return fmt.Errorf("failed to get current directory for searching jar file: %w", err)
 		}
 
 		// Remove /drivers/* from execDir if present
@@ -185,8 +191,9 @@ func (c *Config) Validate() error {
 				logger.Infof("Iceberg JAR file found in target directory: %s", targetJarPath)
 				c.JarPath = targetJarPath
 			} else {
-				return fmt.Errorf("Iceberg JAR file not found in any of the expected locations: %s, %s. Go to destination/iceberg/olake-iceberg-java-writer/target/ directory and run mvn clean package -DskipTests",
-					baseJarPath, targetJarPath)
+				return errs.Precondition(errs.InternalError, codeJarNotFound,
+					fmt.Errorf("Iceberg JAR file not found in any of the expected locations: %s, %s. Go to destination/iceberg/olake-iceberg-java-writer/target/ directory and run mvn clean package -DskipTests",
+						baseJarPath, targetJarPath))
 			}
 		}
 	}

--- a/destination/iceberg/errors.go
+++ b/destination/iceberg/errors.go
@@ -1,0 +1,312 @@
+package iceberg
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/datazip-inc/olake/destination"
+	"github.com/datazip-inc/olake/pkg/objstorage"
+	"github.com/datazip-inc/olake/utils/errs"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Stamped by the writer on every ErrorInfo it attaches, so details from other libraries
+// passing through are ignored.
+const (
+	javaErrorDomain            = "olake.iceberg"
+	javaMetadataCode           = "code"
+	codeCatalogConfigInvalid   = "iceberg.catalog_config_invalid"
+	codeUnsupportedCatalogType = "iceberg.unsupported_catalog_type"
+	codeJarNotFound            = "iceberg.jar_not_found"
+	codeJVMStartFailed         = "iceberg.jvm_start_failed"
+	codePartitionRegexNoMatch  = "iceberg.partition_regex_no_match"
+)
+
+// errJVMStart marks the startup path so the classifier can find it with errors.Is, not message text.
+var errJVMStart = errors.New("failed to start iceberg java writer and setup logger")
+
+// startupCause pulls the root cause's class out of the line OlakeRpcServer prints on its way out.
+var startupCause = regexp.MustCompile(`Iceberg writer failed to start \[([^\]]+)\]`)
+
+// javaExceptions maps the exception the Iceberg JVM caught to a failure category.
+var javaExceptions = map[string]errs.Category{
+	// The catalog does not have it.
+	"NoSuchTableException":        errs.ObjectNotFound,
+	"NoSuchNamespaceException":    errs.ObjectNotFound,
+	"NoSuchViewException":         errs.ObjectNotFound,
+	"EntityNotFoundException":     errs.ObjectNotFound,
+	"NoSuchKeyException":          errs.ObjectNotFound,
+	"NoSuchWarehouseException":    errs.ObjectNotFound,
+	"NoSuchObjectException":       errs.ObjectNotFound,
+	"UnknownDBException":          errs.ObjectNotFound,
+	"NotFoundException":           errs.ObjectNotFound,
+	"NoSuchIcebergTableException": errs.ObjectNotFound,
+	"NoSuchIcebergViewException":  errs.ObjectNotFound,
+
+	// At the catalog or at object storage.
+	"NotAuthorizedException": errs.AuthFailed,
+	"ForbiddenException":     errs.PermissionDenied,
+	"AccessDeniedException":  errs.PermissionDenied,
+	"SaslException":          errs.AuthFailed,
+	"LoginException":         errs.AuthFailed,
+	"GSSException":           errs.AuthFailed,
+	"AccessControlException": errs.PermissionDenied,
+	"GoogleAuthException":    errs.AuthFailed,
+	"TokenResponseException": errs.AuthFailed,
+
+	// Two writers reached the same table. The first clears on retry; the others leave a commit
+	// only the catalog can settle.
+	"CommitFailedException":           errs.ConcurrencyConflict,
+	"AlreadyExistsException":          errs.CatalogError,
+	"CommitStateUnknownException":     errs.CatalogError,
+	"ConcurrentModificationException": errs.ConcurrencyConflict,
+	"LockException":                   errs.ConcurrencyConflict,
+	"WaitingForLockException":         errs.ConcurrencyConflict,
+	"VersionMismatchException":        errs.ConcurrencyConflict,
+
+	// The records do not fit the table.
+	"ValidationException": errs.SchemaUnsupported,
+
+	// Reachability, seen from the JVM rather than from Go.
+	"UnknownHostException":       errs.DNSResolutionFailed,
+	"ConnectException":           errs.NetworkUnreachable,
+	"NoRouteToHostException":     errs.NetworkUnreachable,
+	"HttpHostConnectException":   errs.NetworkUnreachable,
+	"NoHttpResponseException":    errs.NetworkUnreachable,
+	"ConnectionClosedException":  errs.NetworkUnreachable,
+	"SocketException":            errs.NetworkUnreachable,
+	"TTransportException":        errs.NetworkUnreachable,
+	"MetaException":              errs.NetworkUnreachable,
+	"RuntimeMetaException":       errs.NetworkUnreachable,
+	"SocketTimeoutException":     errs.Timeout,
+	"ConnectTimeoutException":    errs.Timeout,
+	"SSLHandshakeException":      errs.TLSFailed,
+	"CertificateException":       errs.TLSFailed,
+	"SSLPeerUnverifiedException": errs.TLSFailed,
+
+	// REST catalog HTTP status shapes, and leftover REST / Hive / JDBC / Glue classes.
+	"ServiceUnavailableException":              errs.NetworkUnreachable,
+	"ServiceFailureException":                  errs.CatalogError,
+	"RESTException":                            errs.CatalogError,
+	"BadRequestException":                      errs.ConfigInvalid,
+	"UnprocessableEntityException":             errs.ConfigInvalid,
+	"NamespaceNotEmptyException":               errs.CatalogError,
+	"InvalidObjectException":                   errs.CatalogError,
+	"InvalidOperationException":                errs.CatalogError,
+	"TException":                               errs.CatalogError,
+	"TApplicationException":                    errs.CatalogError,
+	"UncheckedSQLException":                    errs.CatalogError,
+	"GoogleJsonResponseException":              errs.CatalogError,
+	"InvalidInputException":                    errs.ConfigInvalid,
+	"InternalServiceException":                 errs.NetworkUnreachable,
+	"OperationTimeoutException":                errs.Timeout,
+	"ResourceNumberLimitExceededException":     errs.ResourceExhausted,
+	"GlueEncryptionException":                  errs.PermissionDenied,
+	"UncheckedInterruptedException":            errs.Canceled,
+	"SQLTimeoutException":                      errs.Timeout,
+	"SQLTransientConnectionException":          errs.NetworkUnreachable,
+	"SQLNonTransientConnectionException":       errs.NetworkUnreachable,
+	"SQLInvalidAuthorizationSpecException":     errs.AuthFailed,
+	"SQLIntegrityConstraintViolationException": errs.CatalogError,
+	"SQLTransactionRollbackException":          errs.ConcurrencyConflict,
+	"SQLFeatureNotSupportedException":          errs.UnsupportedFeature,
+
+	// The JVM ran out.
+	"OutOfMemoryError": errs.ResourceExhausted,
+
+	// It understood the request and will not serve it.
+	"UnsupportedOperationException": errs.UnsupportedFeature,
+
+	// Defects in the writer, not conditions a user can fix.
+	"NoClassDefFoundError":     errs.InternalError,
+	"ClassNotFoundException":   errs.InternalError,
+	"NullPointerException":     errs.InternalError,
+	"AssertionError":           errs.InternalError,
+	"IllegalArgumentException": errs.InternalError,
+	"IllegalStateException":    errs.InternalError,
+}
+
+// sqlStateClasses maps the two-character SQLSTATE class a JDBC catalog reports to a category.
+// Only the class: it is standardized across vendors, while the last three characters are
+// vendor-specific and a catalog can be any database.
+var sqlStateClasses = map[string]errs.Category{
+	"28": errs.AuthFailed,          // invalid authorization specification
+	"08": errs.NetworkUnreachable,  // connection exception
+	"40": errs.ConcurrencyConflict, // transaction rollback
+	"53": errs.ResourceExhausted,   // insufficient resources
+	"57": errs.ResourceExhausted,   // operator intervention
+	"3D": errs.ObjectNotFound,      // invalid catalog name
+	"3F": errs.ObjectNotFound,      // invalid schema name
+	"23": errs.CatalogError,        // integrity constraint violation
+	"25": errs.CatalogError,        // invalid transaction state
+	"0A": errs.UnsupportedFeature,  // feature not supported
+}
+
+// sqlStateClass returns the class of a SQLSTATE, or "" for anything that is not one.
+func sqlStateClass(code string) string {
+	if len(code) != 5 {
+		return ""
+	}
+	return code[:2]
+}
+
+// grpcCategories maps a gRPC status code to a failure category — transport level only. These
+// are the codes gRPC produces when the call never reached application code: the JVM is not up,
+// the deadline passed, the channel was torn down. Anything the JVM caught arrives as INTERNAL.
+var grpcCategories = map[codes.Code]errs.Category{
+	codes.Unavailable:       errs.NetworkUnreachable, // the JVM is not listening, or the channel dropped
+	codes.DeadlineExceeded:  errs.Timeout,
+	codes.Canceled:          errs.Canceled,
+	codes.PermissionDenied:  errs.PermissionDenied,
+	codes.Unauthenticated:   errs.AuthFailed,
+	codes.NotFound:          errs.ObjectNotFound,
+	codes.ResourceExhausted: errs.ResourceExhausted,
+	codes.Unimplemented:     errs.UnsupportedFeature,
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only gRPC
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("iceberg", classify) }
+
+// classify reads the gRPC status from the Iceberg JVM, then the writer marker. Order matters: a
+// JVM that is not listening explains a write failure better than the write failure does.
+func classify(err error) *errs.Failure {
+	if f := fromGRPCStatus(err); f != nil {
+		return f
+	}
+	if f := fromJVMStart(err); f != nil {
+		return f
+	}
+	if destination.IsWriteFailure(err) {
+		return &errs.Failure{
+			Category:     errs.DestinationWriteError,
+			ClassifiedBy: errs.ClassifiedByPrecondition,
+		}
+	}
+	return nil
+}
+
+// fromJVMStart classifies a JVM that died before it could serve. Same evidence as fromErrorInfo —
+// the root cause's class — arriving on stderr because no gRPC channel exists yet to carry it.
+func fromJVMStart(err error) *errs.Failure {
+	if !errors.Is(err, errJVMStart) {
+		return nil
+	}
+	// Killed, or dead without naming a cause: the phase is the only thing left to report.
+	f := errs.Failure{Category: errs.Unclassified, ClassifiedBy: errs.ClassifiedByDefault, Code: codeJVMStartFailed}
+
+	match := startupCause.FindStringSubmatch(err.Error())
+	if match == nil {
+		return &f
+	}
+	// The line carries the fully-qualified class; the table is keyed on the simple name.
+	f.Code = match[1]
+	if i := strings.LastIndex(f.Code, "."); i >= 0 {
+		f.Code = f.Code[i+1:]
+	}
+	if category, mapped := javaExceptions[f.Code]; mapped {
+		f.Category, f.ClassifiedBy = category, errs.ClassifiedByVendor
+	}
+	return &f
+}
+
+// fromGRPCStatus classifies a failure the gRPC channel reported. status.FromError reaches the
+// status through %w wrapping, which is why the leaf wraps on this path had to become %w.
+func fromGRPCStatus(err error) *errs.Failure {
+	if err == nil {
+		return nil
+	}
+	grpcStatus, ok := status.FromError(err)
+	if !ok || grpcStatus == nil || grpcStatus.Code() == codes.OK {
+		return nil
+	}
+
+	// Read first: the status is INTERNAL for everything the JVM handles, so the detail is the
+	// only thing that identifies which failure it was.
+	if f := fromErrorInfo(grpcStatus); f != nil {
+		return f
+	}
+
+	// Prefixed because it is the transport's answer, not Iceberg's: a bare "NotFound" would
+	// read as a missing table when it means the gRPC method was not found.
+	code := fmt.Sprintf("grpc.%s", grpcStatus.Code().String())
+
+	if category, mapped := grpcCategories[grpcStatus.Code()]; mapped {
+		return &errs.Failure{
+			Category:     category,
+			ClassifiedBy: errs.ClassifiedByVendor,
+			Code:         code,
+		}
+	}
+
+	// Almost always Internal, which the JVM sends for everything it catches and so identifies
+	// nothing. Unclassified keeps that share visible; any category would be wrong for most.
+	return &errs.Failure{
+		Category:     errs.Unclassified,
+		ClassifiedBy: errs.ClassifiedByDefault,
+		Code:         code,
+	}
+}
+
+// fromErrorInfo reads the structured detail the Iceberg writer attaches to a failed call. Only
+// our own domain is read, so another library's ErrorInfo cannot be mistaken for one of ours.
+func fromErrorInfo(grpcStatus *status.Status) *errs.Failure {
+	for _, detail := range grpcStatus.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok || info.GetDomain() != javaErrorDomain {
+			continue
+		}
+
+		// Reason is the fully-qualified class; the table is keyed on the simple name.
+		exception := info.GetReason()
+		if i := strings.LastIndex(exception, "."); i >= 0 {
+			exception = exception[i+1:]
+		}
+
+		// A JDBC SQLSTATE is more precise and shares a code space with the Postgres and Db2
+		// sources; otherwise the exception names the failure.
+		code := info.GetMetadata()[javaMetadataCode]
+		if code == "" {
+			code = exception
+		}
+
+		if category, mapped := javaExceptions[exception]; mapped {
+			return &errs.Failure{
+				Category:     category,
+				ClassifiedBy: errs.ClassifiedByVendor,
+				Code:         code,
+			}
+		}
+		// The JVM writes straight to object storage through its own AWS SDK, and raises a bare
+		// S3Exception whatever the reason — the meaning is in the service code, the same one
+		// the S3 source and the parquet destination read.
+		if category, mapped := objstorage.ServiceCodeCategories[code]; mapped {
+			return &errs.Failure{
+				Category:     category,
+				ClassifiedBy: errs.ClassifiedByVendor,
+				Code:         code,
+			}
+		}
+		// A JDBC catalog raises classes this table cannot enumerate, but supplies a SQLSTATE
+		// whose class is standardized — the same code space the SQL sources report.
+		if category, mapped := sqlStateClasses[sqlStateClass(info.GetMetadata()[javaMetadataCode])]; mapped {
+			return &errs.Failure{
+				Category:     category,
+				ClassifiedBy: errs.ClassifiedByVendor,
+				Code:         code,
+			}
+		}
+		// No rule covers it yet. The class name is what a rule would be written from.
+		return &errs.Failure{
+			Category:     errs.Unclassified,
+			ClassifiedBy: errs.ClassifiedByDefault,
+			Code:         code,
+			ErrorType:    info.GetReason(),
+		}
+	}
+	return nil
+}

--- a/destination/iceberg/iceberg.go
+++ b/destination/iceberg/iceberg.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datazip-inc/olake/destination/iceberg/proto"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/spf13/viper"
@@ -72,7 +73,7 @@ func (i *Iceberg) Setup(ctx context.Context, stream types.StreamInterface, _ any
 	var err error
 	i.partitionInfo, err = parsePartitionRegex(stream.GetPartitionRegex(), stream.ResolveColumnName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse partition regex: %s", err)
+		return nil, nil, fmt.Errorf("failed to parse partition regex: %w", err)
 	}
 	logger.Debugf("Thread[%s]: setting up iceberg writer for table[%s.%s]", i.options.ThreadID, stream.GetDestinationDatabase(&i.config.IcebergDatabase), stream.GetDestinationTable())
 
@@ -110,21 +111,21 @@ func (i *Iceberg) Setup(ctx context.Context, stream types.StreamInterface, _ any
 
 	response, err := i.server.SendClientRequest(ctx, &requestPayload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load or create table: %s", err)
+		return nil, nil, fmt.Errorf("failed to load or create table: %w", err)
 	}
 
 	// get schema from response
 	ingestResponse := response.(*proto.RecordIngestResponse)
 	schema, err := parseSchema(ingestResponse.GetResult())
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse schema from resp[%s]: %s", ingestResponse.GetResult(), err)
+		return nil, nil, fmt.Errorf("failed to parse schema from resp[%s]: %w", ingestResponse.GetResult(), err)
 	}
 
 	// get metadata state from response
 	var metadataState types.MetadataState
 	if olake2PCState := ingestResponse.GetOlake_2PcState(); olake2PCState != "" {
 		if err := json.Unmarshal([]byte(olake2PCState), &metadataState); err != nil {
-			return schema, nil, fmt.Errorf("failed to unmarshal 2pc metadata state: %s", err)
+			return schema, nil, fmt.Errorf("failed to unmarshal 2pc metadata state: %w", err)
 		}
 	}
 
@@ -134,7 +135,7 @@ func (i *Iceberg) Setup(ctx context.Context, stream types.StreamInterface, _ any
 	if i.config.UseArrowWrites {
 		i.writer, err = arrowwriter.New(ctx, i.options, i.partitionInfo, i.schema, i.stream, i.server, isUpsertMode(i.stream, i.options.Backfill))
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create arrow writer: %s", err)
+			return nil, nil, destination.WriteFailure(fmt.Errorf("failed to create arrow writer: %w", err))
 		}
 	} else {
 		i.writer = legacywriter.New(i.options, i.schema, i.stream, i.server)
@@ -164,7 +165,7 @@ func (i *Iceberg) Close(ctx context.Context, finalMetadataState any) (err error)
 			if err == nil {
 				err = cleanupErr
 			} else {
-				err = fmt.Errorf("%s: cleanup error: %w", err, cleanupErr)
+				err = fmt.Errorf("%w: cleanup error: %w", err, cleanupErr)
 			}
 		}
 	}()
@@ -202,7 +203,7 @@ func (i *Iceberg) Check(ctx context.Context) error {
 
 	res, err := i.server.SendClientRequest(ctx, request)
 	if err != nil {
-		return fmt.Errorf("failed to create or get table: %s", err)
+		return fmt.Errorf("failed to create or get table: %w", err)
 	}
 
 	ingestResponse := res.(*proto.RecordIngestResponse)
@@ -214,7 +215,7 @@ func (i *Iceberg) Check(ctx context.Context) error {
 	record := types.CreateRawRecord(map[string]any{"name": "olake"}, map[string]any{constants.OlakeID: "olake", constants.OpType: "r", constants.CdcTimestamp: &currentTime})
 	protoColumns, err := legacywriter.RawDataColumnBuffer(record, protoSchema)
 	if err != nil {
-		return fmt.Errorf("failed to create raw data column buffer: %s", err)
+		return destination.WriteFailure(fmt.Errorf("failed to create raw data column buffer: %w", err))
 	}
 	recrodInsertRequest := &proto.IcebergPayload{
 		Type: proto.IcebergPayload_RECORDS,
@@ -232,7 +233,7 @@ func (i *Iceberg) Check(ctx context.Context) error {
 
 	resInsert, err := i.server.SendClientRequest(ctx, recrodInsertRequest)
 	if err != nil {
-		return fmt.Errorf("failed to insert request: %s", err)
+		return fmt.Errorf("failed to insert request: %w", err)
 	}
 
 	ingestResponse = resInsert.(*proto.RecordIngestResponse)
@@ -301,7 +302,7 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 		err := utils.Concurrent(ctx, records, runtime.GOMAXPROCS(0)*16, func(_ context.Context, record types.RawRecord, idx int) error {
 			flattenRecord, err := batchFlattener.Flatten(record.Data)
 			if err != nil {
-				return fmt.Errorf("failed to flatten record, iceberg writer: %s", err)
+				return fmt.Errorf("failed to flatten record, iceberg writer: %w", err)
 			}
 			records[idx].Data = flattenRecord
 			maps.Copy(records[idx].Data, record.OlakeColumns)
@@ -309,7 +310,7 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 			if !diffThreadSchema.Load() {
 				// when detectChange is true, the function does not modify schema parameter
 				if changeDetected, err := detectOrUpdateSchema(records[idx], true, i.schema, i.schema); err != nil {
-					return fmt.Errorf("failed to detect schema: %s", err)
+					return fmt.Errorf("failed to detect schema: %w", err)
 				} else if changeDetected {
 					diffThreadSchema.Store(true)
 				}
@@ -318,7 +319,7 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 			return nil
 		})
 		if err != nil {
-			return false, nil, fmt.Errorf("failed to flatten schema concurrently and detect change in records: %s", err)
+			return false, nil, fmt.Errorf("failed to flatten schema concurrently and detect change in records: %w", err)
 		}
 
 		// if schema difference is detected, update schemaMap with the new schema
@@ -327,7 +328,7 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 			for _, record := range records {
 				_, err := detectOrUpdateSchema(record, false, i.schema, schemaMap)
 				if err != nil {
-					return false, nil, fmt.Errorf("failed to update schema: %s", err)
+					return false, nil, fmt.Errorf("failed to update schema: %w", err)
 				}
 			}
 		}
@@ -340,7 +341,7 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 			// JSON-encode original source data before overwriting the map
 			dataBytes, err := json.Marshal(record.Data)
 			if err != nil {
-				return fmt.Errorf("failed to marshal raw data: %s", err)
+				return destination.WriteFailure(fmt.Errorf("failed to marshal raw data: %w", err))
 			}
 			records[idx].Data = make(map[string]any, len(record.OlakeColumns)+1+len(i.partitionInfo))
 			records[idx].Data[constants.StringifiedData] = string(dataBytes)
@@ -360,24 +361,24 @@ func (i *Iceberg) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 			return nil
 		})
 		if err != nil {
-			return false, nil, nil, fmt.Errorf("failed to pre-shape raw records: %s", err)
+			return false, nil, nil, fmt.Errorf("failed to pre-shape raw records: %w", err)
 		}
 		return false, records, i.schema, nil
 	}
 
 	schemaDifference, recordsSchema, err := extractSchemaFromRecords(ctx, records)
 	if err != nil {
-		return false, nil, nil, fmt.Errorf("failed to extract schema from records: %s", err)
+		return false, nil, nil, fmt.Errorf("failed to extract schema from records: %w", err)
 	}
 
 	if i.options.ApplyFilter {
 		filter, isLegacy, filterErr := i.stream.GetFilter()
 		if filterErr != nil {
-			return false, nil, nil, fmt.Errorf("failed to parse stream filter: %s", filterErr)
+			return false, nil, nil, fmt.Errorf("failed to parse stream filter: %w", filterErr)
 		}
 		records, err = typeutils.FilterRecords(ctx, records, filter, isLegacy, recordsSchema, i.stream.ResolveColumnName)
 		if err != nil {
-			return false, nil, nil, fmt.Errorf("failed to filter records: %s", err)
+			return false, nil, nil, fmt.Errorf("failed to filter records: %w", err)
 		}
 	}
 
@@ -443,7 +444,7 @@ func (i *Iceberg) EvolveSchema(ctx context.Context, globalSchema, recordsRawSche
 
 	resp, err := i.server.SendClientRequest(ctx, &request)
 	if err != nil {
-		return false, fmt.Errorf("failed to %s: %s", request.Type.String(), err)
+		return false, fmt.Errorf("failed to %s: %w", request.Type.String(), err)
 	}
 
 	response := resp.(*proto.RecordIngestResponse).GetResult()
@@ -451,12 +452,12 @@ func (i *Iceberg) EvolveSchema(ctx context.Context, globalSchema, recordsRawSche
 	// only refresh table schema
 	schemaAfterEvolution, err := parseSchema(response)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse schema from resp[%s]: %s", response, err)
+		return nil, fmt.Errorf("failed to parse schema from resp[%s]: %w", response, err)
 	}
 
 	i.schema = copySchema(schemaAfterEvolution)
 	if err := i.writer.EvolveSchema(ctx, schemaAfterEvolution); err != nil {
-		return nil, fmt.Errorf("failed to evolve writer schema: %v", err)
+		return nil, destination.WriteFailure(fmt.Errorf("failed to evolve writer schema: %w", err))
 	}
 
 	return schemaAfterEvolution, nil
@@ -474,7 +475,8 @@ func parsePartitionRegex(pattern string, resolveColumnName func(string) string) 
 	patternRegex := regexp.MustCompile(constants.PartitionRegexIceberg)
 	matches := patternRegex.FindAllStringSubmatch(pattern, -1)
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no matches found for partition regex: %s", pattern)
+		return nil, errs.Precondition(errs.ConfigInvalid, codePartitionRegexNoMatch,
+			fmt.Errorf("no matches found for partition regex: %s", pattern))
 	}
 
 	for _, match := range matches {
@@ -547,7 +549,7 @@ func (i *Iceberg) DropStreams(ctx context.Context, tables []types.StreamInterfac
 		}
 		_, err := i.server.SendClientRequest(ctx, &request)
 		if err != nil {
-			return fmt.Errorf("failed to drop table %s: %s", dropTable, err)
+			return fmt.Errorf("failed to drop table %s: %w", dropTable, err)
 		}
 	}
 

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/datazip-inc/olake/destination/iceberg/proto"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -94,7 +95,8 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool, gcpC
 		// BigLake requires this header for request routing/billing.
 		addMapKeyIfNotEmpty("header.x-goog-user-project", config.GCPProjectID)
 	default:
-		return nil, fmt.Errorf("unsupported catalog type: %s", config.CatalogType)
+		return nil, errs.Precondition(errs.ConfigInvalid, codeUnsupportedCatalogType,
+			fmt.Errorf("unsupported catalog type: %s", config.CatalogType))
 	}
 	// Only set access keys if explicitly provided, otherwise they'll be picked up from
 	// environment variables or AWS credential files
@@ -215,7 +217,7 @@ func startServer(config *Config) (*serverInstance, error) {
 		if gcpCredsTemp != "" {
 			os.Remove(gcpCredsTemp)
 		}
-		return nil, fmt.Errorf("failed to start iceberg java writer and setup logger: %w", err)
+		return nil, fmt.Errorf("%w: %w", errJVMStart, err)
 	}
 
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%s", config.ServerHost, strconv.Itoa(port)),

--- a/destination/iceberg/legacy-writer/writer.go
+++ b/destination/iceberg/legacy-writer/writer.go
@@ -93,7 +93,7 @@ func (w *LegacyWriter) Write(ctx context.Context, records []types.RawRecord) err
 	// Send the batch to the server
 	res, err := w.server.SendClientRequest(reqCtx, request)
 	if err != nil {
-		return fmt.Errorf("failed to send batch: %s", err)
+		return fmt.Errorf("failed to send batch: %w", err)
 	}
 
 	ingestResponse := res.(*proto.RecordIngestResponse)
@@ -130,7 +130,7 @@ func (w *LegacyWriter) Close(ctx context.Context, finalMetadataState any) error 
 
 	res, err := w.server.SendClientRequest(ctx, request)
 	if err != nil {
-		return fmt.Errorf("failed to send commit message: %s", err)
+		return fmt.Errorf("failed to send commit message: %w", err)
 	}
 
 	ingestResponse := res.(*proto.RecordIngestResponse)

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -37,6 +37,7 @@
     <version.log4j2>2.26.1</version.log4j2>
     <!-- deliberate family pins; see DEPENDENCY POLICY above -->
     <version.netty>4.1.136.Final</version.netty>
+    <version.junit>5.11.4</version.junit>
     <version.jackson>2.22.1</version.jackson>
     <!-- keeps the grpc artifacts we declare on one version; gcsio brings its
              own 1.67.x grpc modules that this does not reach -->
@@ -51,6 +52,13 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
@@ -516,6 +524,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>5.14.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -32,7 +32,6 @@
     <version.hadoop>3.5.0</version.hadoop>
     <version.hive>3.1.3</version.hive>
     <version.googlebigdataoss>2.2.28</version.googlebigdataoss>
-    <version.testcontainers>1.20.4</version.testcontainers>
     <version.protobuf>3.25.5</version.protobuf>
     <version.log4j2>2.26.1</version.log4j2>
     <!-- deliberate family pins; see DEPENDENCY POLICY above -->
@@ -84,13 +83,6 @@
         <groupId>org.apache.iceberg</groupId>
         <artifactId>iceberg-bom</artifactId>
         <version>${version.iceberg}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${version.testcontainers}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -396,13 +388,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- aws-java-sdk-bundle Test dependency -->
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-bundle</artifactId>
-      <version>1.11.1026</version>
-      <scope>test</scope>
-    </dependency>
     <!-- Hadoop -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -521,34 +506,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>5.14.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>mysql</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>mongodb</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>minio</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/OlakeRpcServer.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.server.iceberg.rpc.OlakeArrowIngester;
+import io.debezium.server.iceberg.rpc.OlakeFailures;
 import io.debezium.server.iceberg.rpc.OlakeRowsIngester;
 import io.debezium.server.iceberg.rpc.IcebergSession;
 import io.grpc.Server;
@@ -32,68 +33,84 @@ public class OlakeRpcServer {
     final static Map<String, String> icebergProperties = new ConcurrentHashMap<>();
     static Catalog icebergCatalog;
 
-    public static void main(String[] args) throws Exception {
-        if (args.length < 1) {
-            LOGGER.error("Please provide a JSON config as an argument.");
-            System.exit(1);
-        }
-
-        String jsonConfig = args[0];
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> configMap = objectMapper.readValue(jsonConfig, new TypeReference<Map<String, Object>>() {
-        });
-        LOGGER.info("Logs will be output to console only");
-
-        // Only catalog/storage-level config is consumed here. Stream-level context
-        // (namespace, upsert, partition-fields, identifier-fields) comes per-request.
-        Map<String, String> stringConfigMap = new ConcurrentHashMap<>();
-        configMap.forEach((key, value) -> {
-            if (value != null) {
-                stringConfigMap.put(key, value.toString());
+    public static void main(String[] args) throws InterruptedException {
+        Server server;
+        try {
+            if (args.length < 1) {
+                LOGGER.error("Please provide a JSON config as an argument.");
+                System.exit(1);
             }
-        });
 
-        stringConfigMap.forEach(hadoopConf::set);
-        icebergProperties.putAll(stringConfigMap);
+            String jsonConfig = args[0];
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String, Object> configMap = objectMapper.readValue(jsonConfig,
+                    new TypeReference<Map<String, Object>>() {
+                    });
+            LOGGER.info("Logs will be output to console only");
 
-        String catalogName = stringConfigMap.getOrDefault("catalog-name", "iceberg");
+            // Only catalog/storage-level config is consumed here. Stream-level context
+            // (namespace, upsert, partition-fields, identifier-fields) comes per-request.
+            Map<String, String> stringConfigMap = new ConcurrentHashMap<>();
+            configMap.forEach((key, value) -> {
+                if (value != null) {
+                    stringConfigMap.put(key, value.toString());
+                }
+            });
 
-        icebergCatalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergProperties, hadoopConf);
+            stringConfigMap.forEach(hadoopConf::set);
+            icebergProperties.putAll(stringConfigMap);
 
-        boolean arrowWriterEnabled = Boolean.parseBoolean(
-            stringConfigMap.getOrDefault("arrow-writer-enabled", "false"));
+            String catalogName = stringConfigMap.getOrDefault("catalog-name", "iceberg");
 
-        int port = Integer.parseInt(stringConfigMap.getOrDefault("port", "50051"));
-        // Set the gRPC message size to the maximum value supported by an int (2 GB - 1),
-        // while the writer buffer is limited to 1 GB, allowing the server to handle the
-        // entire contents of the writer buffer as a single message.
-        int maxMessageSize = Integer.parseInt(
-            stringConfigMap.getOrDefault("max-message-size", String.valueOf(Integer.MAX_VALUE)));
+            icebergCatalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergProperties, hadoopConf);
 
-        ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port)
-                    .maxInboundMessageSize(maxMessageSize);
+            boolean arrowWriterEnabled = Boolean.parseBoolean(
+                stringConfigMap.getOrDefault("arrow-writer-enabled", "false"));
 
-        ConcurrentMap<String, IcebergSession> sharedSessions = new ConcurrentHashMap<>();
+            int port = Integer.parseInt(stringConfigMap.getOrDefault("port", "50051"));
+            // Set the gRPC message size to the maximum value supported by an int (2 GB - 1),
+            // while the writer buffer is limited to 1 GB, allowing the server to handle the
+            // entire contents of the writer buffer as a single message.
+            int maxMessageSize = Integer.parseInt(
+                stringConfigMap.getOrDefault("max-message-size", String.valueOf(Integer.MAX_VALUE)));
 
-        if (arrowWriterEnabled) {
-             OlakeArrowIngester oai = new OlakeArrowIngester(sharedSessions);
-             serverBuilder.addService(oai);
-             LOGGER.info("Arrow writer enabled - registered OlakeArrowIngester service");
+            ServerBuilder<?> serverBuilder = ServerBuilder.forPort(port)
+                        .maxInboundMessageSize(maxMessageSize);
+
+            ConcurrentMap<String, IcebergSession> sharedSessions = new ConcurrentHashMap<>();
+
+            if (arrowWriterEnabled) {
+                 OlakeArrowIngester oai = new OlakeArrowIngester(sharedSessions);
+                 serverBuilder.addService(oai);
+                 LOGGER.info("Arrow writer enabled - registered OlakeArrowIngester service");
+            }
+
+            // Legacy ingester is always registered (Check, GET_OR_CREATE_TABLE, DROP_TABLE
+            // and the default RECORDS path all flow through it).
+            OlakeRowsIngester ori = new OlakeRowsIngester(icebergCatalog, sharedSessions);
+            serverBuilder.addService(ori);
+            LOGGER.info("Legacy writer enabled - registered OlakeRowsIngester service");
+
+            server = serverBuilder.build().start();
+
+            // Graceful shutdown so the OS sees the gRPC port released cleanly.
+            Runtime.getRuntime().addShutdownHook(new Thread(server::shutdown, "olake-grpc-shutdown"));
+
+            LOGGER.info("Server started on port {} with max message size: {}MB",
+                        port, (maxMessageSize / (1024 * 1024)));
+        } catch (Throwable t) {
+            // stderr, not LOGGER: that is stdout, and Go only keeps stderr. Unwrap so Go sees
+            // the real class, not Iceberg's IllegalArgumentException wrapper.
+            Throwable cause = OlakeFailures.rootCause(t);
+            String detail = cause.getMessage() == null ? cause.toString() : cause.getMessage();
+            System.err.println("Iceberg writer failed to start [" + cause.getClass().getName() + "]: " + detail);
+            t.printStackTrace();
+            System.exit(1);
+            return;
         }
 
-        // Legacy ingester is always registered (Check, GET_OR_CREATE_TABLE, DROP_TABLE
-        // and the default RECORDS path all flow through it).
-        OlakeRowsIngester ori = new OlakeRowsIngester(icebergCatalog, sharedSessions);
-        serverBuilder.addService(ori);
-        LOGGER.info("Legacy writer enabled - registered OlakeRowsIngester service");
-
-        Server server = serverBuilder.build().start();
-
-        // Graceful shutdown so the OS sees the gRPC port released cleanly.
-        Runtime.getRuntime().addShutdownHook(new Thread(server::shutdown, "olake-grpc-shutdown"));
-
-        LOGGER.info("Server started on port {} with max message size: {}MB",
-                    port, (maxMessageSize / (1024 * 1024)));
+        // Blocks until shutdown, which is what keeps the process alive. Outside the try above:
+        // a failure while serving is not a failure to start.
         server.awaitTermination();
     }
 }

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeArrowIngester.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeArrowIngester.java
@@ -152,7 +152,7 @@ public class OlakeArrowIngester extends ArrowIngestServiceGrpc.ArrowIngestServic
         } catch (Exception e) {
             String errorMessage = String.format("%s Failed to process request: %s", requestId, e.getMessage());
             LOGGER.error(errorMessage, e);
-            responseObserver.onError(io.grpc.Status.INTERNAL.withDescription(errorMessage).asRuntimeException());
+            responseObserver.onError(OlakeFailures.toStatusException(e, request.getType().name(), errorMessage));
         }
     }
 

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeFailures.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeFailures.java
@@ -1,0 +1,109 @@
+package io.debezium.server.iceberg.rpc;
+
+import java.sql.SQLException;
+
+import com.google.protobuf.Any;
+import com.google.rpc.Code;
+import com.google.rpc.ErrorInfo;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+
+/**
+ * Builds the gRPC error the Go side reads.
+ *
+ * <p>The status code is INTERNAL for everything raised here, and the description is prose the Go
+ * side deliberately does not parse — it changes between library versions and can contain table
+ * names and column values. The facts travel as an {@link ErrorInfo} detail instead, a standard
+ * google.rpc type, so neither side's generated protobuf changes.
+ *
+ * <p>Only what was caught is sent, never what it means: the taxonomy lives in Go alone, so it
+ * cannot drift between two languages.
+ */
+public final class OlakeFailures {
+
+    /** Identifies these details as ours, so the Go side never reads someone else's ErrorInfo. */
+    public static final String DOMAIN = "olake.iceberg";
+
+    /** The underlying system's own code, where the exception carried one. */
+    public static final String METADATA_CODE = "code";
+
+    /** The call being served when the failure happened, e.g. GET_OR_CREATE_TABLE. */
+    public static final String METADATA_OPERATION = "operation";
+
+    private OlakeFailures() {
+    }
+
+    /**
+     * Wraps a caught exception as a gRPC exception carrying an ErrorInfo detail.
+     *
+     * @param cause     the exception that ended the call
+     * @param operation the payload type being served, e.g. {@code GET_OR_CREATE_TABLE}
+     * @param message   the description an operator reads; unchanged from what is logged
+     */
+    public static StatusRuntimeException toStatusException(Throwable cause, String operation, String message) {
+        ErrorInfo.Builder info = ErrorInfo.newBuilder()
+                .setDomain(DOMAIN)
+                .setReason(rootCause(cause).getClass().getName());
+
+        if (operation != null && !operation.isEmpty()) {
+            info.putMetadata(METADATA_OPERATION, operation);
+        }
+        String code = vendorCode(cause);
+        if (code != null && !code.isEmpty()) {
+            info.putMetadata(METADATA_CODE, code);
+        }
+
+        com.google.rpc.Status status = com.google.rpc.Status.newBuilder()
+                .setCode(Code.INTERNAL.getNumber())
+                .setMessage(message == null ? "" : message)
+                .addDetails(Any.pack(info.build()))
+                .build();
+
+        return StatusProto.toStatusRuntimeException(status);
+    }
+
+    /**
+     * Returns the innermost cause. Iceberg and Hadoop wrap heavily, and the outermost class is
+     * usually a generic wrapper that identifies nothing. Public so the startup path can reuse it.
+     */
+    public static Throwable rootCause(Throwable t) {
+        Throwable root = t;
+        // Bounded so a self-referencing cause cannot loop.
+        for (int depth = 0; depth < 16; depth++) {
+            Throwable next = root.getCause();
+            if (next == null || next == root) {
+                break;
+            }
+            root = next;
+        }
+        return root;
+    }
+
+    /**
+     * Reports the underlying system's own error code where the exception carries one. Two systems
+     * do: a JDBC catalog through SQLSTATE, and object storage through the S3 error code, which is
+     * the only thing separating a wrong key from a missing bucket. Everything else is identified
+     * by its exception class alone.
+     */
+    private static String vendorCode(Throwable cause) {
+        for (Throwable t = cause; t != null; t = t.getCause()) {
+            if (t instanceof SQLException) {
+                return ((SQLException) t).getSQLState();
+            }
+            if (t instanceof AwsServiceException) {
+                AwsErrorDetails details = ((AwsServiceException) t).awsErrorDetails();
+                if (details != null) {
+                    return details.errorCode();
+                }
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return null;
+    }
+}

--- a/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/main/java/io/debezium/server/iceberg/rpc/OlakeRowsIngester.java
@@ -188,7 +188,7 @@ public class OlakeRowsIngester extends RecordIngestServiceGrpc.RecordIngestServi
         } catch (Exception e) {
             String errorMessage = String.format("%s Failed to process request: %s", requestId, e.getMessage());
             LOGGER.error(errorMessage, e);
-            responseObserver.onError(io.grpc.Status.INTERNAL.withDescription(errorMessage).asRuntimeException());
+            responseObserver.onError(OlakeFailures.toStatusException(e, request.getType().name(), errorMessage));
         }
     }
 

--- a/destination/iceberg/olake-iceberg-java-writer/src/test/java/io/debezium/server/iceberg/rpc/OlakeFailuresTest.java
+++ b/destination/iceberg/olake-iceberg-java-writer/src/test/java/io/debezium/server/iceberg/rpc/OlakeFailuresTest.java
@@ -1,0 +1,214 @@
+package io.debezium.server.iceberg.rpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.Code;
+import com.google.rpc.ErrorInfo;
+import com.google.rpc.Status;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Pins the ErrorInfo payload Go parses. A change here is invisible to the Go compiler.
+ */
+class OlakeFailuresTest {
+
+    /** Cause that unwraps to itself — both chain walks must terminate. */
+    private static final class SelfReferencing extends RuntimeException {
+        @Override
+        public synchronized Throwable getCause() {
+            return this;
+        }
+    }
+
+    /** Unpacks the ErrorInfo Go will read, or fails if none was attached. */
+    private static ErrorInfo errorInfoOf(StatusRuntimeException e) throws InvalidProtocolBufferException {
+        Status status = StatusProto.fromThrowable(e);
+        assertNotNull(status, "no google.rpc.Status attached");
+        assertEquals(1, status.getDetailsCount(), "expected exactly one detail");
+        return status.getDetails(0).unpack(ErrorInfo.class);
+    }
+
+    private static ErrorInfo errorInfoOf(Throwable cause) throws InvalidProtocolBufferException {
+        return errorInfoOf(OlakeFailures.toStatusException(cause, "OP", "m"));
+    }
+
+    private static S3Exception s3Exception(String errorCode) {
+        return s3Exception(errorCode, null);
+    }
+
+    private static S3Exception s3Exception(String errorCode, Throwable cause) {
+        S3Exception.Builder builder = S3Exception.builder().message("denied");
+        if (errorCode != null) {
+            builder.awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build());
+        }
+        if (cause != null) {
+            builder.cause(cause);
+        }
+        return (S3Exception) builder.build();
+    }
+
+    /** `depth` RuntimeException wrappers around an IllegalStateException. */
+    private static Throwable chainOfDepth(int depth) {
+        Throwable chain = new IllegalStateException("bottom");
+        for (int i = 0; i < depth; i++) {
+            chain = new RuntimeException("layer " + i, chain);
+        }
+        return chain;
+    }
+
+    // status is always INTERNAL; Go ignores the message and reads ErrorInfo instead
+    @Test
+    @DisplayName("status is INTERNAL and the message is unchanged")
+    void statusAndMessage() {
+        Status status = StatusProto.fromThrowable(
+                OlakeFailures.toStatusException(new IllegalStateException("boom"), "GET_OR_CREATE_TABLE", "human text"));
+
+        assertNotNull(status);
+        assertEquals(Code.INTERNAL.getNumber(), status.getCode());
+        assertEquals("human text", status.getMessage());
+    }
+
+    // a null message must not become the string "null", which Go would then treat as prose
+    @Test
+    @DisplayName("a null message becomes empty")
+    void nullMessageIsEmpty() {
+        assertEquals("", StatusProto.fromThrowable(
+                OlakeFailures.toStatusException(new IllegalStateException("x"), "OP", null)).getMessage());
+    }
+
+    // Go matches on this literal, so the constant and the wire value must stay identical
+    @Test
+    @DisplayName("domain is olake.iceberg")
+    void domainIsStamped() throws Exception {
+        assertEquals("olake.iceberg", errorInfoOf(new IllegalStateException("x")).getDomain());
+        assertEquals(OlakeFailures.DOMAIN, errorInfoOf(new IllegalStateException("x")).getDomain());
+    }
+
+    static Stream<Arguments> rootCauseCases() {
+        return Stream.of(
+                // Iceberg wraps heavily; the outermost class identifies nothing
+                Arguments.of("nested wrappers report the innermost",
+                        new RuntimeException("outer",
+                                new IllegalStateException("middle", new NumberFormatException("innermost"))),
+                        NumberFormatException.class.getName()),
+                // no cause to walk
+                Arguments.of("an exception with no cause is its own root",
+                        new IllegalArgumentException("alone"), IllegalArgumentException.class.getName()),
+                // a self-reference cannot hang the writer
+                Arguments.of("a self-referencing cause terminates",
+                        new SelfReferencing(), SelfReferencing.class.getName()),
+                // 16 hops is the last layer that still reaches the leaf
+                Arguments.of("a chain at the bound still reaches the leaf",
+                        chainOfDepth(16), IllegalStateException.class.getName()),
+                // past 16 hops it stops rather than walking forever
+                Arguments.of("a chain deeper than the bound stops at the bound",
+                        chainOfDepth(17), RuntimeException.class.getName()));
+    }
+
+    // reason is the innermost class name — that is what Go maps to a category
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rootCauseCases")
+    @DisplayName("reason is the root cause's class")
+    void reasonIsTheRootCause(String name, Throwable cause, String expectedReason) throws Exception {
+        assertEquals(expectedReason, errorInfoOf(cause).getReason());
+    }
+
+    static Stream<Arguments> vendorCodeCases() {
+        return Stream.of(
+                // JDBC catalogs report SQLSTATE; 28000 is invalid_authorization_specification
+                Arguments.of("sqlstate at the top", new SQLException("denied", "28000"), "28000"),
+                // Iceberg wraps the catalog exception, so the walk must look through wrappers
+                Arguments.of("sqlstate below a wrapper",
+                        new RuntimeException("catalog failed", new SQLException("denied", "28000")), "28000"),
+                // nested SQLSTATE: first match walking outward-in, so the outer code wins
+                Arguments.of("outer sqlstate wins over inner sqlstate",
+                        new SQLException("outer", "28000", new SQLException("inner", "42000")), "28000"),
+                // the S3 code is the only thing separating a wrong key from a missing bucket
+                Arguments.of("s3 error code", new RuntimeException("write failed", s3Exception("AccessDenied")),
+                        "AccessDenied"),
+                // mixed vendors: first match walking outward-in, not the innermost
+                Arguments.of("outer sqlstate wins over inner s3",
+                        new SQLException("denied", "28000", s3Exception("AccessDenied")), "28000"),
+                Arguments.of("outer s3 wins over inner sqlstate",
+                        s3Exception("AccessDenied", new SQLException("denied", "28000")), "AccessDenied"),
+                // absent is omitted, not sent empty — Go treats a missing key as a real slice
+                Arguments.of("no vendor cause at all", new IllegalStateException("x"), null),
+                Arguments.of("sqlstate is null", new SQLException("no sqlstate"), null),
+                Arguments.of("sqlstate is empty", new SQLException("no sqlstate", ""), null),
+                Arguments.of("aws exception with no error details", s3Exception(null), null),
+                Arguments.of("aws error code is empty", s3Exception(""), null),
+                // vendorCode has its own cycle guard, separate from rootCause
+                Arguments.of("self-referencing cause", new SelfReferencing(), null));
+    }
+
+    // SQLSTATE / S3 code travels when present; otherwise the key is omitted
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("vendorCodeCases")
+    @DisplayName("vendor code travels when there is one")
+    void vendorCodeTravels(String name, Throwable cause, String expectedCode) throws Exception {
+        Map<String, String> metadata = errorInfoOf(cause).getMetadataMap();
+
+        if (expectedCode == null) {
+            assertFalse(metadata.containsKey(OlakeFailures.METADATA_CODE),
+                    "an absent code must be omitted, not sent empty");
+        } else {
+            assertEquals(expectedCode, metadata.get(OlakeFailures.METADATA_CODE));
+        }
+    }
+
+    static Stream<Arguments> operationCases() {
+        return Stream.of(
+                // the call being served, e.g. GET_OR_CREATE_TABLE
+                Arguments.of("supplied", "GET_OR_CREATE_TABLE", "GET_OR_CREATE_TABLE"),
+                // empty/null must be omitted so Go does not read a blank operation
+                Arguments.of("empty is omitted", "", null),
+                Arguments.of("null is omitted", null, null));
+    }
+
+    // operation metadata is optional: sent when supplied, omitted when blank
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("operationCases")
+    @DisplayName("operation travels when supplied")
+    void operationMetadata(String name, String operation, String expected) throws Exception {
+        Map<String, String> metadata = errorInfoOf(
+                OlakeFailures.toStatusException(new RuntimeException("x"), operation, "m")).getMetadataMap();
+
+        if (expected == null) {
+            assertFalse(metadata.containsKey(OlakeFailures.METADATA_OPERATION));
+        } else {
+            assertEquals(expected, metadata.get(OlakeFailures.METADATA_OPERATION));
+        }
+    }
+
+    // Java sends facts only (class + vendor code). The category is decided in Go.
+    @Test
+    @DisplayName("no category is sent")
+    void nothingElseTravels() throws Exception {
+        ErrorInfo info = errorInfoOf(OlakeFailures.toStatusException(
+                new SQLException("table users column ssn is invalid", "42000"), "GET_OR_CREATE_TABLE", "m"));
+
+        assertEquals(Map.of(
+                OlakeFailures.METADATA_OPERATION, "GET_OR_CREATE_TABLE",
+                OlakeFailures.METADATA_CODE, "42000"), info.getMetadataMap());
+        assertTrue(info.getReason().startsWith("java.sql."), "reason should be a class name, got " + info.getReason());
+    }
+}

--- a/destination/parquet/errors.go
+++ b/destination/parquet/errors.go
@@ -1,0 +1,140 @@
+package parquet
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"syscall"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/datazip-inc/olake/destination"
+	"github.com/datazip-inc/olake/pkg/objstorage"
+	"github.com/datazip-inc/olake/utils/errs"
+)
+
+// Codes for conditions this writer detects itself, where no vendor error exists to read.
+const codeNoDestinationConfigured = "parquet.no_destination_configured"
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only S3 and
+// filesystem evidence lives here; DNS, TLS and socket failures belong to utils/errs.
+func init() { errs.Register("parquet", classify) }
+
+// classify reads S3 (aws-sdk-go v1) and the local filesystem, then the writer marker. Order is
+// the substance: a write can fail on a full disk, refused credentials or an unencodable value,
+// and only the last is a write error, so the specific causes are checked first.
+func classify(err error) *errs.Failure {
+	if f := fromAWSError(err, 0); f != nil {
+		return f
+	}
+	if f := fromFilesystem(err); f != nil {
+		return f
+	}
+	// Nothing more specific explained it, and the writer raised it.
+	if destination.IsWriteFailure(err) {
+		return &errs.Failure{
+			Category:     errs.DestinationWriteError,
+			ClassifiedBy: errs.ClassifiedByPrecondition,
+		}
+	}
+	return nil
+}
+
+// maxOrigErrDepth bounds the OrigErr walk so a self-referencing error cannot recurse without end.
+const maxOrigErrDepth = 8
+
+// fromAWSError classifies an aws-sdk-go v1 error. v1 predates error wrapping: the cause sits
+// behind OrigErr() with no Unwrap, so errors.As cannot reach the DNS, TLS and socket failures
+// underneath. An unmapped code has its cause pulled out by hand and sent to the shared rules.
+func fromAWSError(err error, depth int) *errs.Failure {
+	var awsErr awserr.Error
+	if !errors.As(err, &awsErr) {
+		return nil
+	}
+
+	if category, ok := objstorage.ServiceCodeCategories[awsErr.Code()]; ok {
+		return &errs.Failure{
+			Category:     category,
+			ClassifiedBy: errs.ClassifiedByVendor,
+			Code:         awsErr.Code(),
+		}
+	}
+
+	// Coarser than a code but never absent on a response error, and what lets S3-compatible
+	// endpoints classify at all.
+	var requestFailure awserr.RequestFailure
+	if errors.As(err, &requestFailure) {
+		if category := categoryForStatus(requestFailure.StatusCode()); category != "" {
+			code := awsErr.Code()
+			if code == "" {
+				// Prefixed so a bare status cannot be read as a service code; both share
+				// one telemetry field.
+				code = fmt.Sprintf("http_%d", requestFailure.StatusCode())
+			}
+			return &errs.Failure{Category: category, ClassifiedBy: errs.ClassifiedByVendor, Code: code}
+		}
+	}
+
+	// Neither a known code nor a usable status: open the error and classify what is under it.
+	if cause := awsErr.OrigErr(); cause != nil && depth < maxOrigErrDepth {
+		if f := fromAWSError(cause, depth+1); f != nil {
+			return f
+		}
+		if underlying := errs.Standard(cause); underlying.Category != errs.Unclassified {
+			return &underlying
+		}
+	}
+
+	// A service code with nothing else to say about it.
+	return &errs.Failure{
+		Category:     errs.Unclassified,
+		ClassifiedBy: errs.ClassifiedByDefault,
+		Code:         awsErr.Code(),
+	}
+}
+
+// fromFilesystem classifies a failure writing to local disk, the other half of what this writer
+// does. All standard-library values, so they cannot be confused with a service error.
+func fromFilesystem(err error) *errs.Failure {
+	var category errs.Category
+	var code string
+
+	// Errno first: os wraps one in a *PathError that can also satisfy fs.ErrPermission, and the
+	// errno is the more specific answer.
+	switch {
+	case errors.Is(err, syscall.ENOSPC):
+		category, code = errs.ResourceExhausted, "no_space_left"
+	case errors.Is(err, syscall.EDQUOT):
+		category, code = errs.ResourceExhausted, "quota_exceeded"
+	case errors.Is(err, syscall.EMFILE), errors.Is(err, syscall.ENFILE):
+		category, code = errs.ResourceExhausted, "too_many_open_files"
+	case errors.Is(err, syscall.EROFS):
+		category, code = errs.PermissionDenied, "read_only_filesystem"
+	case errors.Is(err, fs.ErrPermission):
+		category, code = errs.PermissionDenied, "permission_denied"
+	case errors.Is(err, fs.ErrNotExist):
+		category, code = errs.ConfigInvalid, "path_not_found"
+	default:
+		return nil
+	}
+	return &errs.Failure{Category: category, ClassifiedBy: errs.ClassifiedByStdlib, Code: code}
+}
+
+// categoryForStatus maps an HTTP response status to a category, or "" where it says nothing
+// useful. Matches the S3 source, so a status means the same thing on both sides of a sync.
+func categoryForStatus(status int) errs.Category {
+	switch {
+	case status == 401:
+		return errs.AuthFailed
+	case status == 403:
+		return errs.PermissionDenied
+	case status == 404:
+		return errs.ObjectNotFound
+	case status == 408:
+		return errs.Timeout
+	case status == 429:
+		return errs.ResourceExhausted
+	case status >= 500:
+		return errs.NetworkUnreachable
+	}
+	return ""
+}

--- a/destination/parquet/parquet.go
+++ b/destination/parquet/parquet.go
@@ -24,6 +24,7 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	pqgo "github.com/parquet-go/parquet-go"
@@ -83,7 +84,7 @@ func (p *Parquet) initS3Writer() error {
 	}
 	sess, err := session.NewSession(&s3Config)
 	if err != nil {
-		return fmt.Errorf("failed to create AWS session: %s", err)
+		return fmt.Errorf("failed to create AWS session: %w", err)
 	}
 	p.s3Client = s3.New(sess)
 	// Initialize uploader for multipart uploads (handles files > 5GB automatically)
@@ -96,7 +97,7 @@ func (p *Parquet) createNewPartitionFile(basePath string) error {
 	// construct directory path
 	directoryPath := filepath.Join(p.config.Path, basePath)
 	if err := os.MkdirAll(directoryPath, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create directories[%s]: %s", directoryPath, err)
+		return fmt.Errorf("failed to create directories[%s]: %w", directoryPath, err)
 	}
 
 	fileName := utils.TimestampedFileName(constants.ParquetFileExt)
@@ -104,7 +105,7 @@ func (p *Parquet) createNewPartitionFile(basePath string) error {
 
 	pqFile, err := local.NewLocalFileWriter(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to create parquet file writer: %s", err)
+		return destination.WriteFailure(fmt.Errorf("failed to create parquet file writer: %w", err))
 	}
 
 	writer := func() *pqgo.GenericWriter[any] {
@@ -132,7 +133,7 @@ func (p *Parquet) getOrCreatePartitionFile(basePath string) (*FileMetadata, erro
 	files := p.partitionedFiles[basePath]
 	if len(files) == 0 || files[len(files)-1].file == nil {
 		if err := p.createNewPartitionFile(basePath); err != nil {
-			return nil, fmt.Errorf("failed to create partition file: %s", err)
+			return nil, fmt.Errorf("failed to create partition file: %w", err)
 		}
 		files = p.partitionedFiles[basePath]
 	}
@@ -211,7 +212,7 @@ func (p *Parquet) Write(_ context.Context, records []types.RawRecord) error {
 		} else {
 			dataBytes, merr := json.Marshal(record.Data)
 			if merr != nil {
-				return fmt.Errorf("failed to marshal data: %s", merr)
+				return destination.WriteFailure(fmt.Errorf("failed to marshal data: %w", merr))
 			}
 			recordsMap := map[string]any{constants.StringifiedData: string(dataBytes)}
 			maps.Copy(recordsMap, record.OlakeColumns)
@@ -219,12 +220,12 @@ func (p *Parquet) Write(_ context.Context, records []types.RawRecord) error {
 			_, err = partitionFile.writer.Write([]any{recordsMap})
 		}
 		if err != nil {
-			return fmt.Errorf("failed to write in parquet file: %s", err)
+			return destination.WriteFailure(fmt.Errorf("failed to write in parquet file: %w", err))
 		}
 
 		if p.checkForRoll(i, len(records)) {
 			if err := p.rollPartitionFile(partitionFile); err != nil {
-				return fmt.Errorf("failed to roll partition file: %s", err)
+				return fmt.Errorf("failed to roll partition file: %w", err)
 			}
 		}
 	}
@@ -260,10 +261,10 @@ func (p *Parquet) rollPartitionFile(pf *FileMetadata) error {
 	// Threshold reached: write the footer to seal the file. It stays in partitionedFiles (with
 	// file == nil marking it finalized) to be uploaded in Close.
 	if err := pf.writer.Close(); err != nil {
-		return fmt.Errorf("failed to close parquet writer on roll[%s]: %s", pf.path, err)
+		return destination.WriteFailure(fmt.Errorf("failed to close parquet writer on roll[%s]: %w", pf.path, err))
 	}
 	if err := pf.file.Close(); err != nil {
-		return fmt.Errorf("failed to close parquet file on roll[%s]: %s", pf.path, err)
+		return destination.WriteFailure(fmt.Errorf("failed to close parquet file on roll[%s]: %w", pf.path, err))
 	}
 	pf.file = nil // mark finalized; kept for upload at Close
 	logger.Infof("Thread[%s]: rolled partition file[%s] at %d bytes", p.options.ThreadID, pf.path, pf.writer.Size())
@@ -294,7 +295,7 @@ func (p *Parquet) Check(_ context.Context) error {
 			Body:   strings.NewReader("S3 write test"),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to write test file to S3: %s", err)
+			return fmt.Errorf("failed to write test file to S3: %w", err)
 		}
 		p.config.Path = os.TempDir()
 		// trim '/' from prefix path
@@ -303,18 +304,19 @@ func (p *Parquet) Check(_ context.Context) error {
 	} else if p.config.Path != "" {
 		logger.Infof("Thread[%s]: local writer configuration found, writing at location[%s]", p.options.ThreadID, p.config.Path)
 	} else {
-		return fmt.Errorf("invalid configuration found")
+		return errs.Precondition(errs.ConfigInvalid, codeNoDestinationConfigured,
+			fmt.Errorf("invalid configuration found"))
 	}
 
 	// Create the directory if it doesn't exist
 	if err := os.MkdirAll(p.config.Path, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create path: %s", err)
+		return fmt.Errorf("failed to create path: %w", err)
 	}
 
 	// Test directory writability
 	tempFile, err := os.CreateTemp(p.config.Path, "temporary-*.txt")
 	if err != nil {
-		return fmt.Errorf("directory is not writable: %s", err)
+		return fmt.Errorf("directory is not writable: %w", err)
 	}
 	tempFile.Close()
 	os.Remove(tempFile.Name())
@@ -336,7 +338,7 @@ func (p *Parquet) s3KeyFor(basePath, fileName string) string {
 func (p *Parquet) uploadLocalFileToS3(key, filePath string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to open file %s: %s", filePath, err)
+		return fmt.Errorf("failed to open file %s: %w", filePath, err)
 	}
 	defer file.Close()
 
@@ -345,7 +347,7 @@ func (p *Parquet) uploadLocalFileToS3(key, filePath string) error {
 		Key:    aws.String(key),
 		Body:   file,
 	}); err != nil {
-		return fmt.Errorf("failed to put object into s3 (%s): %s", key, err)
+		return fmt.Errorf("failed to put object into s3 (%s): %w", key, err)
 	}
 
 	// Remove local file after successful upload (best-effort; a leftover file is not fatal).
@@ -383,10 +385,10 @@ func (p *Parquet) closePqFiles(ctx context.Context, _ any, closeOnError bool) er
 			// (most recent) file of each partition here.
 			if parquetFile.file != nil {
 				if err := parquetFile.writer.Close(); err != nil {
-					return fmt.Errorf("failed to close writer: %s", err)
+					return destination.WriteFailure(fmt.Errorf("failed to close writer: %w", err))
 				}
 				if err := parquetFile.file.Close(); err != nil {
-					return fmt.Errorf("failed to close file: %s", err)
+					return destination.WriteFailure(fmt.Errorf("failed to close file: %w", err))
 				}
 			}
 
@@ -448,7 +450,7 @@ func (p *Parquet) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 		maps.Copy(records[idx].Data, record.OlakeColumns)
 		flattenedRecord, err := batchFlattener.Flatten(record.Data)
 		if err != nil {
-			return fmt.Errorf("failed to flatten record at index %d, pq writer: %s", idx, err)
+			return fmt.Errorf("failed to flatten record at index %d, pq writer: %w", idx, err)
 		}
 
 		// Store flattened result back to the record
@@ -474,7 +476,7 @@ func (p *Parquet) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 		return nil
 	})
 	if err != nil {
-		return false, nil, nil, fmt.Errorf("failed to process records: %s", err)
+		return false, nil, nil, fmt.Errorf("failed to process records: %w", err)
 	}
 
 	schemaChange := false // note: diff schema already detected so we can avoid this in future
@@ -490,16 +492,16 @@ func (p *Parquet) FlattenAndCleanData(ctx context.Context, records []types.RawRe
 	if err := utils.Concurrent(ctx, records, runtime.GOMAXPROCS(0)*16, func(_ context.Context, record types.RawRecord, _ int) error {
 		return typeutils.ReformatRecord(p.schema, record.Data)
 	}); err != nil {
-		return false, nil, nil, fmt.Errorf("failed to reformat records: %s", err)
+		return false, nil, nil, fmt.Errorf("failed to reformat records: %w", err)
 	}
 	if p.options.ApplyFilter {
 		filter, isLegacy, filterErr := p.stream.GetFilter()
 		if filterErr != nil {
-			return false, nil, nil, fmt.Errorf("failed to parse stream filter: %s", filterErr)
+			return false, nil, nil, fmt.Errorf("failed to parse stream filter: %w", filterErr)
 		}
 		records, err = typeutils.FilterRecords(ctx, records, filter, isLegacy, p.schema, p.stream.ResolveColumnName)
 		if err != nil {
-			return false, nil, nil, fmt.Errorf("failed to filter records: %s", err)
+			return false, nil, nil, fmt.Errorf("failed to filter records: %w", err)
 		}
 	}
 	return schemaChange, records, p.schema, nil
@@ -517,7 +519,7 @@ func (p *Parquet) EvolveSchema(_ context.Context, _, _ any) (any, error) {
 	for path := range p.partitionedFiles {
 		err := p.createNewPartitionFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create new partition file: %s", err)
+			return nil, fmt.Errorf("failed to create new partition file: %w", err)
 		}
 	}
 
@@ -626,11 +628,11 @@ func (p *Parquet) DropStreams(ctx context.Context, selectedStreams []types.Strea
 
 	if p.s3Client == nil {
 		if err := p.clearLocalFiles(paths); err != nil {
-			return fmt.Errorf("failed to clear local files: %s", err)
+			return fmt.Errorf("failed to clear local files: %w", err)
 		}
 	} else {
 		if err := p.clearS3Files(ctx, paths); err != nil {
-			return fmt.Errorf("failed to clear S3 files: %s", err)
+			return fmt.Errorf("failed to clear S3 files: %w", err)
 		}
 	}
 	return nil
@@ -654,7 +656,7 @@ func (p *Parquet) clearLocalFiles(paths []string) error {
 		}
 
 		if err := os.RemoveAll(streamPath); err != nil {
-			return fmt.Errorf("failed to remove local path %s: %s", streamPath, err)
+			return fmt.Errorf("failed to remove local path %s: %w", streamPath, err)
 		}
 	}
 
@@ -723,7 +725,7 @@ func (p *Parquet) clearS3Files(ctx context.Context, paths []string) error {
 			})
 		})
 		if listErr != nil {
-			return fmt.Errorf("failed to list objects for prefix %s: %v", filtPath, listErr)
+			return fmt.Errorf("failed to list objects for prefix %s: %w", filtPath, listErr)
 		}
 		return pageErr
 	}
@@ -740,7 +742,7 @@ func (p *Parquet) clearS3Files(ctx context.Context, paths []string) error {
 		if err != nil {
 			logger.Warnf("batch delete failed for filtPath %s, falling back to individual deletes: %v", filtPath, err)
 			if fallbackErr := deleteS3PrefixIndividually(filtPath); fallbackErr != nil {
-				return fmt.Errorf("batch delete failed: %v, fallback individual delete also failed: %s", err, fallbackErr)
+				return fmt.Errorf("batch delete failed: %v, fallback individual delete also failed: %w", err, fallbackErr)
 			}
 		}
 		return nil
@@ -765,7 +767,7 @@ func (p *Parquet) clearS3Files(ctx context.Context, paths []string) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("failed to clear S3 prefix %s: %s", s3TablePath, err)
+			return fmt.Errorf("failed to clear S3 prefix %s: %w", s3TablePath, err)
 		}
 
 		logger.Debugf("successfully cleared S3 prefix: s3://%s/%s", p.config.Bucket, s3TablePath)
@@ -786,11 +788,11 @@ func init() {
 		parquetConfig = &Config{}
 		err := utils.Unmarshal(config, parquetConfig)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to unmarshal parquet config: %s", err)
+			return nil, nil, fmt.Errorf("failed to unmarshal parquet config: %w", err)
 		}
 
 		if err := parquetConfig.Validate(); err != nil {
-			return nil, nil, fmt.Errorf("failed to validate parquet config: %s", err)
+			return nil, nil, fmt.Errorf("failed to validate parquet config: %w", err)
 		}
 
 		return &Parquet{

--- a/destination/writers.go
+++ b/destination/writers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 )
 
@@ -88,12 +89,13 @@ func WithApplyFilter(applyFilter bool) ThreadOptions {
 func NewWriterPool(ctx context.Context, config *types.WriterConfig, syncStreams []string, batchSize int64) (*WriterPool, error) {
 	initWriter, found := RegisteredWriters[config.Type]
 	if !found {
-		return nil, fmt.Errorf("invalid destination type has been passed [%s]", config.Type)
+		return nil, errs.Precondition(errs.ConfigInvalid, codeDestinationTypeInvalid,
+			fmt.Errorf("invalid destination type has been passed [%s]", config.Type))
 	}
 
 	adapter, shutdown, err := initWriter(config.WriterConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize destination: %s", err)
+		return nil, fmt.Errorf("failed to initialize destination: %w", err)
 	}
 	pool := &WriterPool{
 		stats: &Stats{
@@ -111,7 +113,7 @@ func NewWriterPool(ctx context.Context, config *types.WriterConfig, syncStreams 
 	err = adapter.Check(ctx)
 	stopCheck()
 	if err != nil {
-		return nil, fmt.Errorf("failed to test destination: %s", err)
+		return nil, fmt.Errorf("failed to test destination: %w", err)
 	}
 
 	for _, stream := range syncStreams {
@@ -162,7 +164,7 @@ func (w *WriterPool) NewWriter(ctx context.Context, stream types.StreamInterface
 		// shared read-only across all writer threads.
 		writerThread, _, err := w.initWriter(nil)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to initialize writer: %s", err)
+			return nil, nil, fmt.Errorf("failed to initialize writer: %w", err)
 		}
 
 		// setup table and schema
@@ -170,7 +172,7 @@ func (w *WriterPool) NewWriter(ctx context.Context, stream types.StreamInterface
 		defer streamArtifact.mu.Unlock()
 		threadSchema, prevStreamState, err := writerThread.Setup(ctx, stream, streamArtifact.schema, opts)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create writer thread: %s", err)
+			return nil, nil, fmt.Errorf("failed to create writer thread: %w", err)
 		}
 		if streamArtifact.schema == nil {
 			// First thread for this stream: cache the schema so subsequent threads
@@ -184,7 +186,7 @@ func (w *WriterPool) NewWriter(ctx context.Context, stream types.StreamInterface
 		return writerThread, prevStreamState, nil
 	}()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to setup writer thread: %s", err)
+		return nil, nil, fmt.Errorf("failed to setup writer thread: %w", err)
 	}
 	return &WriterThread{
 		buffer:         []types.RawRecord{},
@@ -250,7 +252,7 @@ func (wt *WriterThread) flush(ctx context.Context, buf []types.RawRecord) (err e
 	recordsCountBeforeFiltering := len(buf)
 	evolution, buf, threadSchema, err := wt.writer.FlattenAndCleanData(flushCtx, buf)
 	if err != nil {
-		return fmt.Errorf("failed to flatten and clean data: %s", err)
+		return fmt.Errorf("failed to flatten and clean data: %w", err)
 	}
 	filtered := int64(recordsCountBeforeFiltering - len(buf))
 	wt.stats.RecordsFiltered.Add(filtered)
@@ -264,12 +266,12 @@ func (wt *WriterThread) flush(ctx context.Context, buf []types.RawRecord) (err e
 		}
 		wt.streamArtifact.mu.Unlock()
 		if err != nil {
-			return fmt.Errorf("failed to evolve schema: %s", err)
+			return fmt.Errorf("failed to evolve schema: %w", err)
 		}
 	}
 
 	if err := wt.writer.Write(flushCtx, buf); err != nil {
-		return fmt.Errorf("failed to write records: %s", err)
+		return fmt.Errorf("failed to write records: %w", err)
 	}
 
 	logger.Infof("Thread[%s]: successfully wrote %d records", wt.threadID, len(buf))
@@ -296,7 +298,7 @@ func (wt *WriterThread) Close(closeCtx context.Context, finalMetadataState any) 
 		// so nothing this thread pushed reaches the destination — roll its stats back.
 		wt.rollbackStats()
 		if closeErr := wt.writer.Close(closeCtx, finalMetadataState); closeErr != nil {
-			return fmt.Errorf("failed to close writer: %s", closeErr)
+			return fmt.Errorf("failed to close writer: %w", closeErr)
 		}
 		return nil
 	default:
@@ -315,7 +317,7 @@ func (wt *WriterThread) Close(closeCtx context.Context, finalMetadataState any) 
 			defer wt.streamArtifact.mu.Unlock()
 
 			if closeErr := wt.writer.Close(ctx, finalMetadataState); closeErr != nil {
-				err = utils.Ternary(err == nil, closeErr, fmt.Errorf("%s: flush error: %w", closeErr, err)).(error)
+				err = utils.Ternary(err == nil, closeErr, fmt.Errorf("%w: flush error: %w", closeErr, err)).(error)
 			}
 
 			// Commit is successful only when both the final flush and writer.Close (dest
@@ -332,7 +334,7 @@ func (wt *WriterThread) Close(closeCtx context.Context, finalMetadataState any) 
 		})
 
 		if err := wt.group.Block(); err != nil {
-			return fmt.Errorf("failed to flush data while closing: %s", err)
+			return fmt.Errorf("failed to flush data while closing: %w", err)
 		}
 
 		return nil
@@ -346,12 +348,13 @@ func DropStreams(ctx context.Context, config *types.WriterConfig, dropStreams []
 
 	initWriter, found := RegisteredWriters[config.Type]
 	if !found {
-		return fmt.Errorf("invalid destination type has been passed [%s]", config.Type)
+		return errs.Precondition(errs.ConfigInvalid, codeDestinationTypeInvalid,
+			fmt.Errorf("invalid destination type has been passed [%s]", config.Type))
 	}
 
 	adapter, shutdown, err := initWriter(config.WriterConfig)
 	if err != nil {
-		return fmt.Errorf("failed to initialize destination: %s", err)
+		return fmt.Errorf("failed to initialize destination: %w", err)
 	}
 	defer func() {
 		if shutdown != nil {
@@ -360,7 +363,7 @@ func DropStreams(ctx context.Context, config *types.WriterConfig, dropStreams []
 	}()
 
 	if err := adapter.DropStreams(ctx, dropStreams); err != nil {
-		return fmt.Errorf("failed to drop streams: %s", err)
+		return fmt.Errorf("failed to drop streams: %w", err)
 	}
 
 	return nil

--- a/drivers/abstract/abstract.go
+++ b/drivers/abstract/abstract.go
@@ -12,7 +12,11 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
+
+// codeWriterPanicRecovered names a panic recovered inside a writer thread, distinct from sync command.
+const codeWriterPanicRecovered = "sync.writer_panic_recovered"
 
 type CDCChange struct {
 	Stream       types.StreamInterface
@@ -76,7 +80,7 @@ func (a *AbstractDriver) Type() string {
 func (a *AbstractDriver) Discover(ctx context.Context, maxDiscoverThreads int, isSync bool) ([]*types.Stream, error) {
 	streams, err := a.driver.GetStreamNames(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stream names: %s", err)
+		return nil, fmt.Errorf("failed to get stream names: %w", err)
 	}
 
 	// During sync, skip ProduceSchema entirely streams.json already holds
@@ -100,14 +104,14 @@ func (a *AbstractDriver) Discover(ctx context.Context, maxDiscoverThreads int, i
 	utils.ConcurrentInGroupWithRetry(a.GlobalConnGroup, streams, a.driver.MaxRetries(), func(ctx context.Context, _ int, stream types.StreamID) error {
 		streamSchema, err := a.driver.ProduceSchema(ctx, stream) // use conn group context which is discoverCtx
 		if err != nil {
-			return fmt.Errorf("%w: failed to produce schema for stream %s: %s", constants.ErrNonRetryable, stream, err)
+			return fmt.Errorf("%w: failed to produce schema for stream %s: %w", constants.ErrNonRetryable, stream, err)
 		}
 		streamMap.Store(streamSchema.ID(), streamSchema)
 		return nil
 	})
 
 	if err := a.GlobalConnGroup.Block(); err != nil {
-		return nil, fmt.Errorf("error occurred while waiting for connection group: %s", err)
+		return nil, fmt.Errorf("error occurred while waiting for connection group: %w", err)
 	}
 
 	var finalStreams []*types.Stream
@@ -192,17 +196,19 @@ func (a *AbstractDriver) Read(ctx context.Context, pool *destination.WriterPool,
 	if len(cdcStreams) > 0 {
 		if a.driver.CDCSupported() {
 			if err := a.RunChangeStream(ctx, pool, cdcStreams...); err != nil {
-				return fmt.Errorf("failed to run change stream: %s", err)
+				return fmt.Errorf("failed to run change stream: %w", err)
 			}
 		} else {
-			return fmt.Errorf("%s cdc configuration not provided, use full refresh for all streams", a.driver.Type())
+			return errs.Precondition(errs.CDCPreconditionFailed,
+				fmt.Sprintf("%s.cdc_not_configured", a.driver.Type()),
+				fmt.Errorf("%s cdc configuration not provided, use full refresh for all streams", a.driver.Type()))
 		}
 	}
 
 	// run incremental sync
 	if len(incrementalStreams) > 0 {
 		if err := a.Incremental(ctx, pool, incrementalStreams...); err != nil {
-			return fmt.Errorf("failed to run incremental sync: %s", err)
+			return fmt.Errorf("failed to run incremental sync: %w", err)
 		}
 	}
 
@@ -215,12 +221,12 @@ func (a *AbstractDriver) Read(ctx context.Context, pool *destination.WriterPool,
 
 	// wait for all threads to finish
 	if err := a.GlobalCtxGroup.Block(); err != nil {
-		return fmt.Errorf("error occurred while waiting for context groups: %s", err)
+		return fmt.Errorf("error occurred while waiting for context groups: %w", err)
 	}
 
 	// wait for all threads to finish
 	if err := a.GlobalConnGroup.Block(); err != nil {
-		return fmt.Errorf("error occurred while waiting for connections: %s", err)
+		return fmt.Errorf("error occurred while waiting for connections: %w", err)
 	}
 	return nil
 }
@@ -267,7 +273,10 @@ func generateThreadID(streamID, hash string) string {
 //   - map[string]*destination.WriterThread for multiple writers keyed by stream ID
 func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *error, writer any, threadID string, mtState *any, dedupInserts *bool) {
 	if r := recover(); r != nil {
-		*err = utils.Ternary(*err == nil, fmt.Errorf("panic recovered: %v", r), fmt.Errorf("%s: panic recovered: %v", *err, r)).(error)
+		// panic is classified as internal error
+		*err = utils.Ternary(*err == nil,
+			errs.Precondition(errs.InternalError, codeWriterPanicRecovered, fmt.Errorf("panic recovered: %v", r)),
+			fmt.Errorf("%w: panic recovered: %v", *err, r)).(error)
 	}
 
 	if *err != nil {
@@ -283,14 +292,14 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 		if metadataValue != nil {
 			ms, err := types.SetMetadataState(metadataValue, threadID)
 			if err != nil {
-				setErr = fmt.Errorf("failed to set metadata state: %s", err)
+				setErr = fmt.Errorf("failed to set metadata state: %w", err)
 				cancel()
 			}
 			types.SetDedupInserts(ms, dedupInserts)
 			metadataState = ms
 		}
 		if threadErr := w.Close(ctx, metadataState); threadErr != nil {
-			setErr = errors.Join(setErr, fmt.Errorf("failed to close writer: %s", threadErr))
+			setErr = errors.Join(setErr, fmt.Errorf("failed to close writer: %w", threadErr))
 		}
 
 		return setErr
@@ -331,7 +340,7 @@ func handleWriterCleanup(ctx context.Context, cancel context.CancelFunc, err *er
 	}
 
 	if *err != nil && threadID != "" {
-		*err = fmt.Errorf("thread[%s]: %s", threadID, *err)
+		*err = fmt.Errorf("thread[%s]: %w", threadID, *err)
 	}
 }
 

--- a/drivers/abstract/abstract_test.go
+++ b/drivers/abstract/abstract_test.go
@@ -1,0 +1,473 @@
+package abstract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/datazip-inc/olake/constants"
+	"github.com/datazip-inc/olake/destination"
+	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupResult panics under the real handleWriterCleanup defer. An empty writer map is the no-op
+// case of the switch, leaving the recovered panic as the only error; nil takes the default branch,
+// so the close half of the function contributes "unsupported writer type" on top of it.
+func cleanupResult(prior error, r any, threadID string, writer any) error {
+	err := prior
+	func() {
+		defer handleWriterCleanup(context.Background(), func() {}, &err, writer, threadID, nil, nil)
+		panic(r)
+	}()
+	return err
+}
+
+// writerArg picks the switch case a test wants: nil for the default branch, otherwise an empty
+// map, which closes nothing.
+func writerArg(nilWriter bool) any {
+	if nilWriter {
+		return nil
+	}
+	return map[string]*destination.WriterThread{}
+}
+
+func networkReset() error {
+	return fmt.Errorf("read failed: %w", &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET})
+}
+
+func TestHandleWriterCleanupClassification(t *testing.T) {
+	classifiedPrior := errs.Precondition(errs.CDCPositionLost, "mssql.lsn_lost", errors.New("lsn gone"))
+
+	testCases := []struct {
+		name              string
+		prior             error
+		panicValue        any
+		threadID          string
+		expectedCategory  errs.Category
+		expectedBy        string
+		expectedCode      string
+		expectedType      string
+		expectedComponent string
+		nilWriter         bool // takes the default branch, so closeErr wraps the panic
+	}{
+		// the panic is the only evidence, so it is classified at the raise site
+		{
+			name:              "no prior error",
+			panicValue:        "assignment to entry in nil map",
+			expectedCategory:  errs.InternalError,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      codeWriterPanicRecovered,
+			expectedComponent: "sync",
+		},
+		// a runtime panic carries an error value rather than a string
+		{
+			name:              "runtime error value",
+			panicValue:        errors.New("runtime error: index out of range"),
+			expectedCategory:  errs.InternalError,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      codeWriterPanicRecovered,
+			expectedComponent: "sync",
+		},
+		// thread[id] is wrapped after classification; From must still find the panic
+		{
+			name:              "thread wrap still classifies the panic",
+			panicValue:        "boom",
+			threadID:          "public.users_abc",
+			expectedCategory:  errs.InternalError,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      codeWriterPanicRecovered,
+			expectedComponent: "sync",
+		},
+		// a classified prior error is the cause; the panic may be a consequence of it
+		{
+			name:              "classified prior error keeps its category",
+			prior:             classifiedPrior,
+			panicValue:        "boom",
+			expectedCategory:  errs.CDCPositionLost,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      "mssql.lsn_lost",
+			expectedComponent: "mssql",
+		},
+		// the %w wrap is what keeps an unclassified prior reachable by the shared rules
+		{
+			name:             "stdlib prior error still reaches the shared rules",
+			prior:            networkReset(),
+			panicValue:       "boom",
+			expectedCategory: errs.NetworkUnreachable,
+			expectedBy:       errs.ClassifiedByStdlib,
+			expectedCode:     "connection_reset",
+		},
+		// a cancellation is not a bug; wrapping a panic must not reclassify it as internal_error
+		{
+			name:             "canceled prior is not an internal error",
+			prior:            context.Canceled,
+			panicValue:       "boom",
+			expectedCategory: errs.Canceled,
+			expectedBy:       errs.ClassifiedByStdlib,
+		},
+		// Join is a tree; the classified branch must still win after the panic wrap
+		{
+			name:              "join prior, classified branch wins",
+			prior:             errors.Join(errors.New("noise"), classifiedPrior),
+			panicValue:        "boom",
+			expectedCategory:  errs.CDCPositionLost,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      "mssql.lsn_lost",
+			expectedComponent: "mssql",
+		},
+		// an unclassifiable prior leaves the concrete type as the only remaining clue
+		{
+			name:             "unclassifiable prior error",
+			prior:            errors.New("something opaque"),
+			panicValue:       "boom",
+			expectedCategory: errs.Unclassified,
+			expectedBy:       errs.ClassifiedByDefault,
+			expectedType:     "*errors.errorString",
+		},
+		// a close failure wraps the panic with %w, so the panic must stay the classification
+		{
+			name:              "close error does not bury the panic",
+			panicValue:        "boom",
+			nilWriter:         true,
+			expectedCategory:  errs.InternalError,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      codeWriterPanicRecovered,
+			expectedComponent: "sync",
+		},
+		// and it must not bury a prior cause that outranks the panic either
+		{
+			name:              "close error does not bury a classified prior",
+			prior:             classifiedPrior,
+			panicValue:        "boom",
+			nilWriter:         true,
+			expectedCategory:  errs.CDCPositionLost,
+			expectedBy:        errs.ClassifiedByPrecondition,
+			expectedCode:      "mssql.lsn_lost",
+			expectedComponent: "mssql",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cleanupResult(tc.prior, tc.panicValue, tc.threadID, writerArg(tc.nilWriter))
+			require.Error(t, err)
+
+			got := errs.From(errs.Classify(err))
+			assert.Equal(t, tc.expectedCategory, got.Category, "category")
+			assert.Equal(t, tc.expectedBy, got.ClassifiedBy, "classified_by")
+			assert.Equal(t, tc.expectedCode, got.Code, "code")
+			assert.Equal(t, tc.expectedType, got.ErrorType, "error_type")
+			assert.Equal(t, tc.expectedComponent, got.Component, "component")
+		})
+	}
+}
+
+func TestHandleWriterCleanupMessage(t *testing.T) {
+	testCases := []struct {
+		name       string
+		prior      error
+		panicValue any
+		threadID   string
+		contains   []string
+		asOpError  bool
+		nilWriter  bool
+	}{
+		// classification must not rewrite the panic text an operator reads
+		{
+			name:       "panic text is unchanged",
+			panicValue: "nil map write",
+			contains:   []string{"panic recovered: nil map write"},
+		},
+		// the prior error stays in the chain and in the message
+		{
+			name:       "prior error stays reachable",
+			prior:      networkReset(),
+			panicValue: "boom",
+			contains:   []string{"panic recovered: boom", "read failed"},
+			asOpError:  true,
+		},
+		// the thread prefix is added without flattening the chain
+		{
+			name:       "thread wrap is visible and unwraps",
+			prior:      networkReset(),
+			panicValue: "boom",
+			threadID:   "public.users_abc",
+			contains:   []string{"thread[public.users_abc]", "panic recovered: boom", "read failed"},
+			asOpError:  true,
+		},
+		// the close half of the function: a writer it cannot close is reported alongside the panic
+		{
+			name:       "close error is reported with the panic",
+			panicValue: "boom",
+			nilWriter:  true,
+			contains:   []string{"unsupported writer type", "prev error:", "panic recovered: boom"},
+		},
+		// and it still sits inside the thread prefix, with the prior error left reachable
+		{
+			name:       "close error keeps the thread prefix and the chain",
+			prior:      networkReset(),
+			panicValue: "boom",
+			threadID:   "public.users_abc",
+			nilWriter:  true,
+			contains:   []string{"thread[public.users_abc]", "unsupported writer type", "prev error:", "read failed"},
+			asOpError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cleanupResult(tc.prior, tc.panicValue, tc.threadID, writerArg(tc.nilWriter))
+			require.Error(t, err)
+
+			for _, fragment := range tc.contains {
+				assert.Contains(t, err.Error(), fragment)
+			}
+			if tc.asOpError {
+				assert.True(t, errors.As(err, new(*net.OpError)), "the chain must not be flattened")
+			}
+		})
+	}
+}
+
+func TestGenerateThreadID(t *testing.T) {
+	testCases := []struct {
+		name     string
+		streamID string
+		hash     string
+		exact    string
+		prefix   string
+	}{
+		// a supplied hash is used as the suffix, so retries of the same chunk are stable
+		{
+			name:     "hash is the suffix",
+			streamID: "public.users",
+			hash:     "chunk1",
+			exact:    "public.users_chunk1",
+		},
+		// an empty stream id still joins with an underscore
+		{
+			name:     "empty stream id",
+			streamID: "",
+			hash:     "chunk1",
+			exact:    "_chunk1",
+		},
+		// no hash: a ULID is generated; only the stream prefix is stable
+		{
+			name:     "empty hash uses a generated suffix",
+			streamID: "public.users",
+			prefix:   "public.users_",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generateThreadID(tc.streamID, tc.hash)
+			if tc.exact != "" {
+				assert.Equal(t, tc.exact, got)
+				return
+			}
+			assert.True(t, len(got) > len(tc.prefix), "generated suffix must be non-empty")
+			assert.Equal(t, tc.prefix, got[:len(tc.prefix)])
+		})
+	}
+
+	// two calls without a hash must not collide; the ULID is the uniqueness
+	first := generateThreadID("public.users", "")
+	second := generateThreadID("public.users", "")
+	assert.NotEqual(t, first, second)
+}
+
+func TestSupportsCdcColumn(t *testing.T) {
+	testCases := []struct {
+		name         string
+		driverType   string
+		cdcSupported bool
+		expected     bool
+	}{
+		// a cdc-capable relational driver adds the olake cdc timestamp column
+		{name: "postgres with cdc", driverType: "postgres", cdcSupported: true, expected: true},
+		// kafka has no cdc timestamp column even when cdc is on
+		{name: "kafka with cdc", driverType: string(constants.Kafka), cdcSupported: true, expected: false},
+		// cdc off means the column is not added
+		{name: "postgres without cdc", driverType: "postgres", cdcSupported: false, expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := NewAbstractDriver(context.Background(), stubDriver{
+				typ:          tc.driverType,
+				cdcSupported: tc.cdcSupported,
+			})
+			assert.Equal(t, tc.expected, driver.supportsCdcColumn())
+		})
+	}
+}
+
+func TestReadCDCNotConfigured(t *testing.T) {
+	testCases := []struct {
+		name             string
+		driverType       string
+		cdcSupported     bool
+		cdcStreams       int
+		expectedErr      bool
+		expectedCategory errs.Category
+		expectedCode     string
+	}{
+		// no cdc streams: the cdc branch is skipped
+		{name: "no cdc streams", driverType: "postgres", cdcStreams: 0},
+		// cdc selected but the source has no cdc config
+		{
+			name:             "cdc selected without config",
+			driverType:       "postgres",
+			cdcStreams:       1,
+			expectedErr:      true,
+			expectedCategory: errs.CDCPreconditionFailed,
+			expectedCode:     "postgres.cdc_not_configured",
+		},
+		// the code prefix is the driver type, not a hardcoded postgres string
+		{
+			name:             "driver type is interpolated into the code",
+			driverType:       "mysql",
+			cdcStreams:       1,
+			expectedErr:      true,
+			expectedCategory: errs.CDCPreconditionFailed,
+			expectedCode:     "mysql.cdc_not_configured",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := NewAbstractDriver(context.Background(), stubDriver{typ: tc.driverType, cdcSupported: tc.cdcSupported})
+			cdcStreams := make([]types.StreamInterface, tc.cdcStreams)
+
+			err := driver.Read(context.Background(), nil, nil, cdcStreams, nil)
+			if !tc.expectedErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+
+			got := errs.From(errs.Classify(err))
+			assert.Equal(t, tc.expectedCategory, got.Category, "category")
+			assert.Equal(t, errs.ClassifiedByPrecondition, got.ClassifiedBy, "classified_by")
+			assert.Equal(t, tc.expectedCode, got.Code, "code")
+			assert.Equal(t, tc.driverType, got.Component, "component")
+		})
+	}
+}
+
+func TestDiscover(t *testing.T) {
+	ctx := context.Background()
+	networkErr := networkReset()
+
+	testCases := []struct {
+		name               string
+		isSync             bool
+		streamNamesErr     error
+		expectedNilStreams bool
+		expectedErr        bool
+		expectedCategory   errs.Category
+		expectedCode       string
+	}{
+		// sync reuses the catalog schema and must not produce a new one
+		{name: "sync skips schema production", isSync: true, expectedNilStreams: true},
+		// GetStreamNames still runs during sync; a failure is not swallowed
+		{
+			name:             "sync still reports a GetStreamNames failure",
+			isSync:           true,
+			streamNamesErr:   networkErr,
+			expectedErr:      true,
+			expectedCategory: errs.NetworkUnreachable,
+			expectedCode:     "connection_reset",
+		},
+		// discover wraps GetStreamNames with %w so the cause stays classifiable
+		{
+			name:             "discover preserves a GetStreamNames cause",
+			streamNamesErr:   networkErr,
+			expectedErr:      true,
+			expectedCategory: errs.NetworkUnreachable,
+			expectedCode:     "connection_reset",
+		},
+		// a classified names error outranks the discover wrapper
+		{
+			name:             "discover preserves a classified names error",
+			streamNamesErr:   errs.Precondition(errs.AuthFailed, "postgres.auth_failed", errors.New("bad password")),
+			expectedErr:      true,
+			expectedCategory: errs.AuthFailed,
+			expectedCode:     "postgres.auth_failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := NewAbstractDriver(ctx, stubDriver{typ: "postgres", streamNamesErr: tc.streamNamesErr})
+			streams, err := driver.Discover(ctx, 0, tc.isSync)
+
+			if tc.expectedErr {
+				require.Error(t, err)
+				assert.Nil(t, streams)
+
+				got := errs.From(errs.Classify(err))
+				assert.Equal(t, tc.expectedCategory, got.Category, "category")
+				assert.Equal(t, tc.expectedCode, got.Code, "code")
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.expectedNilStreams {
+				assert.Nil(t, streams)
+			}
+		})
+	}
+}
+
+// stubDriver is a DriverInterface that returns zero values except where a test sets a field.
+type stubDriver struct {
+	typ            string
+	cdcSupported   bool
+	streamNamesErr error
+}
+
+func (s stubDriver) GetConfigRef() Config { return nil }
+func (s stubDriver) Spec() any            { return nil }
+func (s stubDriver) Type() string         { return s.typ }
+func (s stubDriver) Setup(context.Context) error {
+	return nil
+}
+func (s stubDriver) SetupState(*types.State) {}
+func (s stubDriver) MaxConnections() int     { return 0 }
+func (s stubDriver) MaxRetries() int         { return 0 }
+func (s stubDriver) GetStreamNames(context.Context) ([]types.StreamID, error) {
+	return nil, s.streamNamesErr
+}
+func (s stubDriver) ProduceSchema(context.Context, types.StreamID) (*types.Stream, error) {
+	return &types.Stream{}, nil
+}
+func (s stubDriver) GetOrSplitChunks(context.Context, *destination.WriterPool, types.StreamInterface) (*types.Set[types.Chunk], error) {
+	return types.NewSet[types.Chunk](), nil
+}
+func (s stubDriver) ChunkIterator(context.Context, types.StreamInterface, types.Chunk, BackfillMsgFn) error {
+	return nil
+}
+func (s stubDriver) FetchMaxCursorValues(context.Context, types.StreamInterface) (any, any, error) {
+	return nil, nil, nil
+}
+func (s stubDriver) StreamIncrementalChanges(context.Context, types.StreamInterface, BackfillMsgFn) error {
+	return nil
+}
+func (s stubDriver) CDCSupported() bool { return s.cdcSupported }
+func (s stubDriver) ChangeStreamConfig() (bool, bool, bool) {
+	return false, false, false
+}
+func (s stubDriver) PreCDC(context.Context, []types.StreamInterface) error { return nil }
+func (s stubDriver) StreamChanges(context.Context, int, map[string]any, CDCMsgFn) (any, error) {
+	// the real drivers return a metadata state here; a stub that streams nothing has none
+	return nil, nil //nolint:nilnil // no metadata state to report
+}
+func (s stubDriver) PostCDC(context.Context, int) error { return nil }

--- a/drivers/abstract/backfill.go
+++ b/drivers/abstract/backfill.go
@@ -21,7 +21,7 @@ func (a *AbstractDriver) Backfill(mainCtx context.Context, backfilledStreams cha
 	if chunksSet == nil || chunksSet.Len() == 0 {
 		chunksSet, err = a.driver.GetOrSplitChunks(mainCtx, pool, stream)
 		if err != nil {
-			return fmt.Errorf("failed to get or split chunks: %s", err)
+			return fmt.Errorf("failed to get or split chunks: %w", err)
 		}
 		// set state chunks
 		a.state.SetChunks(stream.Self(), chunksSet)
@@ -51,7 +51,7 @@ func (a *AbstractDriver) Backfill(mainCtx context.Context, backfilledStreams cha
 		threadID := generateThreadID(stream.ID(), fmt.Sprintf("min[%v]-max[%v]", chunk.Min, chunk.Max))
 		inserter, prevMetadataState, err := pool.NewWriter(backfillCtx, stream, destination.WithBackfill(true), destination.WithThreadID(threadID), destination.WithApplyFilter(slices.Contains(constants.FullRefreshPostReadFilterDrivers, constants.DriverType(a.driver.Type()))))
 		if err != nil {
-			return fmt.Errorf("failed to create new writer thread: %s", err)
+			return fmt.Errorf("failed to create new writer thread: %w", err)
 		}
 
 		defer func(ctx context.Context) {

--- a/drivers/abstract/cdc.go
+++ b/drivers/abstract/cdc.go
@@ -23,7 +23,7 @@ import (
 func (a *AbstractDriver) RunChangeStream(mainCtx context.Context, pool *destination.WriterPool, streams ...types.StreamInterface) error {
 	// run pre cdc of drivers
 	if err := a.driver.PreCDC(mainCtx, streams); err != nil {
-		return fmt.Errorf("failed in pre cdc run for driver[%s]: %s", a.driver.Type(), err)
+		return fmt.Errorf("failed in pre cdc run for driver[%s]: %w", a.driver.Type(), err)
 	}
 
 	isSequentialMode, isParallelMode, isConcurrentMode := a.driver.ChangeStreamConfig()
@@ -48,7 +48,7 @@ func (a *AbstractDriver) RunChangeStream(mainCtx context.Context, pool *destinat
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("%w: failed to run backfill: %s", constants.ErrNonRetryable, err)
+		return fmt.Errorf("%w: failed to run backfill: %w", constants.ErrNonRetryable, err)
 	}
 
 	// Wait for all backfill processes to complete
@@ -71,7 +71,7 @@ func (a *AbstractDriver) RunChangeStream(mainCtx context.Context, pool *destinat
 			// err will be captured in err group block statement
 			return nil
 		}
-		return fmt.Errorf("failed to process cdc streams: %s", err)
+		return fmt.Errorf("failed to process cdc streams: %w", err)
 	}
 
 	// TODO: cdc will not start until backfill get finished, need to study alternate ways (watermarking used by debezium) to do cdc sync parallelly to reduce backpressure on db
@@ -106,7 +106,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 
 	defer func() {
 		if postCDCErr := a.driver.PostCDC(cdcCtx, streamIndex); postCDCErr != nil {
-			err = utils.Ternary(err == nil, fmt.Errorf("post cdc error: %s", postCDCErr), fmt.Errorf("%s: post cdc error: %s", err, postCDCErr)).(error)
+			err = utils.Ternary(err == nil, fmt.Errorf("post cdc error: %w", postCDCErr), fmt.Errorf("%w: post cdc error: %w", err, postCDCErr)).(error)
 		}
 	}()
 
@@ -122,7 +122,7 @@ func (a *AbstractDriver) streamChanges(mainCtx context.Context, pool *destinatio
 		threadID := generateThreadID(stream.ID(), "")
 		w, writerMeta, createErr := pool.NewWriter(cdcCtx, stream, destination.WithThreadID(threadID), destination.WithApplyFilter(true))
 		if createErr != nil {
-			return fmt.Errorf("failed to create CDC writer for stream %s: %s", stream.ID(), createErr)
+			return fmt.Errorf("failed to create CDC writer for stream %s: %w", stream.ID(), createErr)
 		}
 		writers[stream.ID()] = w
 		var writerMetaState any

--- a/drivers/abstract/incremental.go
+++ b/drivers/abstract/incremental.go
@@ -10,6 +10,7 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -36,7 +37,7 @@ func (a *AbstractDriver) Incremental(mainCtx context.Context, pool *destination.
 
 			maxPrimaryCursorValue, maxSecondaryCursorValue, err := a.driver.FetchMaxCursorValues(mainCtx, stream)
 			if err != nil {
-				return fmt.Errorf("failed to fetch max cursor values: %s", err)
+				return fmt.Errorf("failed to fetch max cursor values: %w", err)
 			}
 
 			a.state.SetCursor(stream.Self(), primaryCursor, a.FormatCursorValue(maxPrimaryCursorValue))
@@ -54,7 +55,7 @@ func (a *AbstractDriver) Incremental(mainCtx context.Context, pool *destination.
 		return a.Backfill(mainCtx, backfillWaitChannel, pool, stream)
 	})
 	if err != nil {
-		return fmt.Errorf("backfill failed: %s", err)
+		return fmt.Errorf("backfill failed: %w", err)
 	}
 
 	// Wait for all backfill processes to complete
@@ -67,7 +68,7 @@ func (a *AbstractDriver) Incremental(mainCtx context.Context, pool *destination.
 			// get cursor column from state and typecast it to cursor column type for comparisons
 			maxPrimaryCursorValue, maxSecondaryCursorValue, err := a.getIncrementCursorFromState(primaryCursor, secondaryCursor, stream)
 			if err != nil {
-				return fmt.Errorf("failed to get incremental cursor value from state: %s", err)
+				return fmt.Errorf("failed to get incremental cursor value from state: %w", err)
 			}
 
 			// create incremental context, so that main context not affected if incremental retries
@@ -77,7 +78,7 @@ func (a *AbstractDriver) Incremental(mainCtx context.Context, pool *destination.
 			threadID := generateThreadID(stream.ID(), fmt.Sprintf("%v_%v", maxPrimaryCursorValue, maxSecondaryCursorValue))
 			inserter, prevMetadataState, err := pool.NewWriter(incrementalCtx, stream, destination.WithThreadID(threadID), destination.WithApplyFilter(true))
 			if err != nil {
-				return fmt.Errorf("failed to create new writer thread: %s", err)
+				return fmt.Errorf("failed to create new writer thread: %w", err)
 			}
 
 			defer func(ctx context.Context) {
@@ -103,17 +104,21 @@ func (a *AbstractDriver) Incremental(mainCtx context.Context, pool *destination.
 			if prevMetadataState != nil && threadID == prevMetadataState.ID && prevMetadataState.State != nil {
 				stateString, ok := prevMetadataState.State.(string)
 				if !ok {
-					return fmt.Errorf("failed to unmarshal previous metadata state of type[%T]", prevMetadataState.State)
+					return errs.Precondition(errs.StateInvalid,
+						fmt.Sprintf("%s.metadata_state_invalid", a.driver.Type()),
+						fmt.Errorf("failed to unmarshal previous metadata state of type[%T]", prevMetadataState.State))
 				}
 
 				var mtState map[string]any
 				if err := json.Unmarshal([]byte(stateString), &mtState); err != nil {
-					return fmt.Errorf("failed to unmarshal previous metadata state: %s", err)
+					return fmt.Errorf("failed to unmarshal previous metadata state: %w", err)
 				}
 
 				// detect cursor value difference
 				if mtState[primaryCursor] == nil || (secondaryCursor != "" && mtState[secondaryCursor] == nil) {
-					return fmt.Errorf("cursor value is nil in the metadata state for stream[%s] and thread[%s], cursor field got changed. Please run clear destination first", stream.ID(), threadID)
+					return errs.Precondition(errs.StateInvalid,
+						fmt.Sprintf("%s.cursor_field_changed", a.driver.Type()),
+						fmt.Errorf("cursor value is nil in the metadata state for stream[%s] and thread[%s], cursor field got changed. Please run clear destination first", stream.ID(), threadID))
 				}
 
 				logger.Infof("Stream[%s] cursor(s) mismatch, updating cursor(s) in state", stream.ID())
@@ -157,7 +162,7 @@ func ReformatCursorValue(cursorField string, cursorValue any, stream types.Strea
 	}
 	cursorColType, err := stream.Schema().GetType(cursorField)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cursor column type: %s", err)
+		return nil, fmt.Errorf("failed to get cursor column type: %w", err)
 	}
 	return typeutils.ReformatValue(cursorColType, cursorValue)
 }
@@ -170,11 +175,11 @@ func (a *AbstractDriver) getIncrementCursorFromState(primaryCursorField string, 
 	// typecast in case state was read from file
 	primaryCursorValue, err := ReformatCursorValue(primaryCursorField, primaryStateCursorValue, stream)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to typecast primary cursor value: %s", err)
+		return nil, nil, fmt.Errorf("failed to typecast primary cursor value: %w", err)
 	}
 	secondaryCursorValue, err := ReformatCursorValue(secondaryCursorField, secondaryStateCursorValue, stream)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to typecast secondary cursor value: %s", err)
+		return nil, nil, fmt.Errorf("failed to typecast secondary cursor value: %w", err)
 	}
 	return primaryCursorValue, secondaryCursorValue, nil
 }

--- a/drivers/db2/go.mod
+++ b/drivers/db2/go.mod
@@ -23,15 +23,20 @@ require (
 	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/db2/internal/backfill.go
+++ b/drivers/db2/internal/backfill.go
@@ -28,12 +28,12 @@ func (d *DB2) ChunkIterator(ctx context.Context, stream types.StreamInterface, c
 
 	thresholdFilter, args, err := jdbc.ThresholdFilter(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to set threshold filter: %s", err)
+		return fmt.Errorf("failed to set threshold filter: %w", err)
 	}
 
 	filter, err := jdbc.SQLFilter(stream, d.Type(), thresholdFilter)
 	if err != nil {
-		return fmt.Errorf("failed to parse filter during chunk iteration: %s", err)
+		return fmt.Errorf("failed to parse filter during chunk iteration: %w", err)
 	}
 
 	// if PK present then PK based chunking else RID based chunking
@@ -59,14 +59,14 @@ func (d *DB2) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPool
 	var approxRowCount int64
 	rowCountQuery := jdbc.DB2ApproxRowCountQuery(stream)
 	if err := d.client.QueryRowContext(ctx, rowCountQuery).Scan(&approxRowCount); err != nil {
-		return nil, fmt.Errorf("failed to get approx row count: %s", err)
+		return nil, fmt.Errorf("failed to get approx row count: %w", err)
 	}
 	if approxRowCount == -1 || approxRowCount == 0 {
 		var hasRows bool
 		existsQuery := jdbc.DB2TableStatsExistQuery(stream)
 		err := d.client.QueryRowContext(ctx, existsQuery).Scan(&hasRows)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check if table has rows: %s", err)
+			return nil, fmt.Errorf("failed to check if table has rows: %w", err)
 		}
 
 		if hasRows {
@@ -88,11 +88,11 @@ func (d *DB2) splitTableIntoChunks(ctx context.Context, stream types.StreamInter
 		avgRowSizeQuery := jdbc.DB2AvgRowSizeQuery(stream)
 		err := d.client.QueryRowContext(ctx, avgRowSizeQuery).Scan(&avgRowSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get avg row size: %s", err)
+			return nil, fmt.Errorf("failed to get avg row size: %w", err)
 		}
 		avgRowSizeFloat, err := typeutils.ReformatFloat64(avgRowSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert avg row size to float: %s", err)
+			return nil, fmt.Errorf("failed to convert avg row size to float: %w", err)
 		}
 
 		// chunk size
@@ -109,7 +109,7 @@ func (d *DB2) splitTableIntoChunks(ctx context.Context, stream types.StreamInter
 		// table extremes
 		minVal, maxVal, err := d.getTableExtremes(ctx, stream, pkColumns)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get table extremes: %s", err)
+			return nil, fmt.Errorf("failed to get table extremes: %w", err)
 		}
 		if minVal == nil {
 			return types.NewSet[types.Chunk](), nil
@@ -140,7 +140,7 @@ func (d *DB2) splitTableIntoChunks(ctx context.Context, stream types.StreamInter
 			if err == sql.ErrNoRows || nextValRaw == nil {
 				break
 			} else if err != nil {
-				return nil, fmt.Errorf("failed to get next chunk end: %s", err)
+				return nil, fmt.Errorf("failed to get next chunk end: %w", err)
 			}
 			if currentVal != nil && nextValRaw != nil {
 				chunks.Insert(types.Chunk{
@@ -163,14 +163,14 @@ func (d *DB2) splitTableIntoChunks(ctx context.Context, stream types.StreamInter
 	splitViaRID := func(ctx context.Context, stream types.StreamInterface) (*types.Set[types.Chunk], error) {
 		var minRID, maxRID int64
 		if err := d.client.QueryRowContext(ctx, jdbc.DB2MinMaxRidQuery(stream)).Scan(&minRID, &maxRID); err != nil {
-			return nil, fmt.Errorf("failed to get the min and max rid: %s", err)
+			return nil, fmt.Errorf("failed to get the min and max rid: %w", err)
 		}
 
 		// pages size and number of pages
 		var pageSize, nPages int64
 		pageStatsQuery := jdbc.DB2PageStatsQuery(stream)
 		if err := d.client.QueryRowContext(ctx, pageStatsQuery).Scan(&pageSize, &nPages); err != nil {
-			return nil, fmt.Errorf("failed to get the page size and number of pages: %s", err)
+			return nil, fmt.Errorf("failed to get the page size and number of pages: %w", err)
 		}
 
 		// pages to be in a chunk

--- a/drivers/db2/internal/cdc.go
+++ b/drivers/db2/internal/cdc.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 // CDC is not supported yet
@@ -14,7 +15,8 @@ func (d *DB2) ChangeStreamConfig() (bool, bool, bool) { return false, false, fal
 func (d *DB2) PreCDC(_ context.Context, _ []types.StreamInterface) error { return nil }
 
 func (d *DB2) StreamChanges(_ context.Context, _ int, _ map[string]any, _ abstract.CDCMsgFn) (any, error) {
-	return nil, fmt.Errorf("CDC is not supported for DB2")
+	return nil, errs.Precondition(errs.UnsupportedFeature, codeCDCUnsupported,
+		fmt.Errorf("CDC is not supported for DB2"))
 }
 
 func (d *DB2) PostCDC(_ context.Context, _ int) error { return nil }

--- a/drivers/db2/internal/db2.go
+++ b/drivers/db2/internal/db2.go
@@ -41,7 +41,7 @@ func (d *DB2) Setup(ctx context.Context) error {
 		var err error
 		d.sshClient, err = d.config.SSHConfig.SetupSSHConnection()
 		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
+			return fmt.Errorf("failed to setup SSH connection: %w", err)
 		}
 	}
 
@@ -51,7 +51,7 @@ func (d *DB2) Setup(ctx context.Context) error {
 
 		listener, err := net.Listen("tcp", "localhost:0")
 		if err != nil {
-			return fmt.Errorf("failed to create local listener for SSH tunnel: %s", err)
+			return fmt.Errorf("failed to create local listener for SSH tunnel: %w", err)
 		}
 		d.sshListener = listener
 
@@ -66,7 +66,7 @@ func (d *DB2) Setup(ctx context.Context) error {
 
 	client, err := sqlx.Open("go_ibm_db", dsn)
 	if err != nil {
-		return fmt.Errorf("failed to open db2 connection: %s", err)
+		return fmt.Errorf("failed to open db2 connection: %w", err)
 	}
 
 	client.SetMaxOpenConns(d.config.MaxThreads)
@@ -75,7 +75,7 @@ func (d *DB2) Setup(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	if err := client.PingContext(ctx); err != nil {
-		return fmt.Errorf("failed to ping db2: %s", err)
+		return fmt.Errorf("failed to ping db2: %w", err)
 	}
 
 	d.client = client
@@ -171,7 +171,7 @@ func (d *DB2) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 
 	rows, err := d.client.QueryContext(ctx, jdbc.DB2DiscoveryQuery())
 	if err != nil {
-		return nil, fmt.Errorf("failed to list tables: %s", err)
+		return nil, fmt.Errorf("failed to list tables: %w", err)
 	}
 	defer rows.Close()
 
@@ -179,13 +179,13 @@ func (d *DB2) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	for rows.Next() {
 		var schema, name string
 		if err := rows.Scan(&schema, &name); err != nil {
-			return nil, fmt.Errorf("failed to scan table row: %s", err)
+			return nil, fmt.Errorf("failed to scan table row: %w", err)
 		}
 		streamNames = append(streamNames, types.StreamID{Namespace: schema, Name: name})
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating over table rows: %s", err)
+		return nil, fmt.Errorf("error iterating over table rows: %w", err)
 	}
 
 	return streamNames, nil
@@ -200,7 +200,7 @@ func (d *DB2) ProduceSchema(ctx context.Context, streamName types.StreamID) (*ty
 
 		rows, err := d.client.QueryContext(ctx, jdbc.DB2TableSchemaAndPrimaryKeysQuery(), schemaName, tableName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query column metadata: %s", err)
+			return nil, fmt.Errorf("failed to query column metadata: %w", err)
 		}
 		defer rows.Close()
 
@@ -213,7 +213,7 @@ func (d *DB2) ProduceSchema(ctx context.Context, streamName types.StreamID) (*ty
 			)
 
 			if err := rows.Scan(&columnName, &dataType, &isNullable, &pkColumn); err != nil {
-				return nil, fmt.Errorf("failed to scan column: %s", err)
+				return nil, fmt.Errorf("failed to scan column: %w", err)
 			}
 
 			stream.WithCursorField(columnName)
@@ -237,9 +237,9 @@ func (d *DB2) ProduceSchema(ctx context.Context, streamName types.StreamID) (*ty
 	stream, err := populateStreams(ctx, streamName)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %w", ctx.Err())
 		}
-		return nil, fmt.Errorf("failed to process table[%s]: %s", streamName, err)
+		return nil, fmt.Errorf("failed to process table[%s]: %w", streamName, err)
 	}
 
 	stream.WithSyncMode(types.FULLREFRESH, types.INCREMENTAL)

--- a/drivers/db2/internal/errors.go
+++ b/drivers/db2/internal/errors.go
@@ -1,0 +1,125 @@
+package driver
+
+import (
+	"errors"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	go_ibm_db "github.com/ibmdb/go_ibm_db"
+)
+
+// The one condition this driver detects itself: Db2 has no change feed, so there is no
+// replication state to validate.
+const codeCDCUnsupported = "db2.cdc_unsupported"
+
+// sqlStateCategories maps a Db2 SQLSTATE to a failure category. Two spaces arrive here: Db2's
+// own, and the ODBC/CLI layer's (08S01, HYT00, IM002, 42S02), raised before Db2 is reached.
+// SQLSTATE is what gets reported, never the SQLCODE, even where the SQLCODE decided the category.
+var sqlStateCategories = map[string]errs.Category{
+	// The CLI never reached a usable session.
+	"08001": errs.NetworkUnreachable, // client unable to establish the connection
+	"08003": errs.NetworkUnreachable, // connection does not exist
+	"08006": errs.NetworkUnreachable, // connection failure
+	"08S01": errs.NetworkUnreachable, // communication link failure (CLI)
+	"08004": errs.AuthFailed,         // server rejected the connection — see sqlCodeOverrides
+
+	"28000": errs.AuthFailed,
+
+	// Missing object, or an authorization ID that cannot use it.
+	"42501": errs.PermissionDenied, // insufficient authorization
+	"42502": errs.PermissionDenied, // authorization violation
+	"42704": errs.ObjectNotFound,   // undefined object name
+	"42703": errs.ObjectNotFound,   // undefined column name
+	"42S02": errs.ObjectNotFound,   // base table or view not found (CLI)
+	"42S22": errs.ObjectNotFound,   // column not found (CLI)
+
+	// Also class 42, but these mean the SQL *OLake generated* is wrong — our defect.
+	"42601": errs.SourceReadError, // syntax error
+	"42884": errs.SourceReadError, // no routine found with matching signature
+
+	// Well-formed statement; the data cannot be represented as asked.
+	"22007": errs.SchemaUnsupported, // invalid datetime format
+	"22018": errs.SchemaUnsupported, // invalid character value for cast
+
+	// Two units of work collided; a retry usually clears it.
+	"40001": errs.ConcurrencyConflict, // rollback caused by deadlock or timeout
+	"57033": errs.ConcurrencyConflict, // deadlock or timeout with no automatic rollback
+
+	// Nothing is misconfigured; the server ran out.
+	"57011": errs.ResourceExhausted, // resources not available — includes a full transaction log
+	"57019": errs.ResourceExhausted, // resource unavailable
+	"54001": errs.ResourceExhausted, // statement too complex
+
+	"HYT00": errs.Timeout,  // timeout expired (CLI)
+	"HYT01": errs.Timeout,  // connection timeout expired (CLI)
+	"57014": errs.Canceled, // processing was canceled by an interrupt
+
+	// IM002 is a data source the user named and the driver cannot find; IM003 is our own
+	// packaging, since OLake ships the CLI.
+	"IM002": errs.ConfigInvalid,
+	"IM003": errs.InternalError,
+}
+
+// sqlCodeOverrides resolves the two SQLSTATEs Db2 reuses across conditions needing different
+// fixes. The SQLCODE is consulted only where it changes the answer; the reported code stays
+// the SQLSTATE, so telemetry keeps one code space.
+var sqlCodeOverrides = map[int]errs.Category{
+	-30082: errs.AuthFailed,         // SQL30082N security processing failed — SQLSTATE 08001
+	-30081: errs.NetworkUnreachable, // SQL30081N communication error — SQLSTATE 08001
+	-30061: errs.ObjectNotFound,     // SQL30061N database alias or name not found — SQLSTATE 08004
+	-1403:  errs.AuthFailed,         // SQL1403N username or password incorrect — SQLSTATE 08004
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only Db2
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("db2", classify) }
+
+// classify reads Db2's SQLSTATE, and the SQLCODE where the SQLSTATE is ambiguous, returning nil
+// for anything else. The category comes from the error, never the call site.
+func classify(err error) *errs.Failure {
+	var db2Err *go_ibm_db.Error
+	if !errors.As(err, &db2Err) {
+		return nil
+	}
+
+	// Diagnostics arrive as a slice whose length and contents depend on the CLI build, and the
+	// CLI puts a general record ahead of the real cause — so walk all of them, not just the first.
+	var firstState string
+	for i := range db2Err.Diag {
+		record := db2Err.Diag[i]
+		if record.State == "" {
+			continue
+		}
+		if firstState == "" {
+			firstState = record.State
+		}
+
+		// Consulted only where the SQLSTATE covers unrelated conditions.
+		if category, ok := sqlCodeOverrides[record.NativeError]; ok {
+			return &errs.Failure{
+				Category:     category,
+				ClassifiedBy: errs.ClassifiedByVendor,
+				Code:         record.State,
+			}
+		}
+		if category, ok := sqlStateCategories[record.State]; ok {
+			return &errs.Failure{
+				Category:     category,
+				ClassifiedBy: errs.ClassifiedByVendor,
+				Code:         record.State,
+			}
+		}
+	}
+
+	// Diagnostics present, nothing mapped; the SQLSTATE alone makes the gap actionable.
+	if firstState != "" {
+		return &errs.Failure{
+			Category:     errs.Unclassified,
+			ClassifiedBy: errs.ClassifiedByDefault,
+			Code:         firstState,
+		}
+	}
+
+	// No diagnostics at all, which some CLI builds do normally. Handed back to the shared rules,
+	// which may still recognize the transport failure underneath.
+	return nil
+}

--- a/drivers/db2/internal/incremental.go
+++ b/drivers/db2/internal/incremental.go
@@ -28,7 +28,7 @@ func (d *DB2) StreamIncrementalChanges(ctx context.Context, stream types.StreamI
 
 	incrementalQuery, queryArgs, err := jdbc.BuildIncrementalQuery(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to build incremental query: %s", err)
+		return fmt.Errorf("failed to build incremental query: %w", err)
 	}
 	return d.readBatchConcurrent(ctx, incrementalQuery, queryArgs, processFn)
 }

--- a/drivers/db2/internal/readbatch.go
+++ b/drivers/db2/internal/readbatch.go
@@ -70,7 +70,7 @@ type colBatch struct {
 func (d *DB2) readBatchConcurrent(ctx context.Context, query string, args []any, onMessage abstract.BackfillMsgFn) error {
 	sqlConn, err := d.client.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("readBatchConcurrent: acquire conn: %s", err)
+		return fmt.Errorf("readBatchConcurrent: acquire conn: %w", err)
 	}
 	defer sqlConn.Close()
 
@@ -95,7 +95,7 @@ func (d *DB2) readBatchConcurrent(ctx context.Context, query string, args []any,
 		}
 		rows, err := conn.QueryBatch(query, driverArgs)
 		if err != nil {
-			return fmt.Errorf("readBatchConcurrent: query: %s", err)
+			return fmt.Errorf("readBatchConcurrent: query: %w", err)
 		}
 		defer rows.Close()
 
@@ -138,7 +138,7 @@ func (d *DB2) readBatchConcurrent(ctx context.Context, query string, args []any,
 					raw := batch.getValues[colIdx](rowIdx)
 					conv, err := convFuncs[colIdx](raw)
 					if err != nil {
-						return fmt.Errorf("column %s: %s", colName, err)
+						return fmt.Errorf("column %s: %w", colName, err)
 					}
 					record[colName] = conv
 					rowBytes += db2ColumnBytes(raw, colTypeNames[colIdx])
@@ -169,7 +169,7 @@ func (d *DB2) readBatchConcurrent(ctx context.Context, query string, args []any,
 				if errors.Is(readErr, io.EOF) {
 					return nil
 				} else if readErr != nil {
-					return fmt.Errorf("ReadBatchConcurrent: %s", readErr)
+					return fmt.Errorf("ReadBatchConcurrent: %w", readErr)
 				}
 			}
 		}
@@ -209,7 +209,7 @@ func (d *DB2) readBatchConcurrent(ctx context.Context, query string, args []any,
 					if errors.Is(readErr, io.EOF) {
 						return nil
 					} else if readErr != nil {
-						return fmt.Errorf("ReadBatchConcurrent producer: %s", readErr)
+						return fmt.Errorf("ReadBatchConcurrent producer: %w", readErr)
 					}
 				}
 			}

--- a/drivers/kafka/go.mod
+++ b/drivers/kafka/go.mod
@@ -21,15 +21,20 @@ require (
 	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/kafka/internal/backfill.go
+++ b/drivers/kafka/internal/backfill.go
@@ -7,12 +7,15 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 func (k *Kafka) GetOrSplitChunks(_ context.Context, _ *destination.WriterPool, _ types.StreamInterface) (*types.Set[types.Chunk], error) {
-	return nil, fmt.Errorf("GetOrSplitChunks not supported for Kafka driver")
+	return nil, errs.Precondition(errs.UnsupportedFeature, codeBackfillUnsupported,
+		fmt.Errorf("GetOrSplitChunks not supported for Kafka driver"))
 }
 
 func (k *Kafka) ChunkIterator(_ context.Context, _ types.StreamInterface, _ types.Chunk, _ abstract.BackfillMsgFn) error {
-	return fmt.Errorf("ChunkIterator not supported for Kafka driver")
+	return errs.Precondition(errs.UnsupportedFeature, codeBackfillUnsupported,
+		fmt.Errorf("ChunkIterator not supported for Kafka driver"))
 }

--- a/drivers/kafka/internal/cdc.go
+++ b/drivers/kafka/internal/cdc.go
@@ -14,6 +14,7 @@ import (
 	kafkapkg "github.com/datazip-inc/olake/pkg/kafka"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/linkedin/goavro/v2"
@@ -59,7 +60,7 @@ func (k *Kafka) PreCDC(ctx context.Context, streams []types.StreamInterface) err
 
 	// remove stale consumers before creating new readers
 	if err := k.readerManager.RemoveExistingConsumers(ctx, k.client); err != nil {
-		return fmt.Errorf("failed to remove existing consumers: %s", err)
+		return fmt.Errorf("failed to remove existing consumers: %w", err)
 	}
 
 	// create new readers and wait for partition assignment
@@ -70,13 +71,13 @@ func (k *Kafka) StreamChanges(ctx context.Context, readerID int, metadataStates 
 	// Fetch partition assignment once per StreamChanges attempt than reused for recovery and completion checks.
 	assignedPartitions, err := k.getReaderAssignedPartitions(ctx, readerID)
 	if err != nil {
-		return nil, fmt.Errorf("reader[%d]: get assigned partitions failed: %s", readerID, err)
+		return nil, fmt.Errorf("reader[%d]: get assigned partitions failed: %w", readerID, err)
 	}
 
 	// Recover broker offsets from destination metadata if needed.
 	isRecoveryPerformed, err := k.syncCommittedOffsetsWithMetadata(ctx, readerID, k.readerManager.GetReader(readerID), metadataStates, assignedPartitions)
 	if err != nil {
-		return nil, fmt.Errorf("reader[%d]: sync committed offsets with metadata failed: %s", readerID, err)
+		return nil, fmt.Errorf("reader[%d]: sync committed offsets with metadata failed: %w", readerID, err)
 	}
 
 	// A successful recovery stops processing for this reader so the next run starts from the recovered offsets.
@@ -91,7 +92,7 @@ func (k *Kafka) StreamChanges(ctx context.Context, readerID int, metadataStates 
 	// Note: Since a static instance ID is used, this restart does not trigger a consumer group rebalance.
 	reader, err := k.readerManager.RestartReader(readerID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to restart reader %d: %s", readerID, err)
+		return nil, fmt.Errorf("failed to restart reader %d: %w", readerID, err)
 	}
 
 	// track processing state
@@ -111,7 +112,8 @@ func (k *Kafka) StreamChanges(ctx context.Context, readerID int, metadataStates 
 		currentPartitionKey := types.PartitionKey{Topic: record.Message.Topic, Partition: record.Message.Partition}
 		currentPartitionMeta, exists := k.readerManager.GetPartitionMeta(kafkapkg.PartitionMetadataKey(record.Message.Topic, record.Message.Partition))
 		if !exists {
-			return false, fmt.Errorf("missing partition Metadata for topic %s partition %d", record.Message.Topic, record.Message.Partition)
+			return false, errs.Precondition(errs.StateInvalid, codePartitionMetadataAbsent,
+				fmt.Errorf("missing partition Metadata for topic %s partition %d", record.Message.Topic, record.Message.Partition))
 		}
 
 		// process the change if data is present
@@ -152,7 +154,8 @@ func (k *Kafka) StreamChanges(ctx context.Context, readerID int, metadataStates 
 	for partitionKey, message := range lastMessages {
 		partitionMeta, exists := k.readerManager.GetPartitionMeta(kafkapkg.PartitionMetadataKey(partitionKey.Topic, partitionKey.Partition))
 		if !exists {
-			return nil, fmt.Errorf("missing partition metadata for topic %s partition %d", partitionKey.Topic, partitionKey.Partition)
+			return nil, errs.Precondition(errs.StateInvalid, codePartitionMetadataAbsent,
+				fmt.Errorf("missing partition metadata for topic %s partition %d", partitionKey.Topic, partitionKey.Partition))
 		}
 		streamID := partitionMeta.Stream.ID()
 		state, _ := metadataByStream[streamID].(map[string]any)
@@ -213,7 +216,7 @@ func (k *Kafka) PostCDC(ctx context.Context, readerIdx int) error {
 			logger.Debugf("reader %s post cdc: generation id: %d", readerID, generationID)
 
 			if err := reader.CommitRecords(ctx, messages...); err != nil {
-				return fmt.Errorf("commit failed for reader %s: %s", readerID, err)
+				return fmt.Errorf("commit failed for reader %s: %w", readerID, err)
 			}
 
 			logger.Infof("committed %d partitions for reader %s", len(messages), readerID)
@@ -286,7 +289,7 @@ func (k *Kafka) processKafkaMessages(ctx context.Context, reader *kgo.Client, st
 				data[Key] = key
 				data[KafkaTimestamp], err = typeutils.ReformatDate(message.Timestamp, true)
 				if err != nil {
-					return fmt.Errorf("failed to reformat date: %s", err)
+					return fmt.Errorf("failed to reformat date: %w", err)
 				}
 			}
 
@@ -316,7 +319,7 @@ func (k *Kafka) parseKafkaData(message *kgo.Record) (map[string]interface{}, str
 			// fetch schema
 			schema, err := k.schemaRegistryClient.FetchSchema(schemaID)
 			if err != nil {
-				return nil, fmt.Errorf("failed to fetch schema %d: %s", schemaID, err)
+				return nil, fmt.Errorf("failed to fetch schema %d: %w", schemaID, err)
 			}
 
 			// decode data based on format
@@ -393,7 +396,7 @@ func decodeJSONMessage(value []byte) (map[string]interface{}, error) {
 func decodeAvroMessage(data []byte, codec *goavro.Codec) (interface{}, error) {
 	nativeDatum, _, err := codec.NativeFromBinary(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode Avro: %s", err)
+		return nil, fmt.Errorf("failed to decode Avro: %w", err)
 	}
 
 	if record, ok := nativeDatum.(map[string]interface{}); ok {
@@ -415,7 +418,8 @@ func (k *Kafka) syncCommittedOffsetsWithMetadata(ctx context.Context, readerID i
 
 		partitionMeta, ok := k.readerManager.GetPartitionMeta(kafkapkg.PartitionMetadataKey(currentTopic, currentPartitionID))
 		if !ok {
-			return false, fmt.Errorf("%w: assigned partition %s:%d missing from partition metadata", constants.ErrNonRetryable, currentTopic, currentPartitionID)
+			return false, errs.Precondition(errs.StateInvalid, codePartitionMetadataAbsent,
+				fmt.Errorf("%w: assigned partition %s:%d missing from partition metadata", constants.ErrNonRetryable, currentTopic, currentPartitionID))
 		}
 
 		streamID := partitionMeta.Stream.ID()
@@ -429,20 +433,22 @@ func (k *Kafka) syncCommittedOffsetsWithMetadata(ctx context.Context, readerID i
 				// if metadata state is present, unmarshal it and cache it.
 				mtStateStr, ok := rawMetadataStateValue.(string)
 				if !ok {
-					return false, fmt.Errorf("stream[%s]: failed to typecast metadata state of type[%T] to string", streamID, rawMetadataStateValue)
+					return false, errs.Precondition(errs.StateInvalid, codeMetadataStateInvalid,
+						fmt.Errorf("stream[%s]: failed to typecast metadata state of type[%T] to string", streamID, rawMetadataStateValue))
 				}
 
 				var parsedMetadataStateValue map[string]any
 				decoder := json.NewDecoder(bytes.NewReader([]byte(mtStateStr)))
 				decoder.UseNumber()
 				if err := decoder.Decode(&parsedMetadataStateValue); err != nil {
-					return false, fmt.Errorf("stream[%s]: failed to unmarshal metadata state: %s", streamID, err)
+					return false, fmt.Errorf("stream[%s]: failed to unmarshal metadata state: %w", streamID, err)
 				}
 
 				// check if consumer group id mismatch
 				metaConsumerGroupID, _ := parsedMetadataStateValue["consumer_group_id"].(string)
 				if metaConsumerGroupID != "" && metaConsumerGroupID != k.consumerGroupID {
-					return false, fmt.Errorf("%w: stream[%s]: consumer_group_id mismatch (destination metadata=%q, current=%q), run clear destination and restart", constants.ErrNonRetryable, streamID, metaConsumerGroupID, k.consumerGroupID)
+					return false, errs.Precondition(errs.StateInvalid, codeConsumerGroupMismatch,
+						fmt.Errorf("%w: stream[%s]: consumer_group_id mismatch (destination metadata=%q, current=%q), run clear destination and restart", constants.ErrNonRetryable, streamID, metaConsumerGroupID, k.consumerGroupID))
 				}
 
 				// cache the parsed metadata state for this stream
@@ -462,18 +468,20 @@ func (k *Kafka) syncCommittedOffsetsWithMetadata(ctx context.Context, readerID i
 
 		metaCommittedOffset, err := typeutils.ReformatInt64(offsetValue)
 		if err != nil {
-			return false, fmt.Errorf("stream[%s] topic %s partition %d: invalid metadata offset: %s", streamID, currentTopic, currentPartitionID, err)
+			return false, fmt.Errorf("stream[%s] topic %s partition %d: invalid metadata offset: %w", streamID, currentTopic, currentPartitionID, err)
 		}
 
 		// destination metadata offset must not exceed the current partition end offset.
 		// this can happen when a topic is deleted and recreated with fewer messages.
 		if metaCommittedOffset > partitionMeta.EndOffset {
-			return false, fmt.Errorf("%w: stream[%s] topic %s partition %d metadata offset: %d exceeds partition end offset: %d, run clear destination and restart", constants.ErrNonRetryable, streamID, currentTopic, currentPartitionID, metaCommittedOffset, partitionMeta.EndOffset)
+			return false, errs.Precondition(errs.StateInvalid, codeOffsetMismatch,
+				fmt.Errorf("%w: stream[%s] topic %s partition %d metadata offset: %d exceeds partition end offset: %d, run clear destination and restart", constants.ErrNonRetryable, streamID, currentTopic, currentPartitionID, metaCommittedOffset, partitionMeta.EndOffset))
 		}
 
 		// kafkaCommittedOffset must not exceed metaCommittedOffset.
 		if kafkaCommittedOffset >= 0 && kafkaCommittedOffset > metaCommittedOffset {
-			return false, fmt.Errorf("%w: stream[%s] topic %s partition %d broker committed offset: %d is ahead of destination metadata offset: %d, run clear destination and restart", constants.ErrNonRetryable, streamID, currentTopic, currentPartitionID, kafkaCommittedOffset, metaCommittedOffset)
+			return false, errs.Precondition(errs.StateInvalid, codeOffsetMismatch,
+				fmt.Errorf("%w: stream[%s] topic %s partition %d broker committed offset: %d is ahead of destination metadata offset: %d, run clear destination and restart", constants.ErrNonRetryable, streamID, currentTopic, currentPartitionID, kafkaCommittedOffset, metaCommittedOffset))
 		}
 
 		// Broker is behind destination (or has no committed offset yet): align broker to destination before consuming.
@@ -488,7 +496,7 @@ func (k *Kafka) syncCommittedOffsetsWithMetadata(ctx context.Context, readerID i
 
 	logger.Infof("reader[%d]: crash-recovery detected, committing %d partitions to broker", readerID, len(recordsToCommit))
 	if err := reader.CommitRecords(ctx, recordsToCommit...); err != nil {
-		return false, fmt.Errorf("recovery offset commit failed, cannot continue (would cause duplicates): %s", err)
+		return false, fmt.Errorf("recovery offset commit failed, cannot continue (would cause duplicates): %w", err)
 	}
 	return true, nil
 }

--- a/drivers/kafka/internal/errors.go
+++ b/drivers/kafka/internal/errors.go
@@ -1,0 +1,108 @@
+package driver
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/twmb/franz-go/pkg/kerr"
+)
+
+// Codes for conditions this driver detects itself. All but the first are state that no longer
+// lines up with the broker — visible only by comparing our destination metadata against Kafka.
+const (
+	codeBackfillUnsupported     = "kafka.backfill_unsupported"
+	codeMetadataStateInvalid    = "kafka.metadata_state_invalid"
+	codeConsumerGroupMismatch   = "kafka.consumer_group_mismatch"
+	codeOffsetMismatch          = "kafka.offset_mismatch"
+	codePartitionMetadataAbsent = "kafka.partition_metadata_absent"
+)
+
+// kerrCategories maps a Kafka protocol error code to a failure category; trailing names are as
+// franz-go's own pkg/kerr table spells them. Only codes a *consumer* can receive are mapped —
+// produce- and transaction-side codes cannot reach this driver.
+var kerrCategories = map[int16]errs.Category{
+	// The broker refused the identity itself.
+	58: errs.AuthFailed, // SASL_AUTHENTICATION_FAILED
+	34: errs.AuthFailed, // ILLEGAL_SASL_STATE
+	66: errs.AuthFailed, // DELEGATION_TOKEN_EXPIRED
+
+	// The principal is known and lacks a right on the topic, group or cluster.
+	29: errs.PermissionDenied, // TOPIC_AUTHORIZATION_FAILED
+	30: errs.PermissionDenied, // GROUP_AUTHORIZATION_FAILED
+	31: errs.PermissionDenied, // CLUSTER_AUTHORIZATION_FAILED
+	65: errs.PermissionDenied, // DELEGATION_TOKEN_AUTHORIZATION_FAILED
+
+	3:  errs.ObjectNotFound, // UNKNOWN_TOPIC_OR_PARTITION
+	69: errs.ObjectNotFound, // GROUP_ID_NOT_FOUND
+
+	// Retention passed the committed offset: a full re-read, not a retry.
+	1: errs.CDCPositionLost, // OFFSET_OUT_OF_RANGE
+
+	// The broker, leader or coordinator is not serving — all transient, same remedy.
+	8:  errs.NetworkUnreachable, // BROKER_NOT_AVAILABLE
+	13: errs.NetworkUnreachable, // NETWORK_EXCEPTION
+	15: errs.NetworkUnreachable, // COORDINATOR_NOT_AVAILABLE
+	16: errs.NetworkUnreachable, // NOT_COORDINATOR
+	14: errs.NetworkUnreachable, // COORDINATOR_LOAD_IN_PROGRESS
+	5:  errs.NetworkUnreachable, // LEADER_NOT_AVAILABLE
+	6:  errs.NetworkUnreachable, // NOT_LEADER_FOR_PARTITION
+	9:  errs.NetworkUnreachable, // REPLICA_NOT_AVAILABLE
+	41: errs.NetworkUnreachable, // NOT_CONTROLLER
+	72: errs.NetworkUnreachable, // LISTENER_NOT_FOUND
+
+	// Membership is reshuffling and our claim is stale; the run proceeds once the group settles.
+	27: errs.ConcurrencyConflict, // REBALANCE_IN_PROGRESS
+	22: errs.ConcurrencyConflict, // ILLEGAL_GENERATION
+	25: errs.ConcurrencyConflict, // UNKNOWN_MEMBER_ID
+	60: errs.ConcurrencyConflict, // REASSIGNMENT_IN_PROGRESS
+
+	// The broker could not read its own log.
+	56: errs.ResourceExhausted, // KAFKA_STORAGE_ERROR
+
+	// The bytes on the partition are not what a consumer can read.
+	2: errs.SourceReadError, // CORRUPT_MESSAGE
+	4: errs.SourceReadError, // INVALID_FETCH_SIZE — a value this driver chose
+
+	// Settings the broker rejected; each is a field the user set.
+	40: errs.ConfigInvalid, // INVALID_CONFIG
+	44: errs.ConfigInvalid, // POLICY_VIOLATION
+	24: errs.ConfigInvalid, // INVALID_GROUP_ID
+	26: errs.ConfigInvalid, // INVALID_SESSION_TIMEOUT
+	17: errs.ConfigInvalid, // INVALID_TOPIC_EXCEPTION
+	33: errs.ConfigInvalid, // UNSUPPORTED_SASL_MECHANISM
+	54: errs.ConfigInvalid, // SECURITY_DISABLED
+
+	// Understood, but not servable at this version.
+	35: errs.UnsupportedFeature, // UNSUPPORTED_VERSION
+	43: errs.UnsupportedFeature, // UNSUPPORTED_FOR_MESSAGE_FORMAT
+	76: errs.UnsupportedFeature, // UNSUPPORTED_COMPRESSION_TYPE
+
+	7: errs.Timeout, // REQUEST_TIMED_OUT
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only Kafka
+// protocol evidence lives here; DNS, TLS and socket failures belong to utils/errs.
+func init() { errs.Register("kafka", classify) }
+
+// classify reads Kafka's protocol error code, returning nil for anything else so the shared
+// rules get their chance. The category comes from the error, never the call site.
+func classify(err error) *errs.Failure {
+	var protocolErr *kerr.Error
+	if !errors.As(err, &protocolErr) {
+		return nil
+	}
+
+	// The code travels whether or not it is mapped. protocolErr.Retriable is deliberately not
+	// read: the repo drives retries through constants.ErrNonRetryable.
+	f := errs.Failure{Code: strconv.FormatInt(int64(protocolErr.Code), 10)}
+	if category, ok := kerrCategories[protocolErr.Code]; ok {
+		f.Category = category
+		f.ClassifiedBy = errs.ClassifiedByVendor
+		return &f
+	}
+	// A real protocol code with no rule yet; the code alone makes the gap actionable.
+	f.Category = errs.Unclassified
+	f.ClassifiedBy = errs.ClassifiedByDefault
+	return &f
+}

--- a/drivers/kafka/internal/kafka.go
+++ b/drivers/kafka/internal/kafka.go
@@ -85,7 +85,7 @@ func (k *Kafka) SetupState(state *types.State) {
 
 func (k *Kafka) Setup(ctx context.Context) error {
 	if err := k.config.Validate(); err != nil {
-		return fmt.Errorf("config validation failed: %s", err)
+		return fmt.Errorf("config validation failed: %w", err)
 	}
 
 	// Compile topic pattern regex if provided
@@ -100,13 +100,13 @@ func (k *Kafka) Setup(ctx context.Context) error {
 
 	dialer, err := k.createDialer()
 	if err != nil {
-		return fmt.Errorf("failed to create Kafka dialer: %s", err)
+		return fmt.Errorf("failed to create Kafka dialer: %w", err)
 	}
 
 	// create admin client for metadata and offset operations
 	client, err := kgo.NewClient(dialer...)
 	if err != nil {
-		return fmt.Errorf("failed to create kafka client: %s", err)
+		return fmt.Errorf("failed to create kafka client: %w", err)
 	}
 
 	k.client = client
@@ -115,7 +115,7 @@ func (k *Kafka) Setup(ctx context.Context) error {
 	// Test connectivity by fetching metadata
 	err = client.Ping(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to ping kafka brokers: %s", err)
+		return fmt.Errorf("failed to ping kafka brokers: %w", err)
 	}
 
 	k.dialer = dialer
@@ -124,7 +124,7 @@ func (k *Kafka) Setup(ctx context.Context) error {
 	if k.config.SchemaRegistry != nil {
 		k.config.SchemaRegistry.Init()
 		if err := k.config.SchemaRegistry.Validate(); err != nil {
-			return fmt.Errorf("schema registry validation failed: %s", err)
+			return fmt.Errorf("schema registry validation failed: %w", err)
 		}
 		k.schemaRegistryClient = k.config.SchemaRegistry
 		logger.Infof("initialized schema registry client for endpoint: %s", k.config.SchemaRegistry.Endpoint)
@@ -154,7 +154,7 @@ func (k *Kafka) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	logger.Infof("Starting discover for Kafka")
 	metadata, err := k.adminClient.ListTopics(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list topics: %s", err)
+		return nil, fmt.Errorf("failed to list topics: %w", err)
 	}
 
 	var topicNames []types.StreamID
@@ -197,16 +197,16 @@ func (k *Kafka) ProduceSchema(ctx context.Context, streamID types.StreamID) (*ty
 	// get the topic metadata
 	topicDetail, err := readerManager.GetTopicMetadata(ctx, streamName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch topic metadata for topic %s: %s", streamName, err)
+		return nil, fmt.Errorf("failed to fetch topic metadata for topic %s: %w", streamName, err)
 	}
 
 	startOffsets, endOffsets, err := readerManager.ListTopicOffsets(ctx, streamName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list offsets for topic %s: %s", streamName, err)
+		return nil, fmt.Errorf("failed to list offsets for topic %s: %w", streamName, err)
 	}
 
 	if topicDetail.Err != nil {
-		return nil, fmt.Errorf("topic metadata for %s: %s", streamName, topicDetail.Err)
+		return nil, fmt.Errorf("topic metadata for %s: %w", streamName, topicDetail.Err)
 	}
 
 	partitionList := topicDetail.Partitions.Sorted()
@@ -215,7 +215,7 @@ func (k *Kafka) ProduceSchema(ctx context.Context, streamID types.StreamID) (*ty
 	// get messages from partitions for schema discovery
 	err = utils.Concurrent(ctx, partitionList, len(partitionList), func(ctx context.Context, partitionDetail kadm.PartitionDetail, _ int) error {
 		if partitionDetail.Err != nil {
-			return fmt.Errorf("partition %d: %s", partitionDetail.Partition, partitionDetail.Err)
+			return fmt.Errorf("partition %d: %w", partitionDetail.Partition, partitionDetail.Err)
 		}
 
 		startOffset, endOffset, offsetsFound := readerManager.GetPartitionOffsets(startOffsets, endOffsets, streamName, partitionDetail.Partition)
@@ -265,7 +265,7 @@ func (k *Kafka) ProduceSchema(ctx context.Context, streamID types.StreamID) (*ty
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch schema for topic %s: %s", streamName, err)
+		return nil, fmt.Errorf("failed to fetch schema for topic %s: %w", streamName, err)
 	}
 
 	stream.SourceDefinedPrimaryKey = types.NewSet(Offset, Partition)
@@ -368,7 +368,7 @@ func (k *Kafka) buildTLSConfig() (*tls.Config, error) {
 		if k.config.Protocol.SSL.ClientCert != "" && k.config.Protocol.SSL.ClientKey != "" {
 			cert, err := tls.X509KeyPair([]byte(k.config.Protocol.SSL.ClientCert), []byte(k.config.Protocol.SSL.ClientKey))
 			if err != nil {
-				return nil, fmt.Errorf("failed to load client certificate/key: %s", err)
+				return nil, fmt.Errorf("failed to load client certificate/key: %w", err)
 			}
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
@@ -403,11 +403,11 @@ func (k *Kafka) getReaderAssignedPartitions(ctx context.Context, readerIndex int
 
 	describeGroupResp, describeGroupRespErr := k.adminClient.DescribeGroups(ctx, k.consumerGroupID)
 	if describeGroupRespErr != nil {
-		return nil, fmt.Errorf("DescribeGroups failed: %s", describeGroupRespErr)
+		return nil, fmt.Errorf("DescribeGroups failed: %w", describeGroupRespErr)
 	}
 
 	if describeGroupResp.Error() != nil {
-		return nil, fmt.Errorf("describe group %s response error: %s", k.consumerGroupID, describeGroupResp.Error())
+		return nil, fmt.Errorf("describe group %s response error: %w", k.consumerGroupID, describeGroupResp.Error())
 	}
 
 	var assigned []types.PartitionKey

--- a/drivers/mongodb/go.mod
+++ b/drivers/mongodb/go.mod
@@ -15,15 +15,20 @@ require (
 	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/mongodb/internal/backfill.go
+++ b/drivers/mongodb/internal/backfill.go
@@ -27,7 +27,7 @@ func (m *Mongo) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 
 	filter, err := m.buildFilter(stream)
 	if err != nil {
-		return fmt.Errorf("failed to parse filter during chunk iteration: %s", err)
+		return fmt.Errorf("failed to parse filter during chunk iteration: %w", err)
 	}
 
 	logger.Debugf("Starting backfill from %v to %v with filter: %s", chunk.Min, chunk.Max, filter)
@@ -35,27 +35,27 @@ func (m *Mongo) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 	// check for _id type
 	ObjectIDPresent, err := isObjectID(ctx, collection)
 	if err != nil {
-		return fmt.Errorf("failed to check if _id is ObjectID: %s", err)
+		return fmt.Errorf("failed to check if _id is ObjectID: %w", err)
 	}
 
 	cursor, err := collection.Aggregate(ctx, generatePipeline(chunk.Min, chunk.Max, filter, ObjectIDPresent), opts)
 	if err != nil {
-		return fmt.Errorf("failed to create cursor: %s", err)
+		return fmt.Errorf("failed to create cursor: %w", err)
 	}
 	defer cursor.Close(ctx)
 	for cursor.Next(ctx) {
 		var doc bson.M
 		if _, err = cursor.Current.LookupErr("_id"); err != nil {
-			return fmt.Errorf("looking up idProperty: %s", err)
+			return fmt.Errorf("looking up idProperty: %w", err)
 		} else if err = cursor.Decode(&doc); err != nil {
-			return fmt.Errorf("backfill decoding document: %s", err)
+			return fmt.Errorf("backfill decoding document: %w", err)
 		}
 		// BSON wire-format size of this document, read before the cursor advances.
 		docBytes := int64(len(cursor.Current))
 		// filter mongo object
 		filterMongoObject(doc)
 		if err := OnMessage(ctx, doc, docBytes); err != nil {
-			return fmt.Errorf("failed to send message to writer: %s", err)
+			return fmt.Errorf("failed to send message to writer: %w", err)
 		}
 	}
 	return cursor.Err()
@@ -83,7 +83,7 @@ func (m *Mongo) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 		return retryErr
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed after retry backoff: %s", err)
+		return nil, fmt.Errorf("failed after retry backoff: %w", err)
 	}
 
 	return types.NewSet(chunksArray...), nil
@@ -127,7 +127,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 			}
 
 			if err := collection.Database().RunCommand(ctx, cmd).Decode(&result); err != nil {
-				return nil, fmt.Errorf("failed to run splitVector command: %s", err)
+				return nil, fmt.Errorf("failed to run splitVector command: %w", err)
 			}
 
 			boundaries := []*primitive.ObjectID{&minID}
@@ -141,7 +141,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 
 		boundaries, err := getChunkBoundaries()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get chunk boundaries: %s", err)
+			return nil, fmt.Errorf("failed to get chunk boundaries: %w", err)
 		}
 		// Group every 8 splitVector chunks (~1GB each) into a single larger chunk (~8GB) for consistency with other chunking strategies
 		var chunks []types.Chunk
@@ -178,7 +178,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		opts := options.Aggregate().SetAllowDiskUse(true)
 		cursor, err := collection.Aggregate(ctx, pipeline, opts)
 		if err != nil {
-			return nil, fmt.Errorf("failed to execute bucketAuto aggregation: %s", err)
+			return nil, fmt.Errorf("failed to execute bucketAuto aggregation: %w", err)
 		}
 		defer cursor.Close(ctx)
 
@@ -191,7 +191,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		}
 
 		if err := cursor.All(ctx, &buckets); err != nil {
-			return nil, fmt.Errorf("failed to decode bucketAuto results: %s", err)
+			return nil, fmt.Errorf("failed to decode bucketAuto results: %w", err)
 		}
 
 		var chunks []types.Chunk
@@ -199,14 +199,14 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 			// converts value according to _id string repr.
 			minVal, err := reformatID(bucket.ID.Min)
 			if err != nil {
-				return nil, fmt.Errorf("failed to convert bucket min value to required type: %s", err)
+				return nil, fmt.Errorf("failed to convert bucket min value to required type: %w", err)
 			}
 			var maxVal interface{}
 			// for last bucket, max will be nil
 			if idx != len(buckets)-1 {
 				maxVal, err = reformatID(bucket.ID.Max)
 				if err != nil {
-					return nil, fmt.Errorf("failed to convert bucket max value to required type: %s", err)
+					return nil, fmt.Errorf("failed to convert bucket max value to required type: %w", err)
 				}
 			}
 			chunks = append(chunks, types.Chunk{
@@ -260,7 +260,7 @@ func (m *Mongo) splitChunks(ctx context.Context, collection *mongo.Collection, s
 		// check for _id type
 		ObjectIDPresent, err := isObjectID(ctx, collection)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check if _id is ObjectID: %s", err)
+			return nil, fmt.Errorf("failed to check if _id is ObjectID: %w", err)
 		}
 
 		if ObjectIDPresent {
@@ -287,15 +287,15 @@ func (m *Mongo) totalCountAndStorageSizeInCollection(ctx context.Context, collec
 	// Select the database
 	err := collection.Database().RunCommand(ctx, command).Decode(&statsResult)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to fetch collection stats: %s", err)
+		return 0, 0, fmt.Errorf("failed to fetch collection stats: %w", err)
 	}
 	count, err := typeutils.ReformatInt64(statsResult["count"])
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to reformat total count from %T to int64: %s", statsResult["count"], err)
+		return 0, 0, fmt.Errorf("failed to reformat total count from %T to int64: %w", statsResult["count"], err)
 	}
 	storageSize, err := typeutils.ReformatFloat64(statsResult["storageSize"])
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to reformat storage size from %T to float64: %s", statsResult["storageSize"], err)
+		return 0, 0, fmt.Errorf("failed to reformat storage size from %T to float64: %w", statsResult["storageSize"], err)
 	}
 	return count, storageSize, nil
 }
@@ -320,12 +320,12 @@ func (m *Mongo) fetchExtremes(ctx context.Context, collection *mongo.Collection)
 
 	start, err := extreme(1)
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("failed to find start: %s", err)
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to find start: %w", err)
 	}
 
 	end, err := extreme(-1)
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("failed to find end: %s", err)
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to find end: %w", err)
 	}
 
 	// provide gap of 10 minutes
@@ -475,12 +475,12 @@ func buildMongoCondition(isLegacy bool, cond interface{}) bson.D {
 func (m *Mongo) buildFilter(stream types.StreamInterface) (bson.D, error) {
 	thresholdConditions, err := m.ThresholdFilter(stream)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create threshold filter: %s", err)
+		return nil, fmt.Errorf("failed to create threshold filter: %w", err)
 	}
 
 	filter, isLegacy, err := stream.GetFilter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse stream filter: %s", err)
+		return nil, fmt.Errorf("failed to parse stream filter: %w", err)
 	}
 
 	var allConditions bson.A

--- a/drivers/mongodb/internal/cdc.go
+++ b/drivers/mongodb/internal/cdc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"go.mongodb.org/mongo-driver/bson"
@@ -71,7 +72,8 @@ func (m *Mongo) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 	mtState := metadataStates[stream.ID()]
 	prevResumeToken := m.state.GetCursor(stream.Self(), cdcCursorField)
 	if prevResumeToken == nil {
-		return nil, fmt.Errorf("resume token not found for stream: %s", stream.ID())
+		return nil, errs.Precondition(errs.StateInvalid, codeResumeTokenMissing,
+			fmt.Errorf("resume token not found for stream: %s", stream.ID()))
 	}
 	//   metadata > state  →  metadata is further ahead (crash-recovery path: metadata
 	//                         was committed to the destination but state write failed).
@@ -107,14 +109,14 @@ func (m *Mongo) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 
 	cursor, err := collection.Watch(ctx, pipeline, changeStreamOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open change stream: %s", err)
+		return nil, fmt.Errorf("failed to open change stream: %w", err)
 	}
 	defer cursor.Close(ctx)
 
 	for {
 		hasNext := cursor.TryNext(ctx)
 		if err := cursor.Err(); err != nil {
-			return nil, fmt.Errorf("change stream error: %s", err)
+			return nil, fmt.Errorf("change stream error: %w", err)
 		}
 
 		if hasNext {
@@ -152,7 +154,7 @@ func (m *Mongo) handleStreamCatchup(_ context.Context, cursor *mongo.ChangeStrea
 
 	streamOpTime, err := decodeResumeTokenOpTime(token)
 	if err != nil {
-		return token, fmt.Errorf("failed to decode resume token for stream %s: %s", stream.ID(), err)
+		return token, fmt.Errorf("failed to decode resume token for stream %s: %w", stream.ID(), err)
 	}
 
 	// If stream is caught up -> request graceful termination
@@ -166,7 +168,7 @@ func (m *Mongo) handleStreamCatchup(_ context.Context, cursor *mongo.ChangeStrea
 func (m *Mongo) handleChangeDoc(ctx context.Context, cursor *mongo.ChangeStream, stream types.StreamInterface, OnMessage abstract.CDCMsgFn) error {
 	var record CDCDocument
 	if err := cursor.Decode(&record); err != nil {
-		return fmt.Errorf("error while decoding: %s", err)
+		return fmt.Errorf("error while decoding: %w", err)
 	}
 
 	// Count the BSON bytes of the actual document payload, not the full
@@ -230,7 +232,7 @@ func (m *Mongo) PostCDC(ctx context.Context, streamIndex int) error {
 func (m *Mongo) getCurrentResumeToken(cdcCtx context.Context, collection *mongo.Collection, pipeline []bson.D) (*bson.Raw, error) {
 	cursor, err := collection.Watch(cdcCtx, pipeline, options.ChangeStream().SetMaxAwaitTime(maxAwait))
 	if err != nil {
-		return nil, fmt.Errorf("failed to open change stream: %s", err)
+		return nil, fmt.Errorf("failed to open change stream: %w", err)
 	}
 	defer cursor.Close(cdcCtx)
 
@@ -254,17 +256,17 @@ func (m *Mongo) getClusterOpTime(ctx context.Context, dbName string) (primitive.
 		logger.Debug("failed to run 'hello' command, falling back to 'isMaster' command")
 		raw, err = runCmd(bson.M{"isMaster": 1})
 		if err != nil {
-			return opTime, fmt.Errorf("failed to fetch 'operationTime' from 'isMaster' command: both 'hello' and 'isMaster' failed: %s", err)
+			return opTime, fmt.Errorf("failed to fetch 'operationTime' from 'isMaster' command: both 'hello' and 'isMaster' failed: %w", err)
 		}
 	}
 
 	// Extract 'operationTime' field
 	opRaw, err := raw.LookupErr("operationTime")
 	if err != nil {
-		return opTime, fmt.Errorf("operationTime field missing in server response: %s", err)
+		return opTime, fmt.Errorf("operationTime field missing in server response: %w", err)
 	}
 	if err := opRaw.Unmarshal(&opTime); err != nil {
-		return opTime, fmt.Errorf("failed to unmarshal operationTime: %s", err)
+		return opTime, fmt.Errorf("failed to unmarshal operationTime: %w", err)
 	}
 
 	// Sanity check: zero timestamp
@@ -279,7 +281,8 @@ func (m *Mongo) getClusterOpTime(ctx context.Context, dbName string) (primitive.
 func decodeResumeTokenOpTime(dataStr string) (primitive.Timestamp, error) {
 	dataBytes, err := hex.DecodeString(dataStr)
 	if err != nil || len(dataBytes) < 9 {
-		return primitive.Timestamp{}, fmt.Errorf("invalid resume token")
+		return primitive.Timestamp{}, errs.Precondition(errs.StateInvalid, codeResumeTokenInvalid,
+			fmt.Errorf("invalid resume token"))
 	}
 	return primitive.Timestamp{
 		T: binary.BigEndian.Uint32(dataBytes[1:5]),
@@ -291,18 +294,20 @@ func decodeResumeTokenOpTime(dataStr string) (primitive.Timestamp, error) {
 func GetResumeToken(cursor *mongo.ChangeStream, streamID string) (string, error) {
 	finalToken := cursor.ResumeToken()
 	if finalToken == nil {
-		return "", fmt.Errorf("no resume token available for stream %s", streamID)
+		return "", errs.Precondition(errs.StateInvalid, codeResumeTokenMissing,
+			fmt.Errorf("no resume token available for stream %s", streamID))
 	}
 
 	rawToken, err := finalToken.LookupErr(cdcCursorField)
 	if err != nil {
-		return "", fmt.Errorf("%s field not found in resume token for stream %s: %s",
+		return "", fmt.Errorf("%s field not found in resume token for stream %s: %w",
 			cdcCursorField, streamID, err)
 	}
 
 	token := rawToken.StringValue()
 	if token == "" {
-		return "", fmt.Errorf("empty resume token value for stream %s", streamID)
+		return "", errs.Precondition(errs.StateInvalid, codeResumeTokenInvalid,
+			fmt.Errorf("empty resume token value for stream %s", streamID))
 	}
 
 	return token, nil

--- a/drivers/mongodb/internal/errors.go
+++ b/drivers/mongodb/internal/errors.go
@@ -1,0 +1,149 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	"go.mongodb.org/mongo-driver/mongo"
+	mongodriver "go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+)
+
+// Codes for conditions this driver detects itself; the resume token is the only state it
+// validates before asking the server.
+const (
+	codeResumeTokenMissing = "mongodb.resume_token_missing" // #nosec G101 -- a failure code, not a credential
+	codeResumeTokenInvalid = "mongodb.resume_token_invalid" // #nosec G101 -- a failure code, not a credential
+)
+
+// commandCodeCategories maps a MongoDB server error code to a failure category. Codes marked
+// "driver" are taken from mongo-driver's own retryableCodes and resumableChangeStreamErrors, so
+// telemetry agrees with what the library actually does with the connection.
+var commandCodeCategories = map[int32]errs.Category{
+	18: errs.AuthFailed,       // AuthenticationFailed
+	11: errs.AuthFailed,       // UserNotFound
+	13: errs.PermissionDenied, // Unauthorized
+
+	26: errs.ObjectNotFound, // NamespaceNotFound — database or collection
+
+	// Change streams. CDC preconditions and position losses have their own codes, so none of
+	// this is inferred from a message.
+	286:   errs.CDCPositionLost,       // ChangeStreamHistoryLost — resume token older than the oplog
+	136:   errs.CDCPositionLost,       // CappedPositionLost — the oplog rolled over while tailing
+	280:   errs.CDCPreconditionFailed, // ChangeStreamFatalError
+	40573: errs.UnsupportedFeature,    // Location40573 — $changeStream needs a replica set
+
+	// Our cursor expired server-side because we did not read from it in time — our defect.
+	43: errs.SourceReadError, // CursorNotFound (driver)
+
+	// The server enforced a limit; nothing is unreachable.
+	50:  errs.Timeout, // MaxTimeMSExpired (driver, CommandError.IsMaxTimeMSExpiredError)
+	89:  errs.Timeout, // NetworkTimeout (driver)
+	262: errs.Timeout, // ExceededTimeLimit (driver)
+
+	// The member is gone, going away, or no longer one we may read from — same remedy as
+	// unreachable: wait and retry.
+	6:     errs.NetworkUnreachable, // HostUnreachable (driver)
+	7:     errs.NetworkUnreachable, // HostNotFound (driver)
+	9001:  errs.NetworkUnreachable, // SocketException (driver)
+	91:    errs.NetworkUnreachable, // ShutdownInProgress (driver)
+	189:   errs.NetworkUnreachable, // PrimarySteppedDown (driver)
+	10107: errs.NetworkUnreachable, // NotPrimary (driver)
+	10058: errs.NetworkUnreachable, // legacy not-primary (driver, notPrimaryCodes)
+	13435: errs.NetworkUnreachable, // NotPrimaryNoSecondaryOK (driver)
+	13436: errs.NetworkUnreachable, // NotPrimaryOrSecondary (driver)
+	11600: errs.NetworkUnreachable, // InterruptedAtShutdown (driver)
+	11602: errs.NetworkUnreachable, // InterruptedDueToReplStateChange (driver)
+	133:   errs.NetworkUnreachable, // FailedToSatisfyReadPreference (driver)
+
+	292:   errs.ResourceExhausted, // QueryExceededMemoryLimitNoDiskUseAllowed — reachable from $bucketAuto
+	11601: errs.Canceled,          // Interrupted — killOp, or our own disconnect mid-command
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only MongoDB
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("mongodb", classify) }
+
+// classify reads MongoDB's server code, or the reason recorded against a candidate member, and
+// returns nil for anything else. The category comes from the error, never the call site.
+func classify(err error) *errs.Failure {
+	if f := fromServerCode(err); f != nil {
+		return f
+	}
+	return fromServerSelection(err)
+}
+
+// fromServerCode classifies anything carrying a MongoDB error code. Two types carry one:
+// mongo.CommandError from the public API, and driver.Error, the pre-conversion form kept inside
+// a topology description. Both are read so either path classifies identically.
+func fromServerCode(err error) *errs.Failure {
+	code, ok := serverCode(err)
+	if !ok {
+		return nil
+	}
+
+	// The code travels whether or not it is mapped.
+	f := errs.Failure{Code: strconv.FormatInt(int64(code), 10)}
+	if category, found := commandCodeCategories[code]; found {
+		f.Category = category
+		f.ClassifiedBy = errs.ClassifiedByVendor
+		return &f
+	}
+	// A real server code with no rule yet; the code alone makes the gap actionable.
+	f.Category = errs.Unclassified
+	f.ClassifiedBy = errs.ClassifiedByDefault
+	return &f
+}
+
+// fromServerSelection classifies the failure MongoDB reports when it could not pick a server —
+// the shape most outages take. The reason is not in the error chain: it sits in the topology
+// snapshot's per-server LastError, which errors.As cannot reach, so it is walked by hand.
+func fromServerSelection(err error) *errs.Failure {
+	var selectionErr topology.ServerSelectionError
+	if !errors.As(err, &selectionErr) {
+		return nil
+	}
+
+	// Our own context ended the wait; the shared rules already tell cancellation and deadline apart.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+
+	// Read the structure, never the rendered topology string; the first server with a reason
+	// wins, since one cause takes down the whole selection. A recorded reason is often a
+	// resolver or socket error rather than a MongoDB code, so unmapped ones go to the shared rules.
+	for _, server := range selectionErr.Desc.Servers {
+		if server.LastError == nil {
+			continue
+		}
+		if f := fromServerCode(server.LastError); f != nil {
+			return f
+		}
+		if underlying := errs.Standard(server.LastError); underlying.Category != errs.Unclassified {
+			return &underlying
+		}
+	}
+
+	// No member gave a reason: nothing answered.
+	return &errs.Failure{
+		Category:     errs.NetworkUnreachable,
+		ClassifiedBy: errs.ClassifiedByVendor,
+		Code:         "server_selection_failed",
+	}
+}
+
+// serverCode reads MongoDB's error code out of whichever type carries it. Both are value types,
+// so errors.As gets a value target rather than a pointer.
+func serverCode(err error) (int32, bool) {
+	var commandErr mongo.CommandError
+	if errors.As(err, &commandErr) {
+		return commandErr.Code, true
+	}
+	var wireErr mongodriver.Error
+	if errors.As(err, &wireErr) {
+		return wireErr.Code, true
+	}
+	return 0, false
+}

--- a/drivers/mongodb/internal/incremental.go
+++ b/drivers/mongodb/internal/incremental.go
@@ -19,7 +19,7 @@ func (m *Mongo) StreamIncrementalChanges(ctx context.Context, stream types.Strea
 
 	incrementalCondition, err := m.buildIncrementalCondition(stream)
 	if err != nil {
-		return fmt.Errorf("failed to build incremental condition: %s", err)
+		return fmt.Errorf("failed to build incremental condition: %w", err)
 	}
 	// TODO: check performance improvements based on the batch size
 	findOpts := options.Find().SetBatchSize(10000)
@@ -28,20 +28,20 @@ func (m *Mongo) StreamIncrementalChanges(ctx context.Context, stream types.Strea
 
 	cursor, err := collection.Find(ctx, incrementalCondition, findOpts)
 	if err != nil {
-		return fmt.Errorf("failed to execute incremental query: %s", err)
+		return fmt.Errorf("failed to execute incremental query: %w", err)
 	}
 	defer cursor.Close(ctx)
 
 	for cursor.Next(ctx) {
 		var doc bson.M
 		if err := cursor.Decode(&doc); err != nil {
-			return fmt.Errorf("decode error: %s", err)
+			return fmt.Errorf("decode error: %w", err)
 		}
 		// BSON wire-format size of this document, read before the cursor advances.
 		docBytes := int64(len(cursor.Current))
 		filterMongoObject(doc)
 		if err := processFn(ctx, doc, docBytes); err != nil {
-			return fmt.Errorf("process error: %s", err)
+			return fmt.Errorf("process error: %w", err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func (m *Mongo) FetchMaxCursorValues(ctx context.Context, stream types.StreamInt
 
 	cursor, err := collection.Aggregate(ctx, pipeline)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to execute find max cursor values: %s", err)
+		return nil, nil, fmt.Errorf("failed to execute find max cursor values: %w", err)
 	}
 	defer cursor.Close(ctx)
 
@@ -120,7 +120,7 @@ func (m *Mongo) FetchMaxCursorValues(ctx context.Context, stream types.StreamInt
 
 	if cursor.Next(ctx) {
 		if err := cursor.Decode(&result); err != nil {
-			return nil, nil, fmt.Errorf("failed to decode cursor result: %s", err)
+			return nil, nil, fmt.Errorf("failed to decode cursor result: %w", err)
 		}
 
 		if result.MaxPrimaryCursor == nil {
@@ -152,7 +152,7 @@ func (m *Mongo) ThresholdFilter(stream types.StreamInterface) (bson.A, error) {
 	if maxPrimaryCursorValue != nil {
 		formattedPrimaryValue, err := abstract.ReformatCursorValue(primaryCursor, maxPrimaryCursorValue, stream)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert primary cursor value: %s", err)
+			return nil, fmt.Errorf("failed to convert primary cursor value: %w", err)
 		}
 
 		// Include null values: (column <= value) OR (column IS NULL)
@@ -171,7 +171,7 @@ func (m *Mongo) ThresholdFilter(stream types.StreamInterface) (bson.A, error) {
 	if maxSecondaryCursorValue != nil && secondaryCursor != "" {
 		formattedSecondaryValue, err := abstract.ReformatCursorValue(secondaryCursor, maxSecondaryCursorValue, stream)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert secondary cursor value: %s", err)
+			return nil, fmt.Errorf("failed to convert secondary cursor value: %w", err)
 		}
 
 		conditions = append(conditions, bson.D{{

--- a/drivers/mongodb/internal/mon.go
+++ b/drivers/mongodb/internal/mon.go
@@ -125,14 +125,14 @@ func (m *Mongo) CDCSupported() bool {
 
 func (m *Mongo) Setup(ctx context.Context) error {
 	if err := m.config.Validate(); err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	if m.config.SSHConfig != nil && m.config.SSHConfig.Host != "" {
 		logger.Info("Found SSH Configuration")
 		sshClient, err := m.config.SSHConfig.SetupSSHConnection()
 		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
+			return fmt.Errorf("failed to setup SSH connection: %w", err)
 		}
 		m.sshDialer = &MongoSSHDialer{sshClient: sshClient}
 	}
@@ -142,7 +142,7 @@ func (m *Mongo) Setup(ctx context.Context) error {
 	opts.ApplyURI(m.config.URI())
 	tlsConfig, err := m.config.buildTLSConfig()
 	if err != nil {
-		return fmt.Errorf("failed to build tls config: %s", err)
+		return fmt.Errorf("failed to build tls config: %w", err)
 	}
 	if tlsConfig != nil {
 		opts.SetTLSConfig(tlsConfig)
@@ -165,7 +165,7 @@ func (m *Mongo) Setup(ctx context.Context) error {
 
 	// Validate the connection by pinging the database
 	if err := conn.Ping(connectCtx, nil); err != nil {
-		return fmt.Errorf("failed to connect to MongoDB: %s", err)
+		return fmt.Errorf("failed to connect to MongoDB: %w", err)
 	}
 
 	m.client = conn
@@ -224,7 +224,7 @@ func (m *Mongo) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	for collections.Next(ctx) {
 		var collectionInfo bson.M
 		if err := collections.Decode(&collectionInfo); err != nil {
-			return nil, fmt.Errorf("failed to decode collection: %s", err)
+			return nil, fmt.Errorf("failed to decode collection: %w", err)
 		}
 
 		// Skip if collection is a view
@@ -287,9 +287,9 @@ func (m *Mongo) ProduceSchema(ctx context.Context, streamID types.StreamID) (*ty
 	stream, err := produceCollectionSchema(ctx, database, streamID.Name)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %w", ctx.Err())
 		}
-		return nil, fmt.Errorf("failed to process collection[%s]: %s", streamID.Name, err)
+		return nil, fmt.Errorf("failed to process collection[%s]: %w", streamID.Name, err)
 	}
 	// Add all discovered fields as potential cursor fields
 	stream.Schema.Properties.Range(func(key, _ interface{}) bool {

--- a/drivers/mssql/go.mod
+++ b/drivers/mssql/go.mod
@@ -35,15 +35,20 @@ require (
 	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/mssql/internal/backfill.go
+++ b/drivers/mssql/internal/backfill.go
@@ -36,12 +36,12 @@ func (m *MSSQL) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 	}
 	thresholdFilter, args, err := jdbc.ThresholdFilter(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to set threshold filter: %s", err)
+		return fmt.Errorf("failed to set threshold filter: %w", err)
 	}
 
 	filter, err := jdbc.SQLFilter(stream, m.Type(), thresholdFilter)
 	if err != nil {
-		return fmt.Errorf("failed to parse filter during MSSQL chunk iteration: %s", err)
+		return fmt.Errorf("failed to parse filter during MSSQL chunk iteration: %w", err)
 	}
 
 	keyCols := stream.GetStream().SourceDefinedPrimaryKey.Array()
@@ -63,7 +63,7 @@ func (m *MSSQL) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 
 	tx, err := m.client.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %s", err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
@@ -88,7 +88,7 @@ func (m *MSSQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 	rowStatsQuery := jdbc.MSSQLTableRowStatsQuery()
 	err := m.client.QueryRowContext(ctx, rowStatsQuery, stream.Namespace(), stream.Name()).Scan(&approxRowCount, &avgRowSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get approx row count and avg row size: %s", err)
+		return nil, fmt.Errorf("failed to get approx row count and avg row size: %w", err)
 	}
 
 	if approxRowCount == 0 {
@@ -96,7 +96,7 @@ func (m *MSSQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 		existsQuery := jdbc.MSSQLTableExistsQuery(stream)
 		err := m.client.QueryRowContext(ctx, existsQuery).Scan(&hasRows)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check if table has rows: %s", err)
+			return nil, fmt.Errorf("failed to check if table has rows: %w", err)
 		}
 
 		if hasRows {
@@ -112,7 +112,7 @@ func (m *MSSQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 	// avgRowSize is returned as []uint8 which is converted to float64
 	avgRowSizeFloat, err := typeutils.ReformatFloat64(avgRowSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get avg row size: %s", err)
+		return nil, fmt.Errorf("failed to get avg row size: %w", err)
 	}
 	chunkSize := int64(math.Ceil(float64(constants.EffectiveParquetSize) / avgRowSizeFloat))
 	numberOfChunks := max(int64(math.Ceil(float64(approxRowCount)/float64(chunkSize))), int64(1))
@@ -177,7 +177,7 @@ func (m *MSSQL) splitViaPrimaryKey(ctx context.Context, stream types.StreamInter
 	// Get the minimum and maximum values for the primary key columns
 	minVal, maxVal, err := m.getTableExtremes(ctx, stream, pkCols)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get table extremes: %s", err)
+		return nil, fmt.Errorf("failed to get table extremes: %w", err)
 	}
 	// Skip if table is empty
 	if minVal == nil {
@@ -188,7 +188,7 @@ func (m *MSSQL) splitViaPrimaryKey(ctx context.Context, stream types.StreamInter
 	if len(pkCols) == 1 {
 		columnType, err = m.getColumnTypeMSSQL(ctx, stream, pkCols[0])
 		if err != nil {
-			return nil, fmt.Errorf("failed to get table column type: %s", err)
+			return nil, fmt.Errorf("failed to get table column type: %w", err)
 		}
 	}
 
@@ -225,7 +225,7 @@ func (m *MSSQL) splitViaPrimaryKey(ctx context.Context, stream types.StreamInter
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to get next chunk end: %s", err)
+			return nil, fmt.Errorf("failed to get next chunk end: %w", err)
 		}
 		// Create a chunk between current and next boundary
 		if currentVal != nil {
@@ -251,7 +251,7 @@ func (m *MSSQL) splitViaPhysLoc(ctx context.Context, stream types.StreamInterfac
 	// These define the boundaries of our table for chunking
 	minVal, maxVal, err := m.getPhysLocExtremes(ctx, stream)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %%physloc%% extremes: %s", err)
+		return nil, fmt.Errorf("failed to get %%physloc%% extremes: %w", err)
 	}
 	// Skip if table is empty (no rows to chunk)
 	if minVal == nil || maxVal == nil {
@@ -274,7 +274,7 @@ func (m *MSSQL) splitViaPhysLoc(ctx context.Context, stream types.StreamInterfac
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to get next %%physloc%% chunk end: %s", err)
+			return nil, fmt.Errorf("failed to get next %%physloc%% chunk end: %w", err)
 		}
 		chunks.Insert(types.Chunk{Min: utils.HexEncode(current), Max: utils.HexEncode(next)})
 		current = next
@@ -293,7 +293,7 @@ func (m *MSSQL) splitViaPKSample(ctx context.Context, stream types.StreamInterfa
 
 	rows, err := m.client.QueryContext(ctx, jdbc.MSSQLPKSampleBoundaryQuery(stream, pkCols, samplePercent))
 	if err != nil {
-		return nil, fmt.Errorf("PK TABLESAMPLE query failed: %s", err)
+		return nil, fmt.Errorf("PK TABLESAMPLE query failed: %w", err)
 	}
 	defer rows.Close()
 
@@ -313,12 +313,12 @@ func (m *MSSQL) splitViaPKSample(ctx context.Context, stream types.StreamInterfa
 	for rows.Next() {
 		var val any
 		if err := rows.Scan(&val); err != nil {
-			return nil, fmt.Errorf("failed to scan PK sample: %s", err)
+			return nil, fmt.Errorf("failed to scan PK sample: %w", err)
 		}
 		samples = append(samples, normalizeBoundaryValue(val, pkCols, columnType))
 	}
 	if err = rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate PK samples: %s", err)
+		return nil, fmt.Errorf("failed to iterate PK samples: %w", err)
 	}
 
 	if int64(len(samples)) < numberOfChunks {
@@ -347,12 +347,12 @@ func (m *MSSQL) splitViaIAMWalk(ctx context.Context, stream types.StreamInterfac
 	var objectID int64
 	err := m.client.QueryRowContext(ctx, jdbc.MSSQLObjectIDQuery(), stream.Namespace(), stream.Name()).Scan(&objectID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve object_id for IAM walk: %s", err)
+		return nil, fmt.Errorf("failed to resolve object_id for IAM walk: %w", err)
 	}
 
 	rows, err := m.client.QueryContext(ctx, jdbc.MSSQLIAMWalkQuery(), objectID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to run IAM walk query: %s", err)
+		return nil, fmt.Errorf("failed to run IAM walk query: %w", err)
 	}
 	defer rows.Close()
 
@@ -361,12 +361,12 @@ func (m *MSSQL) splitViaIAMWalk(ctx context.Context, stream types.StreamInterfac
 		var fileID uint16
 		var pageID uint32
 		if err := rows.Scan(&fileID, &pageID); err != nil {
-			return nil, fmt.Errorf("failed to scan IAM walk page: %s", err)
+			return nil, fmt.Errorf("failed to scan IAM walk page: %w", err)
 		}
 		pages = append(pages, physlocSortKey(fileID, pageID))
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate IAM walk rows: %s", err)
+		return nil, fmt.Errorf("failed to iterate IAM walk rows: %w", err)
 	}
 
 	total := int64(len(pages))

--- a/drivers/mssql/internal/cdc.go
+++ b/drivers/mssql/internal/cdc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/pkg/jdbc"
 	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 )
 
@@ -65,7 +66,8 @@ func (m *MSSQL) PreCDC(ctx context.Context, streams []types.StreamInterface) err
 	// check if CDC is enabled for each stream
 	for _, stream := range streams {
 		if _, found := captureInstancesMap[stream.ID()]; !found {
-			return fmt.Errorf("CDC is not enabled for stream %s.%s", stream.Namespace(), stream.Name())
+			return errs.Precondition(errs.CDCPreconditionFailed, codeCDCNotEnabledOnTable,
+				fmt.Errorf("CDC is not enabled for stream %s.%s", stream.Namespace(), stream.Name()))
 		}
 
 		if m.state.GetCursor(stream.Self(), cdcCursorKey) == nil {
@@ -99,7 +101,8 @@ func (m *MSSQL) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 	if exists && rawMtState != nil {
 		mtState, ok := rawMtState.(string)
 		if !ok {
-			return nil, fmt.Errorf("failed to typecast mtstate to string of type[%T]", rawMtState)
+			return nil, errs.Precondition(errs.StateInvalid, codeMetadataStateInvalid,
+				fmt.Errorf("failed to typecast mtstate to string of type[%T]", rawMtState))
 		}
 		// Recovery is only needed when metadata is strictly AHEAD of state.
 		if mtState > lsnInState {
@@ -114,7 +117,7 @@ func (m *MSSQL) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 	// Get target LSN (current max LSN in DB)
 	targetLSN, err := m.currentMaxLSN(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get MSSQL max LSN: %s", err)
+		return nil, fmt.Errorf("failed to get MSSQL max LSN: %w", err)
 	}
 
 	// No changes yet
@@ -125,7 +128,7 @@ func (m *MSSQL) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 	// prepare capture instance
 	captureInstances, err := m.prepareCaptureInstances(ctx, stream)
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare capture instance for stream %s.%s: %s", stream.Namespace(), stream.Name(), err)
+		return nil, fmt.Errorf("failed to prepare capture instance for stream %s.%s: %w", stream.Namespace(), stream.Name(), err)
 	}
 
 	// When multiple capture instances exist for the same table (due to schema
@@ -141,11 +144,11 @@ func (m *MSSQL) StreamChanges(ctx context.Context, streamIndex int, metadataStat
 	// in the LSN range between the DDL and when the new capture instance becomes active.
 	captureIdx, selectedCapture := newestValidInstance(captureInstances, lsnInState)
 	if selectedCapture == nil {
-		return nil, fmt.Errorf(
+		return nil, errs.Precondition(errs.CDCPositionLost, codeLSNBeforeCaptureStart, fmt.Errorf(
 			"LSN %s is earlier than the start LSN of available capture instances for stream %s. Please perform full-refresh",
 			lsnInState,
 			stream.ID(),
-		)
+		))
 	}
 	// If a newer capture instance exists, restrict the targetLSN to the newer instance's startLSN
 	nextCaptureIdx := captureIdx + 1
@@ -194,7 +197,7 @@ func (m *MSSQL) PostCDC(ctx context.Context, streamIndex int) error {
 func (m *MSSQL) prepareCaptureInstancesBulk(ctx context.Context, streamIDs []string) (map[string][]captureInstance, error) {
 	rows, err := m.client.QueryContext(ctx, jdbc.MSSQLCDCDiscoverQuery(streamIDs))
 	if err != nil {
-		return nil, fmt.Errorf("failed to query MSSQL CDC tables: %s", err)
+		return nil, fmt.Errorf("failed to query MSSQL CDC tables: %w", err)
 	}
 	defer rows.Close()
 
@@ -206,7 +209,7 @@ func (m *MSSQL) prepareCaptureInstancesBulk(ctx context.Context, streamIDs []str
 		)
 
 		if err := rows.Scan(&capture.schema, &capture.table, &capture.instanceName, &startLSN); err != nil {
-			return nil, fmt.Errorf("failed to scan MSSQL CDC table: %s", err)
+			return nil, fmt.Errorf("failed to scan MSSQL CDC table: %w", err)
 		}
 		capture.startLSN = hex.EncodeToString(startLSN)
 		streamID := fmt.Sprintf("%s.%s", capture.schema, capture.table)
@@ -282,7 +285,8 @@ func (m *MSSQL) manageCaptureInstances(ctx context.Context, streamIDs []string, 
 		// Find the newest valid instance
 		activeIdx, selected := newestValidInstance(instances, currentCursorLSN)
 		if selected == nil {
-			return fmt.Errorf("LSN %s for stream %s is older than any available scan instances; please perform a full refresh", currentCursorLSN, streamID)
+			return errs.Precondition(errs.CDCPositionLost, codeLSNBeforeCaptureStart,
+				fmt.Errorf("LSN %s for stream %s is older than any available scan instances; please perform a full refresh", currentCursorLSN, streamID))
 		}
 
 		// Delete fully consumed older instances and track survivors
@@ -348,18 +352,18 @@ func (m *MSSQL) fetchTableChangesInLSNRange(ctx context.Context, stream types.St
 	// SQL Server expects LSN parameters as binary; state stores them as hex strings.
 	fromLSNBytes, err := hex.DecodeString(effectiveFromLSN)
 	if err != nil {
-		return fmt.Errorf("failed to parse fromLSN: %s", err)
+		return fmt.Errorf("failed to parse fromLSN: %w", err)
 	}
 	toLSNBytes, err := hex.DecodeString(toLSN)
 	if err != nil {
-		return fmt.Errorf("failed to parse toLSN: %s", err)
+		return fmt.Errorf("failed to parse toLSN: %w", err)
 	}
 
 	// Query CDC rows for this capture instance between the two LSNs.
 	query := jdbc.MSSQLCDCGetChangesQuery(capture.instanceName)
 	rows, err := m.client.QueryContext(ctx, query, fromLSNBytes, toLSNBytes)
 	if err != nil {
-		return fmt.Errorf("failed to query MSSQL CDC changes: %s", err)
+		return fmt.Errorf("failed to query MSSQL CDC changes: %w", err)
 	}
 	defer rows.Close()
 
@@ -370,7 +374,7 @@ func (m *MSSQL) fetchTableChangesInLSNRange(ctx context.Context, stream types.St
 		record := make(map[string]interface{})
 		rowBytes, err := jdbc.MapScan(rows, record, m.dataTypeConverter, mssqlCDCColumnSizer)
 		if err != nil {
-			return fmt.Errorf("failed to scan MSSQL CDC row: %s", err)
+			return fmt.Errorf("failed to scan MSSQL CDC row: %w", err)
 		}
 
 		// Determine operation type from SQL Server CDC operation codes.
@@ -395,7 +399,7 @@ func (m *MSSQL) fetchTableChangesInLSNRange(ctx context.Context, stream types.St
 		// Emit one normalized CDC change event.
 		if err := processFn(ctx, abstract.NewCDCChange(stream, time.Now().UTC(), operationType, record,
 			extraColumns, rowBytes)); err != nil {
-			return fmt.Errorf("failed to process MSSQL CDC change: %s", err)
+			return fmt.Errorf("failed to process MSSQL CDC change: %w", err)
 		}
 	}
 
@@ -412,7 +416,8 @@ func (m *MSSQL) currentMaxLSN(ctx context.Context) (string, error) {
 		return "", err
 	}
 	if len(lsn) == 0 {
-		return "", fmt.Errorf("no LSN available (CDC may not be initialized or no transactions exist)")
+		return "", errs.Precondition(errs.CDCPreconditionFailed, codeLSNUnavailable,
+			fmt.Errorf("no LSN available (CDC may not be initialized or no transactions exist)"))
 	}
 	return hex.EncodeToString(lsn), nil
 }
@@ -422,13 +427,13 @@ func (m *MSSQL) advanceLSN(ctx context.Context, lsnHex string) (string, error) {
 	// Decode the hex string into raw bytes because SQL Server LSN functions use binary values.
 	lsnBytes, err := hex.DecodeString(lsnHex)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse LSN for advance: %s", err)
+		return "", fmt.Errorf("failed to parse LSN for advance: %w", err)
 	}
 
 	// Compute the next LSN.
 	var nextLSNBytes []byte
 	if err := m.client.QueryRowContext(ctx, jdbc.MSSQLCDCAdvanceLSNQuery(), lsnBytes).Scan(&nextLSNBytes); err != nil {
-		return "", fmt.Errorf("failed to advance LSN: %s", err)
+		return "", fmt.Errorf("failed to advance LSN: %w", err)
 	}
 
 	if len(nextLSNBytes) == 0 {
@@ -485,7 +490,7 @@ func (m *MSSQL) resolveInitialLSN(ctx context.Context) (string, error) {
 	var hasPermission bool
 	err := m.client.QueryRowContext(ctx, jdbc.MSSQLViewDatabaseStatePermissionQuery()).Scan(&hasPermission)
 	if err != nil {
-		return "", fmt.Errorf("failed to check VIEW DATABASE STATE permission: %s", err)
+		return "", fmt.Errorf("failed to check VIEW DATABASE STATE permission: %w", err)
 	}
 
 	if !hasPermission {
@@ -508,7 +513,7 @@ func (m *MSSQL) waitForCDCAgentCatchUp(ctx context.Context) (string, error) {
 	)
 	err := m.client.QueryRowContext(ctx, jdbc.MSSQLCDCCaptureJobConfigQuery()).Scan(&maxTrans, &pollingIntervalS)
 	if err != nil {
-		return "", fmt.Errorf("unable to query CDC capture job config: %s", err)
+		return "", fmt.Errorf("unable to query CDC capture job config: %w", err)
 	}
 
 	catchUpTimeout := max(defaultCDCAgentCatchUpTimeout, time.Duration(catchUpTimeoutPollMultiplier*pollingIntervalS)*time.Second)

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -67,7 +67,7 @@ func (c *Config) Validate() error {
 
 	err := c.SSLConfiguration.Validate()
 	if err != nil {
-		return fmt.Errorf("failed to validate ssl config: %s", err)
+		return fmt.Errorf("failed to validate ssl config: %w", err)
 	}
 
 	if c.ManageCaptureInstances && c.PrimaryConfig != nil && c.PrimaryConfig.Host != "" {

--- a/drivers/mssql/internal/errors.go
+++ b/drivers/mssql/internal/errors.go
@@ -1,0 +1,98 @@
+package driver
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	mssql "github.com/microsoft/go-mssqldb"
+)
+
+// Codes for conditions this driver detects itself. Capture instances are catalog rows, so CDC
+// prerequisites are validated up front and those failures carry no server error.
+const (
+	codeCDCNotEnabledOnTable  = "mssql.cdc_not_enabled_on_table"
+	codeLSNBeforeCaptureStart = "mssql.lsn_before_capture_instance"
+	codeLSNUnavailable        = "mssql.lsn_unavailable"
+	codeMetadataStateInvalid  = "mssql.metadata_state_invalid"
+)
+
+// errorNumberCategories maps a SQL Server error number to a failure category. No code table
+// ships with go-mssqldb, so every row comes from Microsoft's published list and is verifiable
+// against the server's own sys.messages catalog view.
+//
+// Client-side numbers (-2, 10061) cannot arrive here: go-mssqldb reports a refused connection
+// or an expired deadline as a Go error, never as a SQL Server error.
+var errorNumberCategories = map[int32]errs.Category{
+	// The server rejected the identity itself.
+	18456: errs.AuthFailed, // Login failed for user '%s'
+	18452: errs.AuthFailed, // Login failed; the login is from an untrusted domain
+	18470: errs.AuthFailed, // Login failed; the account is disabled
+
+	// The login succeeded and lacks a right.
+	229: errs.PermissionDenied, // The %s permission was denied on the object
+	230: errs.PermissionDenied, // The %s permission was denied on the column
+	262: errs.PermissionDenied, // %s permission denied in database '%s'
+	297: errs.PermissionDenied, // The user does not have permission to perform this action
+	300: errs.PermissionDenied, // VIEW SERVER STATE permission was denied
+	916: errs.PermissionDenied, // The server principal is not able to access the database
+
+	// Missing, or not openable by this login.
+	4060: errs.ObjectNotFound, // Cannot open database "%s" requested by the login
+	208:  errs.ObjectNotFound, // Invalid object name '%s'
+	207:  errs.ObjectNotFound, // Invalid column name '%s' — a column vanished from under a sync
+	2812: errs.ObjectNotFound, // Could not find stored procedure '%s'
+
+	// The SQL *OLake generated* is wrong. The user never writes it, so this is our defect.
+	102: errs.SourceReadError, // Incorrect syntax near '%s'
+	156: errs.SourceReadError, // Incorrect syntax near the keyword '%s'
+
+	// Well-formed statement; the type is what the server cannot represent.
+	245:  errs.SchemaUnsupported, // Conversion failed when converting the %s value
+	8114: errs.SchemaUnsupported, // Error converting data type %s to %s
+
+	// Two transactions collided; a retry usually clears it.
+	1205: errs.ConcurrencyConflict, // Transaction was deadlocked and chosen as the deadlock victim
+	1222: errs.ConcurrencyConflict, // Lock request time out period exceeded
+
+	// Nothing is misconfigured; the server ran out.
+	701:   errs.ResourceExhausted, // There is insufficient system memory to run this query
+	1204:  errs.ResourceExhausted, // The instance cannot obtain a LOCK resource
+	1105:  errs.ResourceExhausted, // Could not allocate space; the filegroup is full
+	9002:  errs.ResourceExhausted, // The transaction log for database '%s' is full
+	40501: errs.ResourceExhausted, // Azure SQL: the service is currently busy
+	10928: errs.ResourceExhausted, // Azure SQL: resource limit for the database reached
+	10929: errs.ResourceExhausted, // Azure SQL: minimum guarantee / limit exceeded
+
+	// The server is going away, or the replica is not serving — same remedy as unreachable.
+	6005:  errs.NetworkUnreachable, // SHUTDOWN is in progress
+	40613: errs.NetworkUnreachable, // Azure SQL: database is currently unavailable
+	976:   errs.NetworkUnreachable, // The target database is in an availability group and not available for connections
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only SQL Server
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("mssql", classify) }
+
+// classify reads SQL Server's error number, returning nil for anything else so the shared rules
+// get their chance. The category comes from the error, never the call site.
+func classify(err error) *errs.Failure {
+	// A value type, so errors.As gets a value target. Reachable through the driver's own
+	// ServerError and RetryableError wrappers, both of which implement Unwrap.
+	var serverErr mssql.Error
+	if !errors.As(err, &serverErr) {
+		return nil
+	}
+
+	// The number travels whether or not it is mapped.
+	f := errs.Failure{Code: strconv.FormatInt(int64(serverErr.Number), 10)}
+	if category, ok := errorNumberCategories[serverErr.Number]; ok {
+		f.Category = category
+		f.ClassifiedBy = errs.ClassifiedByVendor
+		return &f
+	}
+	// A real error number with no rule yet; the number alone makes the gap actionable.
+	f.Category = errs.Unclassified
+	f.ClassifiedBy = errs.ClassifiedByDefault
+	return &f
+}

--- a/drivers/mssql/internal/incremental.go
+++ b/drivers/mssql/internal/incremental.go
@@ -19,13 +19,13 @@ func (m *MSSQL) StreamIncrementalChanges(ctx context.Context, stream types.Strea
 	}
 	incrementalQuery, queryArgs, err := jdbc.BuildIncrementalQuery(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to build incremental condition: %s", err)
+		return fmt.Errorf("failed to build incremental condition: %w", err)
 	}
 
 	var rows *sql.Rows
 	rows, err = m.client.QueryContext(ctx, incrementalQuery, queryArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to execute incremental query: %s", err)
+		return fmt.Errorf("failed to execute incremental query: %w", err)
 	}
 	defer rows.Close()
 
@@ -34,11 +34,11 @@ func (m *MSSQL) StreamIncrementalChanges(ctx context.Context, stream types.Strea
 		record := make(types.Record)
 		rowBytes, err := jdbc.MapScan(rows, record, m.dataTypeConverter, mssqlColumnSizer)
 		if err != nil {
-			return fmt.Errorf("failed to scan record: %s", err)
+			return fmt.Errorf("failed to scan record: %w", err)
 		}
 
 		if err := processFn(ctx, record, rowBytes); err != nil {
-			return fmt.Errorf("process error: %s", err)
+			return fmt.Errorf("process error: %w", err)
 		}
 	}
 

--- a/drivers/mssql/internal/mssql.go
+++ b/drivers/mssql/internal/mssql.go
@@ -57,21 +57,21 @@ func (m *MSSQL) CDCSupported() bool {
 // Setup establishes the database connection and initializes CDC settings.
 func (m *MSSQL) Setup(ctx context.Context) error {
 	if err := m.config.Validate(); err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	var err error
 	if m.config.SSHConfig != nil && m.config.SSHConfig.Host != "" {
 		m.sshClient, err = setupSSH(m.config.SSHConfig)
 		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
+			return fmt.Errorf("failed to setup SSH connection: %w", err)
 		}
 		logger.Info("Connecting to MSSQL via SSH tunnel")
 	}
 
 	m.client, err = setupDBConnection(ctx, m.config.URI(), m.sshClient, m.config.Host, m.config.MaxThreads)
 	if err != nil {
-		return fmt.Errorf("failed to connect to MSSQL: %s", err)
+		return fmt.Errorf("failed to connect to MSSQL: %w", err)
 	}
 
 	m.config.RetryCount = utils.Ternary(m.config.RetryCount <= 0, 1, m.config.RetryCount+1).(int)
@@ -99,7 +99,7 @@ func (m *MSSQL) Setup(ctx context.Context) error {
 			1,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to connect to primary for capture instance management: %s", err)
+			return fmt.Errorf("failed to connect to primary for capture instance management: %w", err)
 		}
 		logger.Info("connected to primary node successfully for capture instance management")
 	}
@@ -155,7 +155,7 @@ func setupSSH(sshCfg *utils.SSHConfig) (*ssh.Client, error) {
 func setupDBConnection(ctx context.Context, uri string, sshClient *ssh.Client, host string, maxConns int) (*sqlx.DB, error) {
 	connector, err := mssql.NewConnector(uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create MSSQL connector: %s", err)
+		return nil, fmt.Errorf("failed to create MSSQL connector: %w", err)
 	}
 	if sshClient != nil {
 		connector.Dialer = &mssqlSSHDialer{sshClient: sshClient, host: host}
@@ -167,7 +167,7 @@ func setupDBConnection(ctx context.Context, uri string, sshClient *ssh.Client, h
 	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := client.PingContext(pingCtx); err != nil {
-		return nil, fmt.Errorf("failed to ping database: %s", err)
+		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
 	return client, nil
@@ -207,7 +207,7 @@ func (m *MSSQL) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	query := jdbc.MSSQLDiscoverTablesQuery()
 	rows, err := m.client.QueryContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query tables: %s", err)
+		return nil, fmt.Errorf("failed to query tables: %w", err)
 	}
 	defer rows.Close()
 
@@ -215,7 +215,7 @@ func (m *MSSQL) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	for rows.Next() {
 		var tableName, schemaName string
 		if err := rows.Scan(&schemaName, &tableName); err != nil {
-			return nil, fmt.Errorf("failed to scan table: %s", err)
+			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}
 		tableNames = append(tableNames, types.StreamID{Namespace: schemaName, Name: tableName})
 	}
@@ -237,7 +237,7 @@ func (m *MSSQL) ProduceSchema(ctx context.Context, streamName types.StreamID) (*
 		columnQuery := jdbc.MSSQLTableSchemaQuery()
 		rows, err := m.client.QueryContext(ctx, columnQuery, schemaName, tableName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query column information: %s", err)
+			return nil, fmt.Errorf("failed to query column information: %w", err)
 		}
 		defer rows.Close()
 
@@ -252,7 +252,7 @@ func (m *MSSQL) ProduceSchema(ctx context.Context, streamName types.StreamID) (*
 		for rows.Next() {
 			var colInfo columnInfo
 			if err := rows.Scan(&colInfo.name, &colInfo.dataType, &colInfo.isNullable, &colInfo.isPrimaryKey); err != nil {
-				return nil, fmt.Errorf("failed to scan column: %s", err)
+				return nil, fmt.Errorf("failed to scan column: %w", err)
 			}
 			columns = append(columns, colInfo)
 		}
@@ -282,9 +282,9 @@ func (m *MSSQL) ProduceSchema(ctx context.Context, streamName types.StreamID) (*
 	stream, err := produceTableSchema(ctx, streamName)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %w", ctx.Err())
 		}
-		return nil, fmt.Errorf("failed to process table[%s]: %s", streamName, err)
+		return nil, fmt.Errorf("failed to process table[%s]: %w", streamName, err)
 	}
 
 	stream.WithSyncMode(types.FULLREFRESH, types.INCREMENTAL)
@@ -336,7 +336,7 @@ func (m *MSSQL) isDatabaseCDCEnabled(ctx context.Context) (bool, error) {
 	var isEnabled bool
 	err := m.client.QueryRowContext(ctx, jdbc.MSSQLCDCSupportQuery()).Scan(&isEnabled)
 	if err != nil {
-		return false, fmt.Errorf("failed to check MSSQL CDC enablement: %s", err)
+		return false, fmt.Errorf("failed to check MSSQL CDC enablement: %w", err)
 	}
 
 	return isEnabled, nil

--- a/drivers/mysql/go.mod
+++ b/drivers/mysql/go.mod
@@ -17,15 +17,20 @@ require github.com/jmoiron/sqlx v1.4.0
 require (
 	github.com/apache/arrow-go/v18 v18.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/mysql/internal/backfill.go
+++ b/drivers/mysql/internal/backfill.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -17,6 +18,7 @@ import (
 	"github.com/datazip-inc/olake/pkg/jdbc"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 )
@@ -45,12 +47,12 @@ func (m *MySQL) ChunkIterator(ctx context.Context, stream types.StreamInterface,
 	}
 	thresholdFilter, args, err := jdbc.ThresholdFilter(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to set threshold filter: %s", err)
+		return fmt.Errorf("failed to set threshold filter: %w", err)
 	}
 
 	filter, err := jdbc.SQLFilter(stream, m.Type(), thresholdFilter)
 	if err != nil {
-		return fmt.Errorf("failed to parse filter during chunk iteration: %s", err)
+		return fmt.Errorf("failed to parse filter during chunk iteration: %w", err)
 	}
 	// Begin transaction with repeatable read isolation
 	return jdbc.WithIsolation(ctx, m.client, true, func(tx *sql.Tx) error {
@@ -89,7 +91,13 @@ func (m *MySQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 	tableStatsQuery := jdbc.MySQLTableStatsQuery()
 	err := m.client.QueryRowContext(ctx, tableStatsQuery, stream.Name()).Scan(&approxRowCount, &avgRowSize, &approxTableSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch TableStats query for table=%s: %s", stream.Name(), err)
+		// information_schema hides rows the user has no privilege on, so a dropped table and an
+		// ungranted one are the same empty result. MySQL raises no error number for either.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errs.Precondition(errs.ObjectNotFound, codeTableNotVisible,
+				fmt.Errorf("failed to fetch TableStats query for table=%s: %w", stream.Name(), err))
+		}
+		return nil, fmt.Errorf("failed to fetch TableStats query for table=%s: %w", stream.Name(), err)
 	}
 
 	if approxRowCount == 0 {
@@ -97,7 +105,7 @@ func (m *MySQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 		existsQuery := jdbc.MySQLTableExistsQuery(stream)
 		err := m.client.QueryRowContext(ctx, existsQuery).Scan(&hasRows)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check if table has rows: %s", err)
+			return nil, fmt.Errorf("failed to check if table has rows: %w", err)
 		}
 		if hasRows {
 			return nil, fmt.Errorf("stats not populated for table[%s]. Please run ANALYZE TABLE to update table statistics", stream.ID())
@@ -111,7 +119,7 @@ func (m *MySQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 	// avgRowSize is returned as []uint8 which is converted to float64.
 	avgRowSizeFloat, err := typeutils.ReformatFloat64(avgRowSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get avg row size: %s", err)
+		return nil, fmt.Errorf("failed to get avg row size: %w", err)
 	}
 	chunkSize := int64(math.Ceil(float64(constants.EffectiveParquetSize) / avgRowSizeFloat))
 
@@ -129,7 +137,7 @@ func (m *MySQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 	if len(pkColumns) > 0 {
 		minVal, maxVal, err = m.getTableExtremes(ctx, stream, pkColumns)
 		if err != nil {
-			return nil, fmt.Errorf("stream %s: Failed to get table extremes: %s", stream.ID(), err)
+			return nil, fmt.Errorf("stream %s: Failed to get table extremes: %w", stream.ID(), err)
 		}
 	}
 
@@ -143,7 +151,7 @@ func (m *MySQL) GetOrSplitChunks(ctx context.Context, pool *destination.WriterPo
 		query := jdbc.MySQLColumnStatsQuery()
 		err = m.client.QueryRowContext(ctx, query, stream.Name(), pkColumns[0]).Scan(&dataType, &dataMaxLength, &columnCollationType)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch column datatype and max length for column %s: %s", pkColumns[0], err)
+			return nil, fmt.Errorf("failed to fetch column datatype and max length for column %s: %w", pkColumns[0], err)
 		}
 
 		// 1. Try Numeric Strategy
@@ -247,7 +255,7 @@ func (m *MySQL) splitViaPrimaryKey(ctx context.Context, stream types.StreamInter
 			if err == sql.ErrNoRows || nextValRaw == nil {
 				break
 			} else if err != nil {
-				return fmt.Errorf("failed to get next chunk end: %s", err)
+				return fmt.Errorf("failed to get next chunk end: %w", err)
 			}
 			if currentVal != nil {
 				chunks.Insert(types.Chunk{
@@ -373,7 +381,7 @@ func (m *MySQL) splitEvenlyForString(ctx context.Context, stream types.StreamInt
 		query, args := jdbc.MySQLDistinctAlignedPKValuesWithCollationQuery(stream, pkColumn, rangeSlice, columnCollationType, bounds.MinPadded, bounds.MaxPadded)
 		rows, err := m.client.QueryContext(ctx, query, args...)
 		if err != nil {
-			boundaryQueryErr = fmt.Errorf("distinct boundary query failed for stream %s: %s", stream.ID(), err)
+			boundaryQueryErr = fmt.Errorf("distinct boundary query failed for stream %s: %w", stream.ID(), err)
 			logger.Debugf("%s", boundaryQueryErr)
 			break
 		}
@@ -382,13 +390,13 @@ func (m *MySQL) splitEvenlyForString(ctx context.Context, stream types.StreamInt
 			var val string
 			if err := rows.Scan(&val); err != nil {
 				rows.Close()
-				return nil, fmt.Errorf("failed to scan row: %s", err)
+				return nil, fmt.Errorf("failed to scan row: %w", err)
 			}
 			rangeSlice = append(rangeSlice, val)
 		}
 
 		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("row iteration error during distinct boundaries iteration: %s", err)
+			return nil, fmt.Errorf("row iteration error during distinct boundaries iteration: %w", err)
 		}
 		if len(rangeSlice) > len(chunkBoundaries) {
 			chunkBoundaries = slices.Clone(rangeSlice)

--- a/drivers/mysql/internal/cdc.go
+++ b/drivers/mysql/internal/cdc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/datazip-inc/olake/pkg/binlog"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
@@ -23,13 +24,14 @@ func (m *MySQL) prepareBinlogConn(ctx context.Context, mySQLGlobalState MySQLGlo
 		var err error
 		tlsConfig, err = m.config.buildTLSConfig()
 		if err != nil {
-			return nil, fmt.Errorf("failed to build TLS config for binlog: %s", err)
+			return nil, fmt.Errorf("failed to build TLS config for binlog: %w", err)
 		}
 	}
 
 	port := m.config.Port
 	if port <= 0 || port > math.MaxUint16 {
-		return nil, fmt.Errorf("invalid mysql port: %d", port)
+		return nil, errs.Precondition(errs.ConfigInvalid, codePortInvalid,
+			fmt.Errorf("invalid mysql port: %d", port))
 	}
 
 	config := &binlog.Config{
@@ -73,7 +75,7 @@ func (m *MySQL) PreCDC(ctx context.Context, streams []types.StreamInterface) err
 	if globalState == nil || globalState.State == nil {
 		binlogPos, err := binlog.GetCurrentBinlogPosition(ctx, m.client)
 		if err != nil {
-			return fmt.Errorf("failed to get current binlog position: %s", err)
+			return fmt.Errorf("failed to get current binlog position: %w", err)
 		}
 		m.state.SetGlobal(MySQLGlobalState{ServerID: newServerID(), State: binlog.Binlog{Position: binlogPos}})
 		m.state.ResetStreams()
@@ -85,17 +87,19 @@ func (m *MySQL) PreCDC(ctx context.Context, streams []types.StreamInterface) err
 func (m *MySQL) StreamChanges(ctx context.Context, _ int, metadataStates map[string]any, OnMessage abstract.CDCMsgFn) (any, error) {
 	savedState := m.state.GetGlobal()
 	if savedState == nil || savedState.State == nil {
-		return nil, fmt.Errorf("invalid global state; state is missing")
+		return nil, errs.Precondition(errs.StateInvalid, codeGlobalStateInvalid,
+			fmt.Errorf("invalid global state; state is missing"))
 	}
 
 	var mySQLGlobalState MySQLGlobalState
 	if err := utils.Unmarshal(savedState.State, &mySQLGlobalState); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal global state: %s", err)
+		return nil, fmt.Errorf("failed to unmarshal global state: %w", err)
 	}
 
 	// validate server id
 	if mySQLGlobalState.ServerID == 0 {
-		return nil, fmt.Errorf("invalid global state; server_id is missing")
+		return nil, errs.Precondition(errs.StateInvalid, codeServerIDMissing,
+			fmt.Errorf("invalid global state; server_id is missing"))
 	}
 
 	var finishedStreams []string
@@ -109,7 +113,7 @@ func (m *MySQL) StreamChanges(ctx context.Context, _ int, metadataStates map[str
 			var mysqlMetadataState binlog.Binlog
 			err := json.Unmarshal([]byte(mtState), &mysqlMetadataState)
 			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal metadata state: %s", err)
+				return nil, fmt.Errorf("failed to unmarshal metadata state: %w", err)
 			}
 
 			// Recovery is only needed when metadata is strictly AHEAD of state.
@@ -123,7 +127,8 @@ func (m *MySQL) StreamChanges(ctx context.Context, _ int, metadataStates map[str
 			}
 			// state >= metadata: blank sync scenario — stream forward normally
 		} else {
-			return nil, fmt.Errorf("failed to typecast raw metadata state of type[%T] to string", rawMtState)
+			return nil, errs.Precondition(errs.StateInvalid, codeMetadataStateInvalid,
+				fmt.Errorf("failed to typecast raw metadata state of type[%T] to string", rawMtState))
 		}
 	}
 
@@ -143,7 +148,7 @@ func (m *MySQL) StreamChanges(ctx context.Context, _ int, metadataStates map[str
 
 	conn, err := m.prepareBinlogConn(ctx, mySQLGlobalState, remainingStreams)
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare binlog conn: %s", err)
+		return nil, fmt.Errorf("failed to prepare binlog conn: %w", err)
 	}
 
 	// persist binlog connection for post cdc

--- a/drivers/mysql/internal/config.go
+++ b/drivers/mysql/internal/config.go
@@ -59,11 +59,11 @@ func (c *Config) URI() (string, error) {
 		case utils.SSLModeRequire, utils.SSLModeVerifyCA, utils.SSLModeVerifyFull:
 			tlsConfig, err := c.buildTLSConfig()
 			if err != nil {
-				return "", fmt.Errorf("failed to build TLS config: %s", err)
+				return "", fmt.Errorf("failed to build TLS config: %w", err)
 			}
 			tlsConfigName := "mysql_" + utils.ULID()
 			if err := mysql.RegisterTLSConfig(tlsConfigName, tlsConfig); err != nil {
-				return "", fmt.Errorf("failed to register TLS config: %s", err)
+				return "", fmt.Errorf("failed to register TLS config: %w", err)
 			}
 			cfg.TLSConfig = tlsConfigName
 		}
@@ -125,7 +125,7 @@ func (c *Config) Validate() error {
 	// Validate SSL configuration if provided
 	if c.SSLConfiguration != nil {
 		if err := c.SSLConfiguration.Validate(); err != nil {
-			return fmt.Errorf("failed to validate SSL config: %s", err)
+			return fmt.Errorf("failed to validate SSL config: %w", err)
 		}
 
 		if c.SSLConfiguration.Mode == utils.SSLModeVerifyCA || c.SSLConfiguration.Mode == utils.SSLModeVerifyFull {

--- a/drivers/mysql/internal/errors.go
+++ b/drivers/mysql/internal/errors.go
@@ -1,0 +1,136 @@
+package driver
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	binlogmysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-sql-driver/mysql"
+)
+
+// Codes for conditions this driver detects itself, where the server never named the failure.
+const (
+	codeGlobalStateInvalid   = "mysql.global_state_invalid"
+	codeServerIDMissing      = "mysql.server_id_missing"
+	codeMetadataStateInvalid = "mysql.metadata_state_invalid"
+	codePortInvalid          = "mysql.port_invalid"
+	codeTableNotVisible      = "mysql.table_not_visible"
+)
+
+// errnoCategories maps a MySQL server error number to a failure category. Numbers are stable
+// across versions and language settings, and travel verbatim so an unmapped one stays
+// identifiable; trailing ER_ macros are from go-mysql's generated mysql/errcode.go.
+//
+// Client-side numbers (2002, 2003, 2006, 2013) belong to the C client and cannot arrive here;
+// those failures reach us as standard-library network errors.
+var errnoCategories = map[uint16]errs.Category{
+	// The server refused the identity itself.
+	1045: errs.AuthFailed, // ER_ACCESS_DENIED_ERROR
+	1698: errs.AuthFailed, // ER_ACCESS_DENIED_NO_PASSWORD_ERROR
+	1130: errs.AuthFailed, // ER_HOST_NOT_PRIVILEGED
+
+	// Authentication already succeeded; the grant is missing.
+	1044: errs.PermissionDenied, // ER_DBACCESS_DENIED_ERROR
+	1142: errs.PermissionDenied, // ER_TABLEACCESS_DENIED_ERROR
+	1143: errs.PermissionDenied, // ER_COLUMNACCESS_DENIED_ERROR
+	1227: errs.PermissionDenied, // ER_SPECIFIC_ACCESS_DENIED_ERROR — REPLICATION CLIENT, SUPER
+
+	1049: errs.ObjectNotFound, // ER_BAD_DB_ERROR
+	1146: errs.ObjectNotFound, // ER_NO_SUCH_TABLE
+	1109: errs.ObjectNotFound, // ER_UNKNOWN_TABLE
+	1054: errs.ObjectNotFound, // ER_BAD_FIELD_ERROR — a column vanished from under a running sync
+
+	// The SQL *OLake generated* is wrong. The user never writes it, so this is our defect
+	// rather than a misconfiguration.
+	1064: errs.SourceReadError, // ER_PARSE_ERROR
+	1052: errs.SourceReadError, // ER_NON_UNIQ_ERROR
+	1247: errs.SourceReadError, // ER_ILLEGAL_REFERENCE
+	1305: errs.SourceReadError, // ER_SP_DOES_NOT_EXIST
+
+	// Well-formed statement; the collation is what the server cannot handle.
+	1267: errs.SchemaUnsupported, // ER_CANT_AGGREGATE_2COLLATIONS
+
+	// Nothing is misconfigured; the server ran out.
+	1040: errs.ResourceExhausted, // ER_CON_COUNT_ERROR
+	1203: errs.ResourceExhausted, // ER_TOO_MANY_USER_CONNECTIONS
+	1226: errs.ResourceExhausted, // ER_USER_LIMIT_REACHED
+	1021: errs.ResourceExhausted, // ER_DISK_FULL
+	1041: errs.ResourceExhausted, // ER_OUT_OF_RESOURCES
+	1037: errs.ResourceExhausted, // ER_OUTOFMEMORY
+	1206: errs.ResourceExhausted, // ER_LOCK_TABLE_FULL
+
+	// Two transactions collided; a retry usually clears it.
+	1213: errs.ConcurrencyConflict, // ER_LOCK_DEADLOCK
+	1205: errs.ConcurrencyConflict, // ER_LOCK_WAIT_TIMEOUT
+
+	// The server is going away or tearing the connection down — same remedy as unreachable.
+	1053: errs.NetworkUnreachable, // ER_SERVER_SHUTDOWN
+	1152: errs.NetworkUnreachable, // ER_ABORTING_CONNECTION
+	1158: errs.NetworkUnreachable, // ER_NET_READ_ERROR
+	1159: errs.NetworkUnreachable, // ER_NET_READ_INTERRUPTED
+	1160: errs.NetworkUnreachable, // ER_NET_ERROR_ON_WRITE
+	1161: errs.NetworkUnreachable, // ER_NET_WRITE_INTERRUPTED
+
+	3024: errs.Timeout,  // ER_QUERY_TIMEOUT — max_execution_time exceeded
+	1317: errs.Canceled, // ER_QUERY_INTERRUPTED — KILL QUERY, or our own context cancellation
+
+	// The position we asked to resume from is gone, or binary logging is off entirely.
+	1236: errs.CDCPositionLost,       // ER_MASTER_FATAL_ERROR_READING_BINLOG
+	1373: errs.CDCPositionLost,       // ER_UNKNOWN_TARGET_BINLOG
+	1381: errs.CDCPreconditionFailed, // ER_NO_BINARY_LOGGING
+
+	// The server rejected a setting the config asked for.
+	1298: errs.ConfigInvalid, // ER_UNKNOWN_TIME_ZONE — jdbc_url_params.time_zone
+	1231: errs.ConfigInvalid, // ER_WRONG_VALUE_FOR_VAR
+	3159: errs.ConfigInvalid, // ER_SECURE_TRANSPORT_REQUIRED — ssl.mode disabled against a TLS-only server
+
+	// Understood, but not servable on this version or build.
+	1251: errs.UnsupportedFeature, // ER_NOT_SUPPORTED_AUTH_MODE
+	1235: errs.UnsupportedFeature, // ER_NOT_SUPPORTED_YET
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only MySQL
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("mysql", classify) }
+
+// classify reads MySQL's error number, returning nil for anything else so the shared rules get
+// their chance. The category comes from the error, never the call site: one call can fail on a
+// revoked grant, a missing object, contention or a dropped connection.
+func classify(err error) *errs.Failure {
+	// Two libraries, one server numbering: go-sql-driver carries queries, go-mysql the binlog
+	// stream. One table serves both, and no other library produces either type.
+	var errno uint16
+	var queryErr *mysql.MySQLError
+	var binlogErr *binlogmysql.MyError
+	switch {
+	case errors.As(err, &queryErr):
+		errno = queryErr.Number
+	case errors.As(err, &binlogErr):
+		errno = binlogErr.Code
+
+	case errors.Is(err, mysql.ErrInvalidConn):
+		// The connection died mid-request and go-sql-driver replaced the network error with this
+		// sentinel, leaving nothing for the shared rules. driver.ErrBadConn is deliberately not
+		// checked: database/sql retries that one, and the retry carries the real network error.
+		return &errs.Failure{
+			Category:     errs.NetworkUnreachable,
+			ClassifiedBy: errs.ClassifiedByVendor,
+			Code:         "invalid_connection",
+		}
+
+	default:
+		return nil
+	}
+
+	// The number travels whether or not it is mapped.
+	f := errs.Failure{Code: strconv.FormatUint(uint64(errno), 10)}
+	if category, ok := errnoCategories[errno]; ok {
+		f.Category = category
+		f.ClassifiedBy = errs.ClassifiedByVendor
+		return &f
+	}
+	f.Category = errs.Unclassified
+	f.ClassifiedBy = errs.ClassifiedByDefault
+	return &f
+}

--- a/drivers/mysql/internal/incremental.go
+++ b/drivers/mysql/internal/incremental.go
@@ -19,13 +19,13 @@ func (m *MySQL) StreamIncrementalChanges(ctx context.Context, stream types.Strea
 	}
 	incrementalQuery, queryArgs, err := jdbc.BuildIncrementalQuery(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to build incremental condition: %s", err)
+		return fmt.Errorf("failed to build incremental condition: %w", err)
 	}
 
 	var rows *sql.Rows
 	rows, err = m.client.QueryContext(ctx, incrementalQuery, queryArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to execute incremental query: %s", err)
+		return fmt.Errorf("failed to execute incremental query: %w", err)
 	}
 	defer rows.Close()
 
@@ -34,11 +34,11 @@ func (m *MySQL) StreamIncrementalChanges(ctx context.Context, stream types.Strea
 		record := make(types.Record)
 		rowBytes, err := jdbc.MapScan(rows, record, m.dataTypeConverter, mysqlColumnSizer)
 		if err != nil {
-			return fmt.Errorf("failed to scan record: %s", err)
+			return fmt.Errorf("failed to scan record: %w", err)
 		}
 
 		if err := processFn(ctx, record, rowBytes); err != nil {
-			return fmt.Errorf("process error: %s", err)
+			return fmt.Errorf("process error: %w", err)
 		}
 	}
 

--- a/drivers/mysql/internal/mysql.go
+++ b/drivers/mysql/internal/mysql.go
@@ -68,14 +68,14 @@ func (m *MySQL) Spec() any {
 func (m *MySQL) Setup(ctx context.Context) error {
 	err := m.config.Validate()
 	if err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	if m.config.SSHConfig != nil && m.config.SSHConfig.Host != "" {
 		logger.Info("Found SSH Configuration")
 		m.sshClient, err = m.config.SSHConfig.SetupSSHConnection()
 		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
+			return fmt.Errorf("failed to setup SSH connection: %w", err)
 		}
 	}
 
@@ -85,12 +85,12 @@ func (m *MySQL) Setup(ctx context.Context) error {
 
 		uri, err := m.config.URI()
 		if err != nil {
-			return fmt.Errorf("failed to setup config uri: %s", err)
+			return fmt.Errorf("failed to setup config uri: %w", err)
 		}
 
 		cfg, err := mysql.ParseDSN(uri)
 		if err != nil {
-			return fmt.Errorf("failed to parse mysql DSN: %s", err)
+			return fmt.Errorf("failed to parse mysql DSN: %w", err)
 		}
 
 		// Allows mysql driver to use the SSH client to connect to the database
@@ -101,17 +101,17 @@ func (m *MySQL) Setup(ctx context.Context) error {
 
 		client, err = sqlx.Open("mysql", cfg.FormatDSN())
 		if err != nil {
-			return fmt.Errorf("failed to open tunneled database connection: %s", err)
+			return fmt.Errorf("failed to open tunneled database connection: %w", err)
 		}
 	} else {
 		uri, err := m.config.URI()
 		if err != nil {
-			return fmt.Errorf("failed to setup config uri: %s", err)
+			return fmt.Errorf("failed to setup config uri: %w", err)
 		}
 
 		client, err = sqlx.Open("mysql", uri)
 		if err != nil {
-			return fmt.Errorf("failed to open database connection: %s", err)
+			return fmt.Errorf("failed to open database connection: %w", err)
 		}
 	}
 	// Test connection
@@ -120,7 +120,7 @@ func (m *MySQL) Setup(ctx context.Context) error {
 	// Set connection pool size
 	client.SetMaxOpenConns(m.config.MaxThreads)
 	if err := client.PingContext(ctx); err != nil {
-		return fmt.Errorf("failed to ping database: %s", err)
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
 
 	var resolved *time.Location
@@ -190,7 +190,7 @@ func (m MySQL) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	query := jdbc.MySQLDiscoverTablesQuery()
 	rows, err := m.client.QueryContext(ctx, query, m.config.Database)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query tables: %s", err)
+		return nil, fmt.Errorf("failed to query tables: %w", err)
 	}
 	defer rows.Close()
 
@@ -198,7 +198,7 @@ func (m MySQL) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	for rows.Next() {
 		var tableName, schemaName string
 		if err := rows.Scan(&tableName, &schemaName); err != nil {
-			return nil, fmt.Errorf("failed to scan table: %s", err)
+			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}
 		tableNames = append(tableNames, types.StreamID{Namespace: schemaName, Name: tableName})
 	}
@@ -214,14 +214,14 @@ func (m *MySQL) ProduceSchema(ctx context.Context, streamName types.StreamID) (*
 
 		rows, err := m.client.QueryContext(ctx, query, schemaName, tableName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to query column information: %s", err)
+			return nil, fmt.Errorf("failed to query column information: %w", err)
 		}
 		defer rows.Close()
 
 		for rows.Next() {
 			var columnName, columnType, dataType, isNullable, columnKey string
 			if err := rows.Scan(&columnName, &columnType, &dataType, &isNullable, &columnKey); err != nil {
-				return nil, fmt.Errorf("failed to scan column: %s", err)
+				return nil, fmt.Errorf("failed to scan column: %w", err)
 			}
 			stream.WithCursorField(columnName)
 			var datatype types.DataType
@@ -243,9 +243,9 @@ func (m *MySQL) ProduceSchema(ctx context.Context, streamName types.StreamID) (*
 	stream, err := produceTableSchema(ctx, streamName)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %w", ctx.Err())
 		}
-		return nil, fmt.Errorf("failed to process table[%s]: %s", streamName, err)
+		return nil, fmt.Errorf("failed to process table[%s]: %w", streamName, err)
 	}
 
 	stream.WithSyncMode(types.FULLREFRESH, types.INCREMENTAL)
@@ -308,14 +308,14 @@ func (m *MySQL) Close() error {
 func (m *MySQL) IsCDCSupported(ctx context.Context) (bool, error) {
 	// Permission check via SHOW MASTER STATUS / SHOW BINARY LOG STATUS
 	if _, err := binlog.GetCurrentBinlogPosition(ctx, m.client); err != nil {
-		return false, fmt.Errorf("failed to get binlog position: %s", err)
+		return false, fmt.Errorf("failed to get binlog position: %w", err)
 	}
 
 	// checkMySQLConfig checks a MySQL configuration value against an expected value
 	checkMySQLConfig := func(ctx context.Context, query, expectedValue, warnMessage string) (bool, error) {
 		var name, value string
 		if err := m.client.QueryRowxContext(ctx, query).Scan(&name, &value); err != nil {
-			return false, fmt.Errorf("failed to check %s: %s", name, err)
+			return false, fmt.Errorf("failed to check %s: %w", name, err)
 		}
 
 		if strings.ToUpper(value) != expectedValue {

--- a/drivers/oracle/go.mod
+++ b/drivers/oracle/go.mod
@@ -20,15 +20,20 @@ require (
 	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/oracle/internal/backfill.go
+++ b/drivers/oracle/internal/backfill.go
@@ -27,17 +27,17 @@ func (o *Oracle) ChunkIterator(ctx context.Context, stream types.StreamInterface
 	}
 	thresholdFilter, args, err := jdbc.ThresholdFilter(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to set threshold filter: %s", err)
+		return fmt.Errorf("failed to set threshold filter: %w", err)
 	}
 
 	filter, err := jdbc.SQLFilter(stream, o.Type(), thresholdFilter)
 	if err != nil {
-		return fmt.Errorf("failed to parse filter during chunk iteration: %s", err)
+		return fmt.Errorf("failed to parse filter during chunk iteration: %w", err)
 	}
 
 	tx, err := o.client.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %s", err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
@@ -49,7 +49,7 @@ func (o *Oracle) ChunkIterator(ctx context.Context, stream types.StreamInterface
 
 	stmt, err := jdbc.OracleChunkScanQuery(stream, chunk, filter)
 	if err != nil {
-		return fmt.Errorf("failed to build chunk scan query: %s", err)
+		return fmt.Errorf("failed to build chunk scan query: %w", err)
 	}
 	setter := jdbc.NewReader(ctx, stmt, func(ctx context.Context, query string, _ ...any) (*sql.Rows, error) {
 		// TODO: Add support for user defined datatypes in OracleDB
@@ -79,7 +79,7 @@ func (o *Oracle) GetOrSplitChunks(ctx context.Context, pool *destination.WriterP
 			logger.Warnf("Table %s.%s is empty, skipping chunking", stream.Namespace(), stream.Name())
 			return types.NewSet[types.Chunk](), nil
 		}
-		return nil, fmt.Errorf("failed to check for rows: %s", err)
+		return nil, fmt.Errorf("failed to check for rows: %w", err)
 	}
 
 	chunks, err := o.splitViaRowID(ctx, stream)
@@ -125,7 +125,7 @@ func (o *Oracle) splitViaTableIterationLoop(ctx context.Context, stream types.St
 	query := jdbc.OracleMinMaxRowIDQuery(stream)
 	err := o.client.QueryRowContext(ctx, query).Scan(&minRowID, &maxRowID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get min-max row id: %s", err)
+		return nil, fmt.Errorf("failed to get min-max row id: %w", err)
 	}
 
 	currRowID := minRowID
@@ -141,7 +141,7 @@ func (o *Oracle) splitViaTableIterationLoop(ctx context.Context, stream types.St
 		nextRowIDQuery := jdbc.NextRowIDQuery(stream, currRowID, rowsPerChunk)
 		err = o.client.QueryRowContext(ctx, nextRowIDQuery).Scan(&nextRowID, &rowCount)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get next row id: %s", err)
+			return nil, fmt.Errorf("failed to get next row id: %w", err)
 		}
 
 		if rowCount < rowsPerChunk || nextRowID == maxRowID {
@@ -176,7 +176,7 @@ func (o *Oracle) splitViaTableIterationSample(ctx context.Context, stream types.
 
 	rows, err := o.client.QueryContext(ctx, jdbc.SampleBlockBoundaryQuery(stream, samplePercent))
 	if err != nil {
-		return nil, fmt.Errorf("sample block query failed: %s", err)
+		return nil, fmt.Errorf("sample block query failed: %w", err)
 	}
 	defer rows.Close()
 
@@ -184,12 +184,12 @@ func (o *Oracle) splitViaTableIterationSample(ctx context.Context, stream types.
 	for rows.Next() {
 		var rowID string
 		if err := rows.Scan(&rowID); err != nil {
-			return nil, fmt.Errorf("failed to scan sampled rowid: %s", err)
+			return nil, fmt.Errorf("failed to scan sampled rowid: %w", err)
 		}
 		sampledRowIDs = append(sampledRowIDs, rowID)
 	}
 	if err = rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate sampled rowids: %s", err)
+		return nil, fmt.Errorf("failed to iterate sampled rowids: %w", err)
 	}
 
 	if int64(len(sampledRowIDs)) < numberOfChunks {
@@ -224,7 +224,7 @@ func (o *Oracle) splitViaRowID(ctx context.Context, stream types.StreamInterface
 	query = jdbc.OracleTaskCreationQuery(taskName)
 	_, err = o.client.ExecContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create task: %s", err)
+		return nil, fmt.Errorf("failed to create task: %w", err)
 	}
 	defer func(taskName string) {
 		stmt := jdbc.OracleChunkTaskCleanerQuery(taskName)
@@ -237,13 +237,13 @@ func (o *Oracle) splitViaRowID(ctx context.Context, stream types.StreamInterface
 	query = jdbc.OracleChunkCreationQuery(stream, blocksPerChunk, taskName)
 	_, err = o.client.ExecContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create chunks: %s", err)
+		return nil, fmt.Errorf("failed to create chunks: %w", err)
 	}
 
 	chunkQuery := jdbc.OracleChunkRetrievalQuery(taskName)
 	rows, err := o.client.QueryContext(ctx, chunkQuery)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve chunks: %s", err)
+		return nil, fmt.Errorf("failed to retrieve chunks: %w", err)
 	}
 	defer rows.Close()
 
@@ -254,7 +254,7 @@ func (o *Oracle) splitViaRowID(ctx context.Context, stream types.StreamInterface
 		var startRowID, endRowID string
 		err = rows.Scan(&chunkID, &startRowID, &endRowID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan chunk %d: %s", chunkID, err)
+			return nil, fmt.Errorf("failed to scan chunk %d: %w", chunkID, err)
 		}
 		startRowIDs = append(startRowIDs, startRowID)
 	}
@@ -297,7 +297,7 @@ func (o *Oracle) splitViaExtents(ctx context.Context, stream types.StreamInterfa
 	// 1. Get the Table's Data Object ID, Fetch all physical extents for the table
 	rows, err := o.client.QueryContext(ctx, jdbc.OracleExtentsQuery(), stream.Namespace(), stream.Name())
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch extents: %s", err)
+		return nil, fmt.Errorf("failed to fetch extents: %w", err)
 	}
 	defer rows.Close()
 
@@ -312,7 +312,7 @@ func (o *Oracle) splitViaExtents(ctx context.Context, stream types.StreamInterfa
 		var fileID, blockID, blocks, objectID int64
 		err = rows.Scan(&fileID, &blockID, &blocks, &objectID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan extents: %s", err)
+			return nil, fmt.Errorf("failed to scan extents: %w", err)
 		}
 
 		// If this is the start of a new chunk, generate its starting ROWID

--- a/drivers/oracle/internal/config.go
+++ b/drivers/oracle/internal/config.go
@@ -83,7 +83,7 @@ func (c *Config) Validate() error {
 	}
 	err := c.SSLConfiguration.Validate()
 	if err != nil {
-		return fmt.Errorf("failed to validate ssl config: %s", err)
+		return fmt.Errorf("failed to validate ssl config: %w", err)
 	}
 	return utils.Validate(c)
 }

--- a/drivers/oracle/internal/errors.go
+++ b/drivers/oracle/internal/errors.go
@@ -1,0 +1,114 @@
+package driver
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/sijms/go-ora/v2/network"
+)
+
+// oraCodeCategories maps an Oracle error number to a failure category. Entries marked "go-ora"
+// are taken from the driver's own translate() and Bad() tables, so telemetry agrees with what
+// the library treats as an unusable connection.
+var oraCodeCategories = map[int]errs.Category{
+	// The server rejected the credentials or the account itself.
+	1017:  errs.AuthFailed, // invalid username/password; logon denied
+	1005:  errs.AuthFailed, // null password given; logon denied
+	28000: errs.AuthFailed, // the account is locked
+	28001: errs.AuthFailed, // the password has expired
+
+	// The logon succeeded; the grant is missing.
+	1031: errs.PermissionDenied, // insufficient privileges
+	1039: errs.PermissionDenied, // insufficient privileges on underlying objects of the view
+
+	// Missing object. The last two are the listener's equivalent: a service or SID it does not serve.
+	942:   errs.ObjectNotFound, // table or view does not exist
+	904:   errs.ObjectNotFound, // invalid identifier (go-ora) — a column vanished from under a sync
+	1918:  errs.ObjectNotFound, // user does not exist
+	12514: errs.ObjectNotFound, // TNS:listener does not currently know of service requested (go-ora)
+	12505: errs.ObjectNotFound, // TNS:listener does not currently know of SID given
+
+	// The SQL *OLake generated* is wrong. The user never writes it, so this is our defect.
+	900: errs.SourceReadError, // invalid SQL statement (go-ora)
+	903: errs.SourceReadError, // invalid table name (go-ora)
+	905: errs.SourceReadError, // missing keyword (go-ora)
+	906: errs.SourceReadError, // missing left parenthesis (go-ora)
+	907: errs.SourceReadError, // missing right parenthesis (go-ora)
+	923: errs.SourceReadError, // FROM keyword not found where expected
+	933: errs.SourceReadError, // SQL command not properly ended
+	936: errs.SourceReadError, // missing expression
+
+	// Well-formed statement; the data is what the server cannot convert.
+	902:  errs.SchemaUnsupported, // invalid data type (go-ora)
+	932:  errs.SchemaUnsupported, // inconsistent datatypes
+	1722: errs.SchemaUnsupported, // invalid number
+	1858: errs.SchemaUnsupported, // a non-numeric character was found where a numeric was expected
+
+	// Two sessions collided; a retry usually clears it.
+	60: errs.ConcurrencyConflict, // deadlock detected while waiting for resource
+	54: errs.ConcurrencyConflict, // resource busy and acquire with NOWAIT specified
+
+	// Nothing is misconfigured; the server ran out.
+	257:   errs.ResourceExhausted, // archiver error; connect internal only, until freed
+	4030:  errs.ResourceExhausted, // out of process memory
+	4031:  errs.ResourceExhausted, // unable to allocate bytes of shared memory
+	1652:  errs.ResourceExhausted, // unable to extend temp segment
+	1555:  errs.ResourceExhausted, // snapshot too old — undo was recycled under a long read
+	12516: errs.ResourceExhausted, // TNS:listener could not find available handler (go-ora)
+
+	// Dead connection, or an instance that is not serving. The "Bad" entries are go-ora's own
+	// unusable-connection set.
+	28:    errs.NetworkUnreachable, // your session has been killed (go-ora Bad)
+	1012:  errs.NetworkUnreachable, // not logged on (go-ora Bad)
+	1033:  errs.NetworkUnreachable, // ORACLE initialization or shutdown in progress (go-ora Bad)
+	1034:  errs.NetworkUnreachable, // ORACLE not available (go-ora Bad)
+	1089:  errs.NetworkUnreachable, // immediate shutdown in progress (go-ora Bad)
+	3113:  errs.NetworkUnreachable, // end-of-file on communication channel (go-ora Bad)
+	3114:  errs.NetworkUnreachable, // not connected to ORACLE (go-ora Bad)
+	3135:  errs.NetworkUnreachable, // connection lost contact (go-ora Bad + translate)
+	12528: errs.NetworkUnreachable, // TNS:listener: all appropriate instances are blocking (go-ora Bad)
+	12537: errs.NetworkUnreachable, // TNS:connection closed (go-ora Bad)
+	12541: errs.NetworkUnreachable, // TNS:no listener
+	12545: errs.NetworkUnreachable, // connect failed because target host or object does not exist
+	12560: errs.NetworkUnreachable, // TNS:protocol adapter error
+	12564: errs.NetworkUnreachable, // TNS connection refused (go-ora)
+
+	12170: errs.Timeout,  // TNS:Connect timeout occurred
+	1013:  errs.Canceled, // user requested cancel of current operation (go-ora)
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only Oracle
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("oracle", classify) }
+
+// classify reads Oracle's error number, returning nil for anything else so the shared rules get
+// their chance. The category comes from the error, never the call site.
+func classify(err error) *errs.Failure {
+	var oraErr *network.OracleError
+	if !errors.As(err, &oraErr) {
+		// go-ora swaps in this sentinel when a deadline breaks the connection mid-request, and
+		// the deadline does not always survive with it.
+		if errors.Is(err, network.ErrConnReset) {
+			return &errs.Failure{
+				Category:     errs.Timeout,
+				ClassifiedBy: errs.ClassifiedByVendor,
+				Code:         "connection_break_on_timeout",
+			}
+		}
+		return nil
+	}
+
+	// ErrCode rather than Error(): the message is translated lazily from this field, so the
+	// number is the stable half. It travels whether or not it is mapped.
+	f := errs.Failure{Code: strconv.Itoa(oraErr.ErrCode)}
+	if category, ok := oraCodeCategories[oraErr.ErrCode]; ok {
+		f.Category = category
+		f.ClassifiedBy = errs.ClassifiedByVendor
+		return &f
+	}
+	// A real Oracle code with no rule yet; the number alone makes the gap actionable.
+	f.Category = errs.Unclassified
+	f.ClassifiedBy = errs.ClassifiedByDefault
+	return &f
+}

--- a/drivers/oracle/internal/incremental.go
+++ b/drivers/oracle/internal/incremental.go
@@ -23,12 +23,12 @@ func (o *Oracle) StreamIncrementalChanges(ctx context.Context, stream types.Stre
 	}
 	incrementalQuery, queryArgs, err := jdbc.BuildIncrementalQuery(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to build incremental condition: %s", err)
+		return fmt.Errorf("failed to build incremental condition: %w", err)
 	}
 
 	rows, err := o.client.QueryContext(ctx, incrementalQuery, queryArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to execute incremental query: %s", err)
+		return fmt.Errorf("failed to execute incremental query: %w", err)
 	}
 	defer rows.Close()
 
@@ -36,11 +36,11 @@ func (o *Oracle) StreamIncrementalChanges(ctx context.Context, stream types.Stre
 		record := make(types.Record)
 		rowBytes, err := jdbc.MapScan(rows, record, o.dataTypeConverter, oracleColumnSizer)
 		if err != nil {
-			return fmt.Errorf("failed to scan record: %s", err)
+			return fmt.Errorf("failed to scan record: %w", err)
 		}
 
 		if err := processFn(ctx, record, rowBytes); err != nil {
-			return fmt.Errorf("process error: %s", err)
+			return fmt.Errorf("process error: %w", err)
 		}
 	}
 	return rows.Err()

--- a/drivers/oracle/internal/oracle.go
+++ b/drivers/oracle/internal/oracle.go
@@ -31,14 +31,14 @@ type Oracle struct {
 func (o *Oracle) Setup(ctx context.Context) error {
 	err := o.config.Validate()
 	if err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	if o.config.SSHConfig != nil && o.config.SSHConfig.Host != "" {
 		logger.Info("Found SSH Configuration")
 		o.sshClient, err = o.config.SSHConfig.SetupSSHConnection()
 		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
+			return fmt.Errorf("failed to setup SSH connection: %w", err)
 		}
 	}
 
@@ -48,7 +48,7 @@ func (o *Oracle) Setup(ctx context.Context) error {
 
 		oracleCfg, err := go_ora.ParseConfig(o.config.connectionString())
 		if err != nil {
-			return fmt.Errorf("failed to parse oracle connection string: %s", err)
+			return fmt.Errorf("failed to parse oracle connection string: %w", err)
 		}
 
 		// Allows oracle driver to use the SSH client to connect to the database
@@ -64,13 +64,13 @@ func (o *Oracle) Setup(ctx context.Context) error {
 
 		client, err = sqlx.Open("oracle", "")
 		if err != nil {
-			return fmt.Errorf("failed to open tunneled database connection: %s", err)
+			return fmt.Errorf("failed to open tunneled database connection: %w", err)
 		}
 	} else {
 		// TODO: Add support for more encryption options provided in OracleDB
 		client, err = sqlx.Open("oracle", o.config.connectionString())
 		if err != nil {
-			return fmt.Errorf("failed to open database connection: %s", err)
+			return fmt.Errorf("failed to open database connection: %w", err)
 		}
 	}
 
@@ -81,7 +81,7 @@ func (o *Oracle) Setup(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := client.PingContext(ctx); err != nil {
-		return fmt.Errorf("failed to ping database: %s", err)
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
 
 	o.client = client
@@ -137,7 +137,7 @@ func (o *Oracle) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	query := jdbc.OracleTableDiscoveryQuery()
 	rows, err := o.client.QueryContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query tables: %s", err)
+		return nil, fmt.Errorf("failed to query tables: %w", err)
 	}
 	defer rows.Close()
 
@@ -145,12 +145,12 @@ func (o *Oracle) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 	for rows.Next() {
 		var owner, tableName string
 		if err := rows.Scan(&owner, &tableName); err != nil {
-			return nil, fmt.Errorf("failed to scan table: %s", err)
+			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}
 		streamNames = append(streamNames, types.StreamID{Namespace: owner, Name: tableName})
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating tables: %s", err)
+		return nil, fmt.Errorf("error iterating tables: %w", err)
 	}
 
 	return streamNames, nil
@@ -166,7 +166,7 @@ func (o *Oracle) ProduceSchema(ctx context.Context, streamName types.StreamID) (
 	query := jdbc.OracleTableDetailsQuery(schemaName, tableName)
 	rows, err := o.client.QueryContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query column information: %s", err)
+		return nil, fmt.Errorf("failed to query column information: %w", err)
 	}
 	defer rows.Close()
 
@@ -174,7 +174,7 @@ func (o *Oracle) ProduceSchema(ctx context.Context, streamName types.StreamID) (
 		var columnName, dataType, isNullable string
 		var dataPrecision, dataScale sql.NullInt64
 		if err := rows.Scan(&columnName, &dataType, &isNullable, &dataPrecision, &dataScale); err != nil {
-			return nil, fmt.Errorf("failed to scan column: %s", err)
+			return nil, fmt.Errorf("failed to scan column: %w", err)
 		}
 		stream.WithCursorField(columnName)
 		var datatype types.DataType
@@ -191,14 +191,14 @@ func (o *Oracle) ProduceSchema(ctx context.Context, streamName types.StreamID) (
 	query = jdbc.OraclePrimaryKeyColummsQuery(schemaName, tableName)
 	pkRows, err := o.client.QueryContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query primary key information: %s", err)
+		return nil, fmt.Errorf("failed to query primary key information: %w", err)
 	}
 	defer pkRows.Close()
 
 	for pkRows.Next() {
 		var columnName string
 		if err := pkRows.Scan(&columnName); err != nil {
-			return nil, fmt.Errorf("failed to scan primary key column: %s", err)
+			return nil, fmt.Errorf("failed to scan primary key column: %w", err)
 		}
 		stream.WithPrimaryKey(columnName)
 	}

--- a/drivers/postgres/go.mod
+++ b/drivers/postgres/go.mod
@@ -21,15 +21,20 @@ require (
 	github.com/apache/thrift v0.23.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/drivers/postgres/internal/backfill.go
+++ b/drivers/postgres/internal/backfill.go
@@ -25,12 +25,12 @@ func (p *Postgres) ChunkIterator(ctx context.Context, stream types.StreamInterfa
 	}
 	thresholdFilter, args, err := jdbc.ThresholdFilter(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to set threshold filter: %s", err)
+		return fmt.Errorf("failed to set threshold filter: %w", err)
 	}
 
 	filter, err := jdbc.SQLFilter(stream, p.Type(), thresholdFilter)
 	if err != nil {
-		return fmt.Errorf("failed to parse filter during chunk iteration: %s", err)
+		return fmt.Errorf("failed to parse filter during chunk iteration: %w", err)
 	}
 	tx, err := p.client.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	if err != nil {
@@ -59,7 +59,7 @@ func (p *Postgres) GetOrSplitChunks(ctx context.Context, pool *destination.Write
 	approxRowCountQuery := jdbc.PostgresRowCountQuery(stream)
 	err := p.client.QueryRowContext(ctx, approxRowCountQuery).Scan(&approxRowCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get approx row count: %s", err)
+		return nil, fmt.Errorf("failed to get approx row count: %w", err)
 	}
 	pool.AddRecordsToSyncStats(approxRowCount)
 	return p.splitTableIntoChunks(ctx, stream)
@@ -71,7 +71,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		var blockSize uint32
 		err := p.client.QueryRowContext(ctx, blockSizeQuery).Scan(&blockSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get block size: %s", err)
+			return nil, fmt.Errorf("failed to get block size: %w", err)
 		}
 
 		//  Step 1: Detect if the table is partitioned
@@ -79,7 +79,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		partitionQuery := jdbc.PostgresIsPartitionedQuery(stream)
 		err = p.client.QueryRowContext(ctx, partitionQuery).Scan(&partitionCount)
 		if err != nil {
-			return nil, fmt.Errorf("failed to detect table partitioning: %s", err)
+			return nil, fmt.Errorf("failed to detect table partitioning: %w", err)
 		}
 
 		//  Step 2: Non-partitioned
@@ -88,7 +88,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 			relPagesQuery := jdbc.PostgresRelPageCount(stream)
 			err := p.client.QueryRowContext(ctx, relPagesQuery).Scan(&relPages)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get relPages: %s", err)
+				return nil, fmt.Errorf("failed to get relPages: %w", err)
 			}
 
 			batchSize := uint32(math.Ceil(float64(constants.EffectiveParquetSize) / float64(blockSize)))
@@ -111,7 +111,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		//  Step 3: Partitioned table
 		partitions, maxPageCountAcrossPartitions, err := loadPartitionPages(ctx, p.client.DB, stream)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load partition pages: %s", err)
+			return nil, fmt.Errorf("failed to load partition pages: %w", err)
 		}
 
 		batchPages := int64(math.Ceil(float64(constants.EffectiveParquetSize) / float64(blockSize)))
@@ -142,7 +142,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		chunkStart := minVal
 		chunkEnd, err := utils.AddConstantToInterface(minVal, dynamicChunkSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to split batch size chunks: %s", err)
+			return nil, fmt.Errorf("failed to split batch size chunks: %w", err)
 		}
 
 		for typeutils.Compare(chunkEnd, maxVal) <= 0 {
@@ -150,7 +150,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 			chunkStart = chunkEnd
 			newChunkEnd, err := utils.AddConstantToInterface(chunkEnd, dynamicChunkSize)
 			if err != nil {
-				return nil, fmt.Errorf("failed to split batch size chunks: %s", err)
+				return nil, fmt.Errorf("failed to split batch size chunks: %w", err)
 			}
 			chunkEnd = newChunkEnd
 		}
@@ -164,7 +164,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		for {
 			chunkEnd, err := p.nextChunkEnd(ctx, stream, chunkStart, chunkColumn)
 			if err != nil {
-				return nil, fmt.Errorf("failed to split chunks based on next query size: %s", err)
+				return nil, fmt.Errorf("failed to split chunks based on next query size: %w", err)
 			}
 			if chunkEnd == nil || chunkEnd == chunkStart {
 				splits.Insert(types.Chunk{Min: chunkStart, Max: nil})
@@ -184,7 +184,7 @@ func (p *Postgres) splitTableIntoChunks(ctx context.Context, stream types.Stream
 		// TODO: Fails on UUID type (Good First Issue)
 		err := p.client.QueryRowContext(ctx, minMaxRowCountQuery).Scan(&minValue, &maxValue)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch table min max: %s", err)
+			return nil, fmt.Errorf("failed to fetch table min max: %w", err)
 		}
 		if minValue == maxValue {
 			return types.NewSet(types.Chunk{Min: minValue, Max: nil}), nil
@@ -212,7 +212,7 @@ func (p *Postgres) nextChunkEnd(ctx context.Context, stream types.StreamInterfac
 	nextChunkEnd := jdbc.PostgresNextChunkEndQuery(stream, chunkColumn, previousChunkEnd)
 	err := p.client.QueryRowContext(ctx, nextChunkEnd).Scan(&chunkEnd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query[%s] next chunk end: %s", nextChunkEnd, err)
+		return nil, fmt.Errorf("failed to query[%s] next chunk end: %w", nextChunkEnd, err)
 	}
 	return chunkEnd, nil
 }
@@ -229,7 +229,7 @@ const postgresMinVersionPG12 = 120000
 func loadPartitionPages(ctx context.Context, db *sql.DB, stream types.StreamInterface) ([]PartitionPage, int64, error) {
 	var serverVersionNum int
 	if err := db.QueryRowContext(ctx, jdbc.PostgresServerVersionNum()).Scan(&serverVersionNum); err != nil {
-		return nil, 0, fmt.Errorf("failed to detect postgres server version: %s", err)
+		return nil, 0, fmt.Errorf("failed to detect postgres server version: %w", err)
 	}
 
 	var query string
@@ -243,7 +243,7 @@ func loadPartitionPages(ctx context.Context, db *sql.DB, stream types.StreamInte
 
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to load partition pages: %s", err)
+		return nil, 0, fmt.Errorf("failed to load partition pages: %w", err)
 	}
 	defer rows.Close()
 
@@ -258,7 +258,7 @@ func loadPartitionPages(ctx context.Context, db *sql.DB, stream types.StreamInte
 		partitions = append(partitions, p)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("failed to iterate partition pages: %s", err)
+		return nil, 0, fmt.Errorf("failed to iterate partition pages: %w", err)
 	}
 
 	if maxPageCountAcrossPartitions == 0 {

--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -23,7 +23,7 @@ func (p *Postgres) prepareWALJSConfig(streams ...types.StreamInterface) (*waljs.
 
 	tlsConfig, err := p.config.buildTLSConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to build tls config for wal replication: %s", err)
+		return nil, fmt.Errorf("failed to build tls config for wal replication: %w", err)
 	}
 
 	return &waljs.Config{
@@ -44,7 +44,7 @@ func (p *Postgres) ChangeStreamConfig() (bool, bool, bool) {
 func (p *Postgres) PreCDC(ctx context.Context, streams []types.StreamInterface) error {
 	slot, err := waljs.GetSlotPosition(ctx, p.client, p.cdcConfig.ReplicationSlot)
 	if err != nil {
-		return fmt.Errorf("failed to get slot position: %s", err)
+		return fmt.Errorf("failed to get slot position: %w", err)
 	}
 
 	globalState := p.state.GetGlobal()
@@ -63,7 +63,7 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 	var postgresGlobalState waljs.WALState
 	rawGlobalState := p.state.GetGlobal()
 	if err := utils.Unmarshal(rawGlobalState.State, &postgresGlobalState); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal global state: %s", err)
+		return nil, fmt.Errorf("failed to unmarshal global state: %w", err)
 	}
 
 	var metadataCommittedLSN string
@@ -77,17 +77,17 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 		if stMtState, ok := rawMtState.(string); ok {
 			var mtState waljs.WALState
 			if err := json.Unmarshal([]byte(stMtState), &mtState); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal metadata state: %s", err)
+				return nil, fmt.Errorf("failed to unmarshal metadata state: %w", err)
 			}
 
 			// Recovery is only needed when metadata is strictly AHEAD of state .
 			parsedMetaLSN, err := pglogrepl.ParseLSN(mtState.LSN)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse metadata LSN %q: %s", mtState.LSN, err)
+				return nil, fmt.Errorf("failed to parse metadata LSN %q: %w", mtState.LSN, err)
 			}
 			parsedStateLSN, err := pglogrepl.ParseLSN(postgresGlobalState.LSN)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse global state LSN %q: %s", postgresGlobalState.LSN, err)
+				return nil, fmt.Errorf("failed to parse global state LSN %q: %w", postgresGlobalState.LSN, err)
 			}
 			if parsedMetaLSN > parsedStateLSN {
 				// metadata ahead of state: genuine crash-recovery path
@@ -109,7 +109,7 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 		// recovery sync required: read up to the LSN stored in the Iceberg metadata
 		parsed, err := pglogrepl.ParseLSN(metadataCommittedLSN)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse recovery LSN %q: %s", metadataCommittedLSN, err)
+			return nil, fmt.Errorf("failed to parse recovery LSN %q: %w", metadataCommittedLSN, err)
 		}
 		recoveryLSN = &parsed
 
@@ -127,17 +127,17 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 
 	config, err := p.prepareWALJSConfig(remainingStreams...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to prepare wal config: %s", err)
+		return nil, fmt.Errorf("failed to prepare wal config: %w", err)
 	}
 
 	slot, err := waljs.GetSlotPosition(ctx, p.client, p.cdcConfig.ReplicationSlot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get slot position: %s", err)
+		return nil, fmt.Errorf("failed to get slot position: %w", err)
 	}
 
 	replicator, err := waljs.NewReplicator(ctx, config, slot, recoveryLSN, p.dataTypeConverter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create wal connection: %s", err)
+		return nil, fmt.Errorf("failed to create wal connection: %w", err)
 	}
 
 	// persist replicator for post cdc
@@ -150,7 +150,7 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 	slotAtMetadataLSN := recoveryLSN != nil && slot.LSN == *recoveryLSN
 	if len(remainingStreams) > 0 && !slotAtMetadataLSN {
 		if err := validateGlobalState(postgresGlobalState, slot.LSN); err != nil {
-			return nil, fmt.Errorf("%s: invalid global state: %s", constants.ErrNonRetryable, err)
+			return nil, fmt.Errorf("%s: invalid global state: %w", constants.ErrNonRetryable, err)
 		}
 	} else {
 		logger.Infof("all streams already committed in destination, skipping state LSN validation")
@@ -236,7 +236,7 @@ func validateGlobalState(postgresGlobalState waljs.WALState, confirmedFlushLSN p
 	}
 	parsed, err := pglogrepl.ParseLSN(postgresGlobalState.LSN)
 	if err != nil {
-		return fmt.Errorf("failed to parse stored lsn[%s]: %s", postgresGlobalState.LSN, err)
+		return fmt.Errorf("failed to parse stored lsn[%s]: %w", postgresGlobalState.LSN, err)
 	}
 	// failing sync when lsn mismatch found (from state and confirmed flush lsn), as otherwise on backfill, duplication of data will occur
 	// suggesting to proceed with clear destination

--- a/drivers/postgres/internal/config.go
+++ b/drivers/postgres/internal/config.go
@@ -82,7 +82,7 @@ func (c *Config) Validate() error {
 
 	err := c.SSLConfiguration.Validate()
 	if err != nil {
-		return fmt.Errorf("failed to validate ssl config: %s", err)
+		return fmt.Errorf("failed to validate ssl config: %w", err)
 	}
 
 	parsed.RawQuery = query.Encode()

--- a/drivers/postgres/internal/errors.go
+++ b/drivers/postgres/internal/errors.go
@@ -1,0 +1,95 @@
+package driver
+
+import (
+	"errors"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Codes for conditions this driver detects itself, where the server never named the failure.
+const (
+	codeReplicationSlotMissing = "postgres.replication_slot_missing"
+	codeCDCWaitTimeTooLow      = "postgres.cdc_initial_wait_time_too_low"
+)
+
+// sqlStateCategories maps a PostgreSQL SQLSTATE to a failure category. SQLSTATE rather than the
+// message: stable across versions, locale-independent, and free of user data. Codes travel
+// verbatim; trailing names are the condition names from postgres src/backend/utils/errcodes.txt.
+var sqlStateCategories = map[string]errs.Category{
+	"28P01": errs.AuthFailed, // invalid_password
+	"28000": errs.AuthFailed, // invalid_authorization_specification
+
+	// Missing object, or a role that cannot use it. Authentication already succeeded.
+	"3D000": errs.ObjectNotFound,   // invalid_catalog_name, alias undefined_database
+	"3F000": errs.ObjectNotFound,   // invalid_schema_name, alias undefined_schema
+	"42P01": errs.ObjectNotFound,   // undefined_table
+	"42703": errs.ObjectNotFound,   // undefined_column — a column vanished from under a running sync
+	"42501": errs.PermissionDenied, // insufficient_privilege
+
+	// Also class 42, but these mean the SQL *OLake generated* is wrong. The user never writes
+	// it, so this is our defect rather than a misconfiguration.
+	"42601": errs.SourceReadError, // syntax_error
+	"42883": errs.SourceReadError, // undefined_function
+	"42702": errs.SourceReadError, // ambiguous_column
+	"42P10": errs.SourceReadError, // invalid_column_reference
+	"42P08": errs.SourceReadError, // ambiguous_parameter
+	"42809": errs.SourceReadError, // wrong_object_type
+
+	// Well-formed statement; the type is what the server cannot handle.
+	"42804": errs.SchemaUnsupported, // datatype_mismatch
+	"42846": errs.SchemaUnsupported, // cannot_coerce
+	"42P18": errs.SchemaUnsupported, // indeterminate_datatype
+
+	"53300": errs.ResourceExhausted, // too_many_connections
+	"53100": errs.ResourceExhausted, // disk_full
+	"53200": errs.ResourceExhausted, // out_of_memory
+	"54000": errs.ResourceExhausted, // program_limit_exceeded
+
+	// 55000 is deliberately unmapped: it covers replication preconditions and unrelated features
+	// alike, separable only by message text. It still reaches telemetry with its SQLSTATE.
+	"55006": errs.ConcurrencyConflict, // object_in_use — another process holds the slot
+	"55P03": errs.ConcurrencyConflict, // lock_not_available
+
+	// Two transactions collided; a retry usually clears it.
+	"40001": errs.ConcurrencyConflict, // serialization_failure
+	"40P01": errs.ConcurrencyConflict, // deadlock_detected
+
+	// The server is going away or not yet accepting work — same remedy as unreachable.
+	"57P01": errs.NetworkUnreachable, // admin_shutdown
+	"57P03": errs.NetworkUnreachable, // cannot_connect_now
+
+	"08006": errs.NetworkUnreachable, // connection_failure
+	"08001": errs.NetworkUnreachable, // sqlclient_unable_to_establish_sqlconnection
+	"08004": errs.NetworkUnreachable, // sqlserver_rejected_establishment_of_sqlconnection
+	"08003": errs.NetworkUnreachable, // connection_does_not_exist
+	"08007": errs.NetworkUnreachable, // transaction_resolution_unknown
+
+	"XX000": errs.InternalError, // internal_error — the server hit a bug
+}
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only PostgreSQL
+// evidence lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("postgres", classify) }
+
+// classify reads PostgreSQL's SQLSTATE, returning nil for anything else so the shared rules get
+// their chance. The category comes from the error, never the call site: one call can fail on a
+// revoked grant, a missing object, contention or a dropped connection.
+func classify(err error) *errs.Failure {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return nil
+	}
+
+	// The code travels whether or not it is mapped.
+	f := errs.Failure{Code: pgErr.Code}
+	if category, ok := sqlStateCategories[pgErr.Code]; ok {
+		f.Category = category
+		f.ClassifiedBy = errs.ClassifiedByVendor
+		return &f
+	}
+	// A real SQLSTATE with no rule yet; the code alone makes the gap actionable.
+	f.Category = errs.Unclassified
+	f.ClassifiedBy = errs.ClassifiedByDefault
+	return &f
+}

--- a/drivers/postgres/internal/incremental.go
+++ b/drivers/postgres/internal/incremental.go
@@ -18,12 +18,12 @@ func (p *Postgres) StreamIncrementalChanges(ctx context.Context, stream types.St
 	}
 	incrementalQuery, queryArgs, err := jdbc.BuildIncrementalQuery(ctx, opts)
 	if err != nil {
-		return fmt.Errorf("failed to build incremental condition: %s", err)
+		return fmt.Errorf("failed to build incremental condition: %w", err)
 	}
 
 	rows, err := p.client.QueryContext(ctx, incrementalQuery, queryArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to execute incremental query: %s", err)
+		return fmt.Errorf("failed to execute incremental query: %w", err)
 	}
 	defer rows.Close()
 
@@ -31,11 +31,11 @@ func (p *Postgres) StreamIncrementalChanges(ctx context.Context, stream types.St
 		record := make(types.Record)
 		rowBytes, err := jdbc.MapScan(rows, record, p.dataTypeConverter, pgColumnSizer)
 		if err != nil {
-			return fmt.Errorf("failed to scan record: %s", err)
+			return fmt.Errorf("failed to scan record: %w", err)
 		}
 
 		if err := processFn(ctx, record, rowBytes); err != nil {
-			return fmt.Errorf("process error: %s", err)
+			return fmt.Errorf("process error: %w", err)
 		}
 	}
 

--- a/drivers/postgres/internal/postgres.go
+++ b/drivers/postgres/internal/postgres.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/datazip-inc/olake/pkg/waljs"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/jackc/pgx/v5"
@@ -80,25 +82,25 @@ func (p *Postgres) CDCSupported() bool {
 func (p *Postgres) Setup(ctx context.Context) error {
 	err := p.config.Validate()
 	if err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	if p.config.SSHConfig != nil && p.config.SSHConfig.Host != "" {
 		logger.Info("Found SSH Configuration")
 		p.sshClient, err = p.config.SSHConfig.SetupSSHConnection()
 		if err != nil {
-			return fmt.Errorf("failed to setup SSH connection: %s", err)
+			return fmt.Errorf("failed to setup SSH connection: %w", err)
 		}
 	}
 
 	var db *sql.DB
 	pgCfg, err := pgx.ParseConfig(p.config.Connection.String())
 	if err != nil {
-		return fmt.Errorf("failed to parse postgres connection string: %s", err)
+		return fmt.Errorf("failed to parse postgres connection string: %w", err)
 	}
 	tlsConfig, err := p.config.buildTLSConfig()
 	if err != nil {
-		return fmt.Errorf("failed to build tls config: %s", err)
+		return fmt.Errorf("failed to build tls config: %w", err)
 	}
 	if tlsConfig != nil {
 		pgCfg.TLSConfig = tlsConfig
@@ -122,7 +124,7 @@ func (p *Postgres) Setup(ctx context.Context) error {
 	// force a connection and test that it worked
 	err = pgClient.PingContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to ping database: %s", err)
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
 	// TODO: correct cdc setup
 	found, _ := utils.IsOfType(p.config.UpdateMethod, "replication_slot")
@@ -137,21 +139,24 @@ func (p *Postgres) Setup(ctx context.Context) error {
 
 		// check if initial wait time is valid or not
 		if cdc.InitialWaitTime < 120 {
-			return fmt.Errorf("the CDC initial wait time must be at least 120 seconds")
+			return errs.Precondition(errs.ConfigInvalid, codeCDCWaitTimeTooLow,
+				fmt.Errorf("the CDC initial wait time must be at least 120 seconds"))
 		}
 
 		logger.Infof("CDC initial wait time set to: %d", cdc.InitialWaitTime)
 
 		exists, err := doesReplicationSlotExists(ctx, pgClient, cdc.ReplicationSlot, cdc.Publication, p.config.Database)
 		if err != nil {
-			if strings.Contains(err.Error(), "sql: no rows in result set") {
-				err = fmt.Errorf("no record found")
+			if errors.Is(err, sql.ErrNoRows) {
+				return errs.Precondition(errs.CDCPreconditionFailed, codeReplicationSlotMissing,
+					fmt.Errorf("failed to validate cdc configuration for slot %s: no record found", cdc.ReplicationSlot))
 			}
-			return fmt.Errorf("failed to validate cdc configuration for slot %s: %s", cdc.ReplicationSlot, err)
+			return fmt.Errorf("failed to validate cdc configuration for slot %s: %w", cdc.ReplicationSlot, err)
 		}
 
 		if !exists {
-			return fmt.Errorf("replication slot '%s' does not exist in the current database '%s'", cdc.ReplicationSlot, p.config.Database)
+			return errs.Precondition(errs.CDCPreconditionFailed, codeReplicationSlotMissing,
+				fmt.Errorf("replication slot '%s' does not exist in the current database '%s'", cdc.ReplicationSlot, p.config.Database))
 		}
 		// no use of it if check not being called while sync run
 		p.CDCSupport = true
@@ -214,7 +219,7 @@ func (p *Postgres) GetStreamNames(ctx context.Context) ([]types.StreamID, error)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve table names: %s", err)
+		return nil, fmt.Errorf("failed to retrieve table names: %w", err)
 	}
 
 	tablesNames := make([]types.StreamID, 0, len(tableNamesOutput))
@@ -231,7 +236,7 @@ func (p *Postgres) ProduceSchema(ctx context.Context, streamID types.StreamID) (
 		var columnSchemaOutput []ColumnDetails
 		err := p.client.SelectContext(ctx, &columnSchemaOutput, getTableSchemaTmpl, schemaName, streamName)
 		if err != nil {
-			return stream, fmt.Errorf("failed to retrieve column details for table %s: %s", streamName, err)
+			return stream, fmt.Errorf("failed to retrieve column details for table %s: %w", streamName, err)
 		}
 
 		if len(columnSchemaOutput) == 0 {
@@ -242,7 +247,7 @@ func (p *Postgres) ProduceSchema(ctx context.Context, streamID types.StreamID) (
 		var primaryKeyOutput []ColumnDetails
 		err = p.client.SelectContext(ctx, &primaryKeyOutput, getTablePrimaryKey, schemaName, streamName)
 		if err != nil {
-			return stream, fmt.Errorf("failed to retrieve primary key columns for table %s: %s", streamName, err)
+			return stream, fmt.Errorf("failed to retrieve primary key columns for table %s: %w", streamName, err)
 		}
 
 		for _, column := range columnSchemaOutput {
@@ -275,7 +280,7 @@ func (p *Postgres) ProduceSchema(ctx context.Context, streamID types.StreamID) (
 	stream, err := populateStream(streamID)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to produce schema context deadline exceeded: %w", ctx.Err())
 		}
 		return nil, err
 	}

--- a/drivers/s3/go.mod
+++ b/drivers/s3/go.mod
@@ -8,6 +8,7 @@ replace (
 )
 
 require (
+	github.com/aws/smithy-go v1.24.2
 	github.com/datazip-inc/olake v0.2.6
 	github.com/parquet-go/parquet-go v0.29.0
 	github.com/shopspring/decimal v1.4.0
@@ -38,7 +39,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/drivers/s3/internal/backfill.go
+++ b/drivers/s3/internal/backfill.go
@@ -12,6 +12,7 @@ import (
 	"github.com/datazip-inc/olake/drivers/s3/internal/pkg/parser"
 	"github.com/datazip-inc/olake/pkg/objstorage"
 	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 )
 
@@ -159,7 +160,7 @@ func (s *S3) ChunkIterator(ctx context.Context, stream types.StreamInterface, ch
 		fileSize := s.getFileSize(stream.Name(), key)
 		lastModified := s.getFileLastModified(stream.Name(), key)
 		if err := s.processFile(ctx, stream, key, fileSize, lastModified, processFn); err != nil {
-			return fmt.Errorf("failed to process file %s in chunk: %s", key, err)
+			return fmt.Errorf("failed to process file %s in chunk: %w", key, err)
 		}
 	}
 
@@ -186,7 +187,7 @@ func (s *S3) processFile(ctx context.Context, stream types.StreamInterface, key 
 				logger.Warnf("File %s was deleted or not found, skipping", key)
 				return nil // Don't fail the entire sync for a missing file
 			}
-			return fmt.Errorf("failed to get reader: %s", err)
+			return fmt.Errorf("failed to get reader: %w", err)
 		}
 		wrapper := parser.NewParquetReaderWrapper(readerAt, size)
 		return s.parseFileWithReader(ctx, stream, key, wrapper, lastModified, processFn)
@@ -200,7 +201,7 @@ func (s *S3) processFile(ctx context.Context, stream types.StreamInterface, key 
 			logger.Warnf("File %s was deleted or not found, skipping", key)
 			return nil // Don't fail the entire sync for a missing file
 		}
-		return fmt.Errorf("failed to get reader: %s", err)
+		return fmt.Errorf("failed to get reader: %w", err)
 	}
 	defer reader.Close()
 
@@ -246,11 +247,12 @@ func (s *S3) parseFileWithReader(ctx context.Context, stream types.StreamInterfa
 		xmlParser := parser.NewXMLParser(xmlCfg, underlyingStream)
 		parseErr = xmlParser.StreamRecords(ctx, reader, callback)
 	default:
-		return fmt.Errorf("unsupported file format: %s", s.config.FileFormat)
+		return errs.Precondition(errs.ConfigInvalid, codeUnsupportedFileFormat,
+			fmt.Errorf("unsupported file format: %s", s.config.FileFormat))
 	}
 
 	if parseErr != nil {
-		return fmt.Errorf("failed to process file %s: %s", key, parseErr)
+		return fmt.Errorf("failed to process file %s: %w", key, parseErr)
 	}
 
 	return nil

--- a/drivers/s3/internal/cdc.go
+++ b/drivers/s3/internal/cdc.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 // ChangeStreamConfig returns the change stream configuration for S3
@@ -20,15 +21,18 @@ func (s *S3) CDCSupported() bool {
 
 // PreCDC is not supported for S3
 func (s *S3) PreCDC(_ context.Context, _ []types.StreamInterface) error {
-	return fmt.Errorf("CDC is not supported for S3 source")
+	return errs.Precondition(errs.UnsupportedFeature, codeCDCUnsupported,
+		fmt.Errorf("CDC is not supported for S3 source"))
 }
 
 // StreamChanges is not supported for S3
 func (s *S3) StreamChanges(_ context.Context, _ int, _ map[string]any, _ abstract.CDCMsgFn) (any, error) {
-	return nil, fmt.Errorf("CDC is not supported for S3 source")
+	return nil, errs.Precondition(errs.UnsupportedFeature, codeCDCUnsupported,
+		fmt.Errorf("CDC is not supported for S3 source"))
 }
 
 // PostCDC is not supported for S3
 func (s *S3) PostCDC(_ context.Context, _ int) error {
-	return fmt.Errorf("CDC is not supported for S3 source")
+	return errs.Precondition(errs.UnsupportedFeature, codeCDCUnsupported,
+		fmt.Errorf("CDC is not supported for S3 source"))
 }

--- a/drivers/s3/internal/errors.go
+++ b/drivers/s3/internal/errors.go
@@ -1,0 +1,134 @@
+package driver
+
+import (
+	"archive/zip"
+	"compress/gzip"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/smithy-go"
+	"github.com/datazip-inc/olake/drivers/s3/internal/pkg/parser"
+	"github.com/datazip-inc/olake/pkg/objstorage"
+	"github.com/datazip-inc/olake/utils/errs"
+	pq "github.com/parquet-go/parquet-go"
+)
+
+// Codes for conditions this driver detects itself, where no API error exists to read.
+const (
+	codeCDCUnsupported        = "s3.cdc_unsupported"
+	codeUnsupportedFileFormat = "s3.unsupported_file_format"
+	codeNoFilesForStream      = "s3.no_files_for_stream"
+)
+
+// Registered so ReportFailure can classify without knowing which connector ran. Only S3 evidence
+// lives here; DNS, TLS and socket failures are shared and belong to utils/errs.
+func init() { errs.Register("s3", classify) }
+
+// classify reads S3's API code, the response status, or a decoder failure, returning nil for
+// anything else. The category comes from the error, never the call site.
+func classify(err error) *errs.Failure {
+	if f := fromAPIError(err); f != nil {
+		return f
+	}
+	if f := fromDecoder(err); f != nil {
+		return f
+	}
+
+	// Checked last: a dropped connection and a throttled request fail inside the parser too,
+	// and both have better answers than "the file is unreadable".
+	if parser.IsDecodeFailure(err) {
+		return &errs.Failure{Category: errs.SourceReadError, ClassifiedBy: errs.ClassifiedByPrecondition}
+	}
+
+	// objstorage joins this sentinel alongside the service error rather than replacing it, so
+	// the checks above keep the service code. This covers one arriving alone.
+	if errors.Is(err, objstorage.ErrNotFound) {
+		return &errs.Failure{
+			Category:     errs.ObjectNotFound,
+			ClassifiedBy: errs.ClassifiedByVendor,
+			Code:         "object_not_found",
+		}
+	}
+	return nil
+}
+
+// fromAPIError classifies anything the service answered with. The API code is preferred; where
+// there is none — S3 answers several requests with a bare status and no body — the status
+// stands in, which is also what makes S3-compatible endpoints classify at all.
+func fromAPIError(err error) *errs.Failure {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return nil
+	}
+
+	code := apiErr.ErrorCode()
+	if category, ok := objstorage.ServiceCodeCategories[code]; ok {
+		return &errs.Failure{Category: category, ClassifiedBy: errs.ClassifiedByVendor, Code: code}
+	}
+
+	// Read through an interface, not a concrete type: the SDK has two response-error types and
+	// both answer it.
+	var httpErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &httpErr) {
+		if category := categoryForStatus(httpErr.HTTPStatusCode()); category != "" {
+			if code == "" {
+				// Prefixed so a bare status cannot be read as a service code; both share
+				// one telemetry field.
+				code = fmt.Sprintf("http_%d", httpErr.HTTPStatusCode())
+			}
+			return &errs.Failure{Category: category, ClassifiedBy: errs.ClassifiedByVendor, Code: code}
+		}
+	}
+
+	// No mapping and no usable status; the code alone makes the gap actionable.
+	return &errs.Failure{Category: errs.Unclassified, ClassifiedBy: errs.ClassifiedByDefault, Code: code}
+}
+
+// categoryForStatus maps an HTTP response status to a category, or "" where the status says
+// nothing useful on its own.
+func categoryForStatus(status int) errs.Category {
+	switch {
+	case status == 401:
+		return errs.AuthFailed
+	case status == 403:
+		return errs.PermissionDenied
+	case status == 404:
+		return errs.ObjectNotFound
+	case status == 408:
+		return errs.Timeout
+	case status == 429:
+		return errs.ResourceExhausted
+	case status >= 500:
+		return errs.NetworkUnreachable
+	}
+	return ""
+}
+
+// fromDecoder classifies a file that arrived intact and could not be read. Keyed on the decoder's
+// own types, never on "raised inside pkg/parser": a connection dropped mid-object fails inside
+// the parser too, and a call-site rule would report a healthy file as corrupt.
+func fromDecoder(err error) *errs.Failure {
+	var (
+		csvErr       *csv.ParseError
+		jsonSyntax   *json.SyntaxError
+		jsonType     *json.UnmarshalTypeError
+		parquetValue *pq.ConvertError
+	)
+	switch {
+	case errors.As(err, &csvErr),
+		errors.As(err, &jsonSyntax),
+		errors.As(err, &jsonType),
+		errors.Is(err, gzip.ErrHeader), errors.Is(err, gzip.ErrChecksum),
+		errors.Is(err, zip.ErrFormat), errors.Is(err, zip.ErrChecksum),
+		errors.Is(err, pq.ErrCorrupted), errors.Is(err, pq.ErrMissingPageHeader),
+		errors.Is(err, pq.ErrMissingRootColumn), errors.Is(err, pq.ErrSeekOutOfRange):
+		return &errs.Failure{Category: errs.SourceReadError, ClassifiedBy: errs.ClassifiedByVendor}
+
+	case errors.As(err, &parquetValue):
+		// A value the file holds does not fit the column type it declares.
+		return &errs.Failure{Category: errs.SchemaUnsupported, ClassifiedBy: errs.ClassifiedByVendor}
+	}
+	return nil
+}

--- a/drivers/s3/internal/incremental.go
+++ b/drivers/s3/internal/incremental.go
@@ -112,7 +112,7 @@ func (s *S3) StreamIncrementalChanges(ctx context.Context, stream types.StreamIn
 		// Process the file using the same logic as backfill
 		// Pass file.LastModified directly (already available) to avoid redundant lookup
 		if err := s.processFile(ctx, stream, file.FileKey, file.Size, file.LastModified, cb); err != nil {
-			return fmt.Errorf("failed to process incremental file %s: %s", file.FileKey, err)
+			return fmt.Errorf("failed to process incremental file %s: %w", file.FileKey, err)
 		}
 	}
 

--- a/drivers/s3/internal/pkg/parser/csv.go
+++ b/drivers/s3/internal/pkg/parser/csv.go
@@ -36,7 +36,9 @@ func NewCSVParser(config CSVConfig, stream *types.Stream) *CSVParser {
 
 // InferSchema reads the first few rows of a CSV file to infer the schema
 // Uses small samples to avoid loading entire file into memory
-func (p *CSVParser) InferSchema(_ context.Context, reader io.Reader) (*types.Stream, error) {
+func (p *CSVParser) InferSchema(_ context.Context, reader io.Reader) (_ *types.Stream, err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	logger.Debug("Inferring CSV schema from sample data")
 
 	// Create CSV reader
@@ -50,23 +52,22 @@ func (p *CSVParser) InferSchema(_ context.Context, reader io.Reader) (*types.Str
 	for i := 0; i < p.config.SkipRows; i++ {
 		_, err := csvReader.Read()
 		if err != nil {
-			return nil, fmt.Errorf("failed to skip row %d: %s", i, err)
+			return nil, fmt.Errorf("failed to skip row %d: %w", i, err)
 		}
 	}
 
 	var headers []string
-	var err error
 	if p.config.HasHeader {
 		// Read header row
 		headers, err = csvReader.Read()
 		if err != nil {
-			return nil, fmt.Errorf("failed to read CSV headers: %s", err)
+			return nil, fmt.Errorf("failed to read CSV headers: %w", err)
 		}
 	} else {
 		// Read first data row to determine column count
 		firstRow, err := csvReader.Read()
 		if err != nil {
-			return nil, fmt.Errorf("failed to read first CSV row: %s", err)
+			return nil, fmt.Errorf("failed to read first CSV row: %w", err)
 		}
 		// Generate column names as column_0, column_1, etc.
 		for i := range firstRow {
@@ -100,7 +101,9 @@ func (p *CSVParser) InferSchema(_ context.Context, reader io.Reader) (*types.Str
 }
 
 // StreamRecords reads and streams CSV records with context support
-func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) error {
+func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) (err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	csvReader := csv.NewReader(reader)
 	csvReader.Comma = rune(p.config.Delimiter[0])
 	if p.config.QuoteCharacter != "" {
@@ -111,7 +114,7 @@ func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 	for i := 0; i < p.config.SkipRows; i++ {
 		_, err := csvReader.Read()
 		if err != nil {
-			return fmt.Errorf("failed to skip row %d: %s", i, err)
+			return fmt.Errorf("failed to skip row %d: %w", i, err)
 		}
 	}
 
@@ -121,13 +124,13 @@ func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 		var err error
 		headers, err = csvReader.Read()
 		if err != nil {
-			return fmt.Errorf("failed to read CSV headers: %s", err)
+			return fmt.Errorf("failed to read CSV headers: %w", err)
 		}
 	} else {
 		// Generate default column names based on first row
 		firstRow, err := csvReader.Read()
 		if err != nil {
-			return fmt.Errorf("failed to read first row: %s", err)
+			return fmt.Errorf("failed to read first row: %w", err)
 		}
 		for i := range firstRow {
 			headers = append(headers, fmt.Sprintf("column_%d", i))
@@ -142,7 +145,7 @@ func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 						// errNullValue indicates a valid null/empty value
 						record[headers[i]] = nil
 					} else {
-						return fmt.Errorf("failed to convert value for field %s: %s", headers[i], err)
+						return fmt.Errorf("failed to convert value for field %s: %w", headers[i], err)
 					}
 				} else {
 					record[headers[i]] = convertedValue
@@ -150,7 +153,7 @@ func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 			}
 		}
 		if err := callback(ctx, record); err != nil {
-			return fmt.Errorf("failed to process first record: %s", err)
+			return fmt.Errorf("failed to process first record: %w", err)
 		}
 	}
 
@@ -183,7 +186,7 @@ func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 						// errNullValue indicates a valid null/empty value
 						record[headers[i]] = nil
 					} else {
-						return fmt.Errorf("failed to convert value for field %s in row %d: %s", headers[i], recordCount, err)
+						return fmt.Errorf("failed to convert value for field %s in row %d: %w", headers[i], recordCount, err)
 					}
 				} else {
 					record[headers[i]] = convertedValue
@@ -192,7 +195,7 @@ func (p *CSVParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 		}
 
 		if err := callback(ctx, record); err != nil {
-			return fmt.Errorf("failed to process record: %s", err)
+			return fmt.Errorf("failed to process record: %w", err)
 		}
 		recordCount++
 	}
@@ -306,19 +309,19 @@ func convertValue(value string, fieldType types.DataType) (interface{}, error) {
 	case types.Int32:
 		intVal, err := strconv.ParseInt(trimmed, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert '%s' to integer: %s", trimmed, err)
+			return nil, fmt.Errorf("failed to convert '%s' to integer: %w", trimmed, err)
 		}
 		return int32(intVal), nil
 	case types.Int64:
 		intVal, err := strconv.ParseInt(trimmed, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert '%s' to int64: %s", trimmed, err)
+			return nil, fmt.Errorf("failed to convert '%s' to int64: %w", trimmed, err)
 		}
 		return intVal, nil
 	case types.Float32:
 		floatVal, err := strconv.ParseFloat(trimmed, 32)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert '%s' to float32: %s", trimmed, err)
+			return nil, fmt.Errorf("failed to convert '%s' to float32: %w", trimmed, err)
 		}
 		// Handle NaN/Inf - JSON doesn't support these values, so convert to nil
 		if math.IsNaN(floatVal) || math.IsInf(floatVal, 0) {
@@ -328,7 +331,7 @@ func convertValue(value string, fieldType types.DataType) (interface{}, error) {
 	case types.Float64:
 		floatVal, err := strconv.ParseFloat(trimmed, 64)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert '%s' to float64: %s", trimmed, err)
+			return nil, fmt.Errorf("failed to convert '%s' to float64: %w", trimmed, err)
 		}
 		// Handle NaN/Inf - JSON doesn't support these values, so convert to nil
 		if math.IsNaN(floatVal) || math.IsInf(floatVal, 0) {
@@ -338,14 +341,14 @@ func convertValue(value string, fieldType types.DataType) (interface{}, error) {
 	case types.Bool:
 		boolVal, err := strconv.ParseBool(trimmed)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert '%s' to boolean: %s", trimmed, err)
+			return nil, fmt.Errorf("failed to convert '%s' to boolean: %w", trimmed, err)
 		}
 		return boolVal, nil
 	case types.Timestamp, types.TimestampMilli, types.TimestampMicro, types.TimestampNano:
 		// Parse timestamp string using ReformatDate which handles multiple formats
 		timestampVal, err := typeutils.ReformatDate(trimmed, true)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert '%s' to timestamp: %s", trimmed, err)
+			return nil, fmt.Errorf("failed to convert '%s' to timestamp: %w", trimmed, err)
 		}
 		return timestampVal, nil
 	case types.Object:

--- a/drivers/s3/internal/pkg/parser/errors.go
+++ b/drivers/s3/internal/pkg/parser/errors.go
@@ -1,0 +1,25 @@
+package parser
+
+import "errors"
+
+// decodeFailure marks an error raised while decoding a file's contents. It carries no category:
+// a truncated file arrives as a bare io.EOF and a bad header as an untyped fmt.Errorf, and a
+// connection dropped mid-file surfaces here too, so a classifier checks this marker last.
+type decodeFailure struct{ err error }
+
+func (d decodeFailure) Error() string { return d.err.Error() }
+func (d decodeFailure) Unwrap() error { return d.err }
+
+// DecodeFailure marks err as raised while decoding.
+func DecodeFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	return decodeFailure{err: err}
+}
+
+// IsDecodeFailure reports whether err was marked by DecodeFailure.
+func IsDecodeFailure(err error) bool {
+	var marker decodeFailure
+	return errors.As(err, &marker)
+}

--- a/drivers/s3/internal/pkg/parser/json.go
+++ b/drivers/s3/internal/pkg/parser/json.go
@@ -28,7 +28,9 @@ func NewJSONParser(config JSONConfig, stream *types.Stream) *JSONParser {
 
 // InferSchema reads the first few records of a JSON file to infer the schema
 // Supports JSONL (line-delimited), JSON Array, and single JSON object formats
-func (p *JSONParser) InferSchema(_ context.Context, reader io.Reader) (*types.Stream, error) {
+func (p *JSONParser) InferSchema(_ context.Context, reader io.Reader) (_ *types.Stream, err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	logger.Debug("Inferring JSON schema from sample data")
 	//TODO : implement sampling of records from first and last files to get a more accurate schema
 	// Collect sample records using smart JSON format detection
@@ -41,7 +43,7 @@ func (p *JSONParser) InferSchema(_ context.Context, reader io.Reader) (*types.St
 
 	data, err := io.ReadAll(limitedReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read JSON file: %s", err)
+		return nil, fmt.Errorf("failed to read JSON file: %w", err)
 	}
 
 	trimmed := bytes.TrimSpace(data)
@@ -52,7 +54,7 @@ func (p *JSONParser) InferSchema(_ context.Context, reader io.Reader) (*types.St
 	// Parse JSON based on detected format
 	sampleRecords, err := p.parseJSONContent(trimmed, maxSamples)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %s", err)
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
 	if len(sampleRecords) == 0 {
@@ -62,7 +64,7 @@ func (p *JSONParser) InferSchema(_ context.Context, reader io.Reader) (*types.St
 	// Resolve schema one record at a time similar to MongoDB driver
 	for i, record := range sampleRecords {
 		if err := typeutils.Resolve(p.stream, record); err != nil {
-			return nil, fmt.Errorf("failed to resolve schema for record %d: %s", i, err)
+			return nil, fmt.Errorf("failed to resolve schema for record %d: %w", i, err)
 		}
 	}
 
@@ -71,7 +73,9 @@ func (p *JSONParser) InferSchema(_ context.Context, reader io.Reader) (*types.St
 }
 
 // StreamRecords reads and streams JSON records with context support
-func (p *JSONParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) error {
+func (p *JSONParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) (err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	recordCount := 0
 
 	if p.config.LineDelimited {
@@ -95,7 +99,7 @@ func (p *JSONParser) StreamRecords(ctx context.Context, reader io.Reader, callba
 			}
 
 			if err := callback(ctx, record); err != nil {
-				return fmt.Errorf("failed to process record: %s", err)
+				return fmt.Errorf("failed to process record: %w", err)
 			}
 			recordCount++
 		}
@@ -106,7 +110,7 @@ func (p *JSONParser) StreamRecords(ctx context.Context, reader io.Reader, callba
 		// Read opening bracket
 		token, err := decoder.Token()
 		if err != nil {
-			return fmt.Errorf("failed to read JSON array start: %s", err)
+			return fmt.Errorf("failed to read JSON array start: %w", err)
 		}
 
 		// Verify it's an array
@@ -130,7 +134,7 @@ func (p *JSONParser) StreamRecords(ctx context.Context, reader io.Reader, callba
 			}
 
 			if err := callback(ctx, record); err != nil {
-				return fmt.Errorf("failed to process record: %s", err)
+				return fmt.Errorf("failed to process record: %w", err)
 			}
 			recordCount++
 		}
@@ -171,7 +175,7 @@ func (p *JSONParser) parseJSONArray(data []byte, maxSamples int) ([]map[string]i
 	// Read opening bracket
 	token, err := decoder.Token()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read JSON array start: %s", err)
+		return nil, fmt.Errorf("failed to read JSON array start: %w", err)
 	}
 
 	// Verify it's an array
@@ -189,7 +193,7 @@ func (p *JSONParser) parseJSONArray(data []byte, maxSamples int) ([]map[string]i
 				logger.Warnf("Stopped reading JSON array after %d records due to error: %v", len(records), err)
 				break
 			}
-			return nil, fmt.Errorf("failed to decode JSON array element: %s", err)
+			return nil, fmt.Errorf("failed to decode JSON array element: %w", err)
 		}
 		records = append(records, record)
 	}
@@ -215,9 +219,9 @@ func (p *JSONParser) parseJSONLOrObject(data []byte, maxSamples int) ([]map[stri
 	if err := json.Unmarshal(data, &singleRecord); err != nil {
 		// If both failed, return a more helpful error
 		if isJSONL {
-			return nil, fmt.Errorf("failed to parse as JSONL: %s", err)
+			return nil, fmt.Errorf("failed to parse as JSONL: %w", err)
 		}
-		return nil, fmt.Errorf("failed to parse as single JSON object or JSONL: %s", err)
+		return nil, fmt.Errorf("failed to parse as single JSON object or JSONL: %w", err)
 	}
 
 	logger.Debug("Parsed single JSON object")

--- a/drivers/s3/internal/pkg/parser/parquet.go
+++ b/drivers/s3/internal/pkg/parser/parquet.go
@@ -52,7 +52,9 @@ func NewParquetParser(config ParquetConfig, stream *types.Stream) *ParquetParser
 // InferSchema reads Parquet file metadata to infer the schema
 // For Parquet, schema is stored in file metadata, so we don't need to read data
 // NOTE: reader must be io.ReaderAt for Parquet (use objstorage.ReaderAt or bytes.Reader)
-func (p *ParquetParser) InferSchema(_ context.Context, reader io.Reader) (*types.Stream, error) {
+func (p *ParquetParser) InferSchema(_ context.Context, reader io.Reader) (_ *types.Stream, err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	logger.Debug("Inferring Parquet schema from file metadata")
 
 	// Prepare reader and get file size
@@ -64,7 +66,7 @@ func (p *ParquetParser) InferSchema(_ context.Context, reader io.Reader) (*types
 	// Open Parquet file to read schema
 	pqFile, err := pq.OpenFile(readerAt, fileSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open parquet file: %s", err)
+		return nil, fmt.Errorf("failed to open parquet file: %w", err)
 	}
 
 	// Get the schema from parquet file
@@ -83,7 +85,9 @@ func (p *ParquetParser) InferSchema(_ context.Context, reader io.Reader) (*types
 
 // StreamRecords reads and streams Parquet records with context support
 // NOTE: reader must be io.ReaderAt for Parquet (use objstorage.ReaderAt or bytes.Reader)
-func (p *ParquetParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) error {
+func (p *ParquetParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) (err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	// Prepare reader and get file size
 	readerAt, fileSize, err := prepareParquetReader(reader)
 	if err != nil {
@@ -93,7 +97,7 @@ func (p *ParquetParser) StreamRecords(ctx context.Context, reader io.Reader, cal
 	// Open Parquet file
 	pqFile, err := pq.OpenFile(readerAt, fileSize)
 	if err != nil {
-		return fmt.Errorf("failed to open parquet file: %s", err)
+		return fmt.Errorf("failed to open parquet file: %w", err)
 	}
 
 	// Decoder holds the per-file schema state and the leaf-column index used to decode rows.
@@ -125,7 +129,7 @@ func (p *ParquetParser) StreamRecords(ctx context.Context, reader io.Reader, cal
 			streamErr = p.streamRowGroupColumns(ctx, rowGroup, decoder, callback, &recordCount)
 		}
 		if streamErr != nil {
-			return fmt.Errorf("failed to read row group %d: %s", rgIdx, streamErr)
+			return fmt.Errorf("failed to read row group %d: %w", rgIdx, streamErr)
 		}
 
 		logger.Debugf("Completed row group %d/%d (%d total records so far)",
@@ -163,7 +167,7 @@ func (p *ParquetParser) streamRowGroupRows(ctx context.Context, rowGroup pq.RowG
 				return err
 			}
 			if err := callback(ctx, record); err != nil {
-				return fmt.Errorf("failed to process record: %s", err)
+				return fmt.Errorf("failed to process record: %w", err)
 			}
 			*recordCount++
 		}
@@ -171,7 +175,7 @@ func (p *ParquetParser) streamRowGroupRows(ctx context.Context, rowGroup pq.RowG
 			return nil
 		}
 		if readErr != nil {
-			return fmt.Errorf("failed to read rows: %s", readErr)
+			return fmt.Errorf("failed to read rows: %w", readErr)
 		}
 	}
 }
@@ -218,7 +222,7 @@ func (p *ParquetParser) streamRowGroupColumns(ctx context.Context, rowGroup pq.R
 		}
 
 		if err := callback(ctx, record); err != nil {
-			return fmt.Errorf("failed to process record: %s", err)
+			return fmt.Errorf("failed to process record: %w", err)
 		}
 		*recordCount++
 	}
@@ -238,7 +242,7 @@ func readColumnValues(columnChunk pq.ColumnChunk, numRows int64) ([]pq.Value, er
 			return values, nil
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to read page: %s", err)
+			return nil, fmt.Errorf("failed to read page: %w", err)
 		}
 
 		// Read into the tail of the result: no per-page buffer, no copy out of it.
@@ -246,7 +250,7 @@ func readColumnValues(columnChunk pq.ColumnChunk, numRows int64) ([]pq.Value, er
 		values = slices.Grow(values, count)
 		n, err := page.Values().ReadValues(values[len(values) : len(values)+count])
 		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("failed to read page values: %s", err)
+			return nil, fmt.Errorf("failed to read page values: %w", err)
 		}
 		values = values[:len(values)+n]
 	}
@@ -309,7 +313,7 @@ func (d *rowDecoder) decode(row pq.Row) (map[string]any, error) {
 	if d.hasGroupField {
 		groups = map[string]any{}
 		if err := d.schema.Reconstruct(&groups, row); err != nil {
-			return nil, fmt.Errorf("failed to reconstruct row: %s", err)
+			return nil, fmt.Errorf("failed to reconstruct row: %w", err)
 		}
 	}
 
@@ -839,12 +843,12 @@ func prepareParquetReader(reader io.Reader) (io.ReaderAt, int64, error) {
 	if seeker, ok := reader.(io.Seeker); ok {
 		size, err := seeker.Seek(0, io.SeekEnd)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to determine file size: %s", err)
+			return nil, 0, fmt.Errorf("failed to determine file size: %w", err)
 		}
 		// Seek back to beginning
 		_, err = seeker.Seek(0, io.SeekStart)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to seek to start: %s", err)
+			return nil, 0, fmt.Errorf("failed to seek to start: %w", err)
 		}
 		fileSize = size
 	} else {

--- a/drivers/s3/internal/pkg/parser/xml.go
+++ b/drivers/s3/internal/pkg/parser/xml.go
@@ -34,14 +34,15 @@ func NewXMLParser(config XMLConfig, stream *types.Stream) *XMLParser {
 
 // InferSchema reads the first few records of an XML file to infer the schema
 // Supports XML with a specified record tag or entire document as a single record
-func (p *XMLParser) InferSchema(_ context.Context, reader io.Reader) (*types.Stream, error) {
+func (p *XMLParser) InferSchema(_ context.Context, reader io.Reader) (_ *types.Stream, err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	logger.Debug("Inferring XML schema from sample data")
 
 	//TODO : implement sampling of records from first and last files to get more accurate schema
 	maxSamples := 100
 
 	var data []byte
-	var err error
 
 	if p.config.RowIdentifier == "" {
 		data, err = io.ReadAll(reader)
@@ -50,7 +51,7 @@ func (p *XMLParser) InferSchema(_ context.Context, reader io.Reader) (*types.Str
 		data, err = io.ReadAll(limitedReader)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to read XML file: %s", err)
+		return nil, fmt.Errorf("failed to read XML file: %w", err)
 	}
 
 	trimmed := bytes.TrimSpace(data)
@@ -60,7 +61,7 @@ func (p *XMLParser) InferSchema(_ context.Context, reader io.Reader) (*types.Str
 
 	sampleRecords, err := p.parseSampleXMLContent(trimmed, maxSamples)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse XML: %s", err)
+		return nil, fmt.Errorf("failed to parse XML: %w", err)
 	}
 
 	if len(sampleRecords) == 0 {
@@ -70,7 +71,7 @@ func (p *XMLParser) InferSchema(_ context.Context, reader io.Reader) (*types.Str
 	// Resolve schema for each sample Record and update stream schema
 	for i, record := range sampleRecords {
 		if err := typeutils.Resolve(p.stream, record); err != nil {
-			return nil, fmt.Errorf("failed to resolve schema for record %d: %s", i, err)
+			return nil, fmt.Errorf("failed to resolve schema for record %d: %w", i, err)
 		}
 	}
 
@@ -86,7 +87,9 @@ func (p *XMLParser) InferSchema(_ context.Context, reader io.Reader) (*types.Str
 }
 
 // StreamRecords reads and streams records from XML reader with context support
-func (p *XMLParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) error {
+func (p *XMLParser) StreamRecords(ctx context.Context, reader io.Reader, callback RecordCallback) (err error) {
+	defer func() { err = DecodeFailure(err) }()
+
 	recordCount := 0
 
 	if p.config.RowIdentifier == "" {
@@ -97,11 +100,11 @@ func (p *XMLParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 		default:
 			record, err := p.parseXMLDocumentAsMap(reader)
 			if err != nil {
-				return fmt.Errorf("failed to parse XML document: %s", err)
+				return fmt.Errorf("failed to parse XML document: %w", err)
 			}
 
 			if err := callback(ctx, record); err != nil {
-				return fmt.Errorf("failed to process record: %s", err)
+				return fmt.Errorf("failed to process record: %w", err)
 			}
 			recordCount++
 		}
@@ -121,7 +124,7 @@ func (p *XMLParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 			if err == io.EOF {
 				break
 			} else if err != nil {
-				return fmt.Errorf("error reading XML token at record %d: %v", recordCount, err)
+				return fmt.Errorf("error reading XML token at record %d: %w", recordCount, err)
 			}
 
 			// Process only start elements that match the specified record tag
@@ -149,7 +152,7 @@ func (p *XMLParser) StreamRecords(ctx context.Context, reader io.Reader, callbac
 
 			// callback processing the record
 			if err := callback(ctx, recordMap); err != nil {
-				return fmt.Errorf("failed to process record: %s", err)
+				return fmt.Errorf("failed to process record: %w", err)
 			}
 			recordCount++
 		}
@@ -184,7 +187,7 @@ func (p *XMLParser) parseSampleXMLContent(data []byte, maxSamples int) ([]map[st
 				logger.Warnf("Stopped reading XML after %d records (truncated): %v", len(records), err)
 				break
 			}
-			return nil, fmt.Errorf("xml token error: %s", err)
+			return nil, fmt.Errorf("xml token error: %w", err)
 		}
 
 		// process start elements matching record tag
@@ -229,7 +232,7 @@ func (p *XMLParser) parseXMLDocumentAsMap(reader io.Reader) (map[string]any, err
 			return nil, fmt.Errorf("empty XML document")
 		}
 		if err != nil {
-			return nil, fmt.Errorf("xml token error: %s", err)
+			return nil, fmt.Errorf("xml token error: %w", err)
 		}
 
 		startElement, ok := token.(xml.StartElement)

--- a/drivers/s3/internal/s3.go
+++ b/drivers/s3/internal/s3.go
@@ -14,6 +14,7 @@ import (
 	"github.com/datazip-inc/olake/pkg/objstorage"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 )
 
@@ -51,14 +52,14 @@ func (s *S3) Type() string {
 func (s *S3) Setup(ctx context.Context) error {
 	// Validate configuration
 	if err := s.config.Validate(); err != nil {
-		return fmt.Errorf("failed to validate config: %s", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	// Compile file pattern regex if provided
 	if s.config.FilePattern != "" {
 		pattern, err := regexp.Compile(s.config.FilePattern)
 		if err != nil {
-			return fmt.Errorf("failed to compile file_pattern regex: %s", err)
+			return fmt.Errorf("failed to compile file_pattern regex: %w", err)
 		}
 		s.filePattern = pattern
 		logger.Infof("Using file pattern filter: %s", s.config.FilePattern)
@@ -80,7 +81,7 @@ func (s *S3) Setup(ctx context.Context) error {
 	// Test connection by checking if bucket exists and is accessible
 	logger.Infof("Testing connection to bucket: %s", s.config.BucketName)
 	if err := s.store.Check(ctx); err != nil {
-		return fmt.Errorf("failed to access bucket %s: %s", s.config.BucketName, err)
+		return fmt.Errorf("failed to access bucket %s: %w", s.config.BucketName, err)
 	}
 
 	logger.Info("Successfully connected to S3")
@@ -152,7 +153,7 @@ func (s *S3) GetStreamNames(ctx context.Context) ([]types.StreamID, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list objects in bucket: %s", err)
+		return nil, fmt.Errorf("failed to list objects in bucket: %w", err)
 	}
 
 	logger.Infof("Completed S3 discovery: discovered %d files", totalDiscovered)
@@ -230,7 +231,8 @@ func (s *S3) ProduceSchema(ctx context.Context, streamID types.StreamID) (*types
 	// Get files for this stream
 	files, exists := s.discoveredFiles[streamID.Name]
 	if !exists || len(files) == 0 {
-		return nil, fmt.Errorf("no files found for stream: %s", streamID.Name)
+		return nil, errs.Precondition(errs.ObjectNotFound, codeNoFilesForStream,
+			fmt.Errorf("no files found for stream: %s", streamID.Name))
 	}
 
 	// Create stream
@@ -254,11 +256,12 @@ func (s *S3) ProduceSchema(ctx context.Context, streamID types.StreamID) (*types
 	case FormatXML:
 		inferredStream, err = s.inferSchemaForXML(ctx, firstFile, stream)
 	default:
-		return nil, fmt.Errorf("unsupported file format: %s", s.config.FileFormat)
+		return nil, errs.Precondition(errs.ConfigInvalid, codeUnsupportedFileFormat,
+			fmt.Errorf("unsupported file format: %s", s.config.FileFormat))
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to infer schema: %s", err)
+		return nil, fmt.Errorf("failed to infer schema: %w", err)
 	}
 
 	// Add _last_modified_time as a cursor field for incremental sync
@@ -274,7 +277,7 @@ func (s *S3) ProduceSchema(ctx context.Context, streamID types.StreamID) (*types
 func (s *S3) withFileReader(ctx context.Context, fileKey string, callback func(io.Reader) (*types.Stream, error)) (*types.Stream, error) {
 	reader, err := s.getFileReader(ctx, fileKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file reader: %s", err)
+		return nil, fmt.Errorf("failed to get file reader: %w", err)
 	}
 	defer reader.Close()
 
@@ -286,7 +289,7 @@ func (s *S3) withFileReader(ctx context.Context, fileKey string, callback func(i
 func (s *S3) withParquetReader(ctx context.Context, fileKey string, fileSize int64, callback func(io.Reader) (*types.Stream, error)) (*types.Stream, error) {
 	parquetReader, parquetSize, err := s.getParquetReaderAt(ctx, fileKey, fileSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Parquet reader: %s", err)
+		return nil, fmt.Errorf("failed to get Parquet reader: %w", err)
 	}
 	defer func() {
 		if closer, ok := parquetReader.(io.Closer); ok {
@@ -344,7 +347,7 @@ func (s *S3) getFileReader(ctx context.Context, key string) (io.ReadCloser, erro
 	reader, err := getDecompressedReader(body, key)
 	if err != nil {
 		body.Close()
-		return nil, fmt.Errorf("failed to create decompressed reader: %s", err)
+		return nil, fmt.Errorf("failed to create decompressed reader: %w", err)
 	}
 
 	return reader, nil
@@ -377,7 +380,7 @@ func (s *S3) getParquetReaderAt(ctx context.Context, key string, fileSize int64)
 
 	data, err := io.ReadAll(body)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to read Parquet file: %s", err)
+		return nil, 0, fmt.Errorf("failed to read Parquet file: %w", err)
 	}
 
 	return bytes.NewReader(data), int64(len(data)), nil
@@ -393,7 +396,7 @@ func getDecompressedReader(body io.ReadCloser, key string) (io.ReadCloser, error
 	if strings.HasSuffix(lowerKey, ".gz") {
 		gzipReader, err := gzip.NewReader(body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create gzip reader: %s", err)
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
 		}
 		logger.Debugf("Using gzip decompression for file: %s", key)
 		// gzip.Reader.Close does not close the underlying body; close both

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect; from staging
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/pkg/binlog/binlog.go
+++ b/pkg/binlog/binlog.go
@@ -68,7 +68,7 @@ func (c *Connection) StreamMessages(ctx context.Context, client *sqlx.DB, latest
 		var err error
 		latestBinlogPos, err = GetCurrentBinlogPosition(ctx, client)
 		if err != nil {
-			return fmt.Errorf("failed to get current binlog position: %s", err)
+			return fmt.Errorf("failed to get current binlog position: %w", err)
 		}
 	}
 
@@ -76,7 +76,7 @@ func (c *Connection) StreamMessages(ctx context.Context, client *sqlx.DB, latest
 
 	streamer, err := c.syncer.StartSync(c.CurrentPos)
 	if err != nil {
-		return fmt.Errorf("failed to start binlog sync: %s", err)
+		return fmt.Errorf("failed to start binlog sync: %w", err)
 	}
 
 	startTime := time.Now()
@@ -104,7 +104,7 @@ func (c *Connection) StreamMessages(ctx context.Context, client *sqlx.DB, latest
 					// Timeout means no event, continue to monitor idle time
 					continue
 				}
-				return fmt.Errorf("failed to get binlog event: %s", err)
+				return fmt.Errorf("failed to get binlog event: %w", err)
 			}
 			// Update current position
 			c.CurrentPos.Pos = ev.Header.LogPos
@@ -147,7 +147,7 @@ func GetCurrentBinlogPosition(ctx context.Context, client *sqlx.DB) (mysql.Posit
 	// Get MySQL version
 	mysqlFlavor, majorVersion, minorVersion, err := jdbc.MySQLVersion(ctx, client)
 	if err != nil {
-		return mysql.Position{}, fmt.Errorf("failed to get MySQL version: %s", err)
+		return mysql.Position{}, fmt.Errorf("failed to get MySQL version: %w", err)
 	}
 
 	// Use the appropriate query based on the MySQL version
@@ -155,7 +155,7 @@ func GetCurrentBinlogPosition(ctx context.Context, client *sqlx.DB) (mysql.Posit
 
 	rows, err := client.QueryContext(ctx, query)
 	if err != nil {
-		return mysql.Position{}, fmt.Errorf("failed to get master status: %s", err)
+		return mysql.Position{}, fmt.Errorf("failed to get master status: %w", err)
 	}
 	defer rows.Close()
 
@@ -170,12 +170,12 @@ func GetCurrentBinlogPosition(ctx context.Context, client *sqlx.DB) (mysql.Posit
 	switch mysqlFlavor {
 	case "MySQL":
 		if err := rows.Scan(&file, &position, &binlogDoDB, &binlogIgnoreDB, &executeGtidSet); err != nil {
-			return mysql.Position{}, fmt.Errorf("failed to scan MySQL binlog position: %s", err)
+			return mysql.Position{}, fmt.Errorf("failed to scan MySQL binlog position: %w", err)
 		}
 	case "MariaDB":
 		// MariaDB returns 4 columns: File, Position, Binlog_Do_DB, Binlog_Ignore_DB
 		if err := rows.Scan(&file, &position, &binlogDoDB, &binlogIgnoreDB); err != nil {
-			return mysql.Position{}, fmt.Errorf("failed to scan MariaDB binlog position: %s", err)
+			return mysql.Position{}, fmt.Errorf("failed to scan MariaDB binlog position: %w", err)
 		}
 	default:
 		return mysql.Position{}, fmt.Errorf("unsupported database flavor: %s", mysqlFlavor)

--- a/pkg/jdbc/jdbc.go
+++ b/pkg/jdbc/jdbc.go
@@ -545,7 +545,7 @@ func MySQLVersion(ctx context.Context, client *sqlx.DB) (string, int, int, error
 	var version string
 	err := client.QueryRowContext(ctx, "SELECT @@version").Scan(&version)
 	if err != nil {
-		return "", 0, 0, fmt.Errorf("failed to get MySQL version: %s", err)
+		return "", 0, 0, fmt.Errorf("failed to get MySQL version: %w", err)
 	}
 
 	parts := strings.Split(version, ".")
@@ -554,12 +554,12 @@ func MySQLVersion(ctx context.Context, client *sqlx.DB) (string, int, int, error
 	}
 	majorVersion, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return "", 0, 0, fmt.Errorf("invalid major version: %s", err)
+		return "", 0, 0, fmt.Errorf("invalid major version: %w", err)
 	}
 
 	minorVersion, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return "", 0, 0, fmt.Errorf("invalid minor version: %s", err)
+		return "", 0, 0, fmt.Errorf("invalid minor version: %w", err)
 	}
 
 	mysqlFlavor := "MySQL"
@@ -576,7 +576,7 @@ func WithIsolation(ctx context.Context, client *sqlx.DB, readOnly bool, fn func(
 		ReadOnly:  readOnly,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %s", err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() {
 		if rerr := tx.Rollback(); rerr != nil && rerr != sql.ErrTxDone {
@@ -1195,13 +1195,13 @@ func IncrementalValueFormatter(ctx context.Context, cursorField, argumentPlaceho
 	// remove cursorField conversion to lower case once column normalization is based on writer side
 	datatype, err := stream.Self().Stream.Schema.GetType(cursorField)
 	if err != nil {
-		return "", nil, fmt.Errorf("cursor field %s not found in schema: %s", cursorField, err)
+		return "", nil, fmt.Errorf("cursor field %s not found in schema: %w", cursorField, err)
 	}
 
 	isTimestamp := strings.Contains(string(datatype), "timestamp")
 	formattedValue, err := typeutils.ReformatValue(datatype, lastCursorValue)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to reformat value %v of type %T: %s", lastCursorValue, lastCursorValue, err)
+		return "", nil, fmt.Errorf("failed to reformat value %v of type %T: %w", lastCursorValue, lastCursorValue, err)
 	}
 
 	quotedCol := QuoteIdentifier(cursorField, opts.Driver)
@@ -1215,7 +1215,7 @@ func IncrementalValueFormatter(ctx context.Context, cursorField, argumentPlaceho
 		query := OracleColumnDataTypeQuery(stream.Namespace(), stream.Name(), cursorField)
 		err = opts.Client.QueryRowContext(ctx, query).Scan(&dbDatatype)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to get column datatype: %s", err)
+			return "", nil, fmt.Errorf("failed to get column datatype: %w", err)
 		}
 		// if the cursor field is a timestamp and not timezone aware, we need to cast the value as timestamp
 		if isTimestamp && !strings.Contains(dbDatatype, "TIME ZONE") {
@@ -1225,7 +1225,7 @@ func IncrementalValueFormatter(ctx context.Context, cursorField, argumentPlaceho
 		query := "SELECT TYPENAME FROM SYSCAT.COLUMNS WHERE TABSCHEMA = ? AND TABNAME = ? AND COLNAME = ?"
 		err = opts.Client.QueryRowContext(ctx, query, stream.Namespace(), stream.Name(), cursorField).Scan(&dbDatatype)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to get db2 column datatype: %s", err)
+			return "", nil, fmt.Errorf("failed to get db2 column datatype: %w", err)
 		}
 
 		if isTimestamp && strings.Contains(strings.ToUpper(dbDatatype), "TIMESTAMP") {
@@ -1262,7 +1262,7 @@ func SQLFilter(stream types.StreamInterface, driver string, thresholdFilter stri
 
 	filter, isLegacy, err := stream.GetFilter()
 	if err != nil {
-		return "", fmt.Errorf("failed to parse stream filter: %s", err)
+		return "", fmt.Errorf("failed to parse stream filter: %w", err)
 	}
 
 	formatFilterBoolValue := func(driverType constants.DriverType, value bool) string {
@@ -1425,7 +1425,7 @@ func BuildIncrementalQuery(ctx context.Context, opts DriverOptions) (string, []a
 	// Build primary cursor condition
 	incrementalCondition, primaryArg, err := buildCursorCondition(primaryCursor, lastPrimaryCursorValue, 1)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to format primary cursor value: %s", err)
+		return "", nil, fmt.Errorf("failed to format primary cursor value: %w", err)
 	}
 	queryArgs := []any{primaryArg}
 
@@ -1433,7 +1433,7 @@ func BuildIncrementalQuery(ctx context.Context, opts DriverOptions) (string, []a
 	if secondaryCursor != "" && lastSecondaryCursorValue != nil {
 		secondaryCondition, secondaryArg, err := buildCursorCondition(secondaryCursor, lastSecondaryCursorValue, 2)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to format secondary cursor value: %s", err)
+			return "", nil, fmt.Errorf("failed to format secondary cursor value: %w", err)
 		}
 		quotedPrimaryCursor := QuoteIdentifier(primaryCursor, opts.Driver)
 		incrementalCondition = fmt.Sprintf("%s OR (%s IS NULL AND %s)",
@@ -1475,13 +1475,13 @@ func GetMaxCursorValues(ctx context.Context, client *sqlx.DB, driverType constan
 	if secondaryCursor != "" {
 		err := client.QueryRowContext(ctx, cursorValueQuery).Scan(&maxPrimaryCursorValue, &maxSecondaryCursorValue)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to scan the cursor values: %s", err)
+			return nil, nil, fmt.Errorf("failed to scan the cursor values: %w", err)
 		}
 		maxSecondaryCursorValue = bytesConverter(maxSecondaryCursorValue)
 	} else {
 		err := client.QueryRowContext(ctx, cursorValueQuery).Scan(&maxPrimaryCursorValue)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to scan primary cursor value: %s", err)
+			return nil, nil, fmt.Errorf("failed to scan primary cursor value: %w", err)
 		}
 	}
 	return bytesConverter(maxPrimaryCursorValue), maxSecondaryCursorValue, nil
@@ -1507,7 +1507,7 @@ func ThresholdFilter(ctx context.Context, opts DriverOptions) (string, []any, er
 
 	thresholdFilter, argument, err := createThresholdCondition(1, primaryCursor, primaryCursorValue)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to format primary cursor value: %s", err)
+		return "", nil, fmt.Errorf("failed to format primary cursor value: %w", err)
 	}
 	// IS NULL condition is required to handle the case where cursor value is NULL for some rows.
 	// Some driver will avoid returning such rows when <= condition is used.
@@ -1517,7 +1517,7 @@ func ThresholdFilter(ctx context.Context, opts DriverOptions) (string, []any, er
 		secondaryCursorValue := opts.State.GetCursor(opts.Stream.Self(), secondaryCursor)
 		secondaryCondition, argument, err := createThresholdCondition(2, secondaryCursor, secondaryCursorValue)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to format secondary cursor value: %s", err)
+			return "", nil, fmt.Errorf("failed to format secondary cursor value: %w", err)
 		}
 		thresholdFilter = fmt.Sprintf("%s AND (%s IS NULL OR %s)", thresholdFilter, QuoteIdentifier(secondaryCursor, opts.Driver), secondaryCondition)
 		arguments = append(arguments, argument)

--- a/pkg/jdbc/reader.go
+++ b/pkg/jdbc/reader.go
@@ -209,7 +209,7 @@ func MapScanConcurrent(setter *Reader[*sql.Rows], converter func(value interface
 
 				conv, err := normalizeDataTypeAndConvert(rawData, colTypes[i], converter)
 				if err != nil {
-					return fmt.Errorf("failed to convert value for column %s: %s", col, err)
+					return fmt.Errorf("failed to convert value for column %s: %w", col, err)
 				}
 				record[col] = conv
 			}

--- a/pkg/kafka/reader.go
+++ b/pkg/kafka/reader.go
@@ -33,7 +33,7 @@ func (r *ReaderManager) CreateReaders(ctx context.Context, streams []types.Strea
 
 		partitionsMetadata, err := r.PartitionsForStream(ctx, stream)
 		if err != nil {
-			return fmt.Errorf("failed to get partitions for stream %s: %s", stream.ID(), err)
+			return fmt.Errorf("failed to get partitions for stream %s: %w", stream.ID(), err)
 		}
 		for key, meta := range partitionsMetadata {
 			r.partitionMeta[key] = meta
@@ -57,7 +57,7 @@ func (r *ReaderManager) CreateReaders(ctx context.Context, streams []types.Strea
 		// create reader (rebalance callbacks disabled during initial reader creation and partition assignment)
 		reader, err := r.CreateReader(readerID, clientID, false)
 		if err != nil {
-			return fmt.Errorf("failed to create reader %d: %s", readerIndex, err)
+			return fmt.Errorf("failed to create reader %d: %w", readerIndex, err)
 		}
 
 		// add reader to manager
@@ -103,18 +103,18 @@ func (r *ReaderManager) PartitionsForStream(ctx context.Context, stream types.St
 	topic := stream.Name()
 	topicDetail, topicDetailErr := r.GetTopicMetadata(ctx, topic)
 	if topicDetailErr != nil {
-		return nil, fmt.Errorf("failed to fetch topic metadata for topic %s: %s", topic, topicDetailErr)
+		return nil, fmt.Errorf("failed to fetch topic metadata for topic %s: %w", topic, topicDetailErr)
 	}
 
 	startOffsets, endOffsets, listOffsetsErr := r.ListTopicOffsets(ctx, topic)
 	if listOffsetsErr != nil {
-		return nil, fmt.Errorf("failed to list offsets for topic %s: %s", topic, listOffsetsErr)
+		return nil, fmt.Errorf("failed to list offsets for topic %s: %w", topic, listOffsetsErr)
 	}
 
 	// fetch already committed offset of partition
 	committedTopicOffsets, committedOffsetsErr := r.FetchCommittedOffsets(ctx, topic)
 	if committedOffsetsErr != nil {
-		return nil, fmt.Errorf("failed to fetch committed offsets for topic %s: %s", topic, committedOffsetsErr)
+		return nil, fmt.Errorf("failed to fetch committed offsets for topic %s: %w", topic, committedOffsetsErr)
 	}
 
 	partitionsMetadata := make(map[string]types.PartitionMetaData)
@@ -160,12 +160,12 @@ func PartitionMetadataKey(topic string, partition int32) string {
 func (r *ReaderManager) ListTopicOffsets(ctx context.Context, topic string) (kadm.ListedOffsets, kadm.ListedOffsets, error) {
 	startOffsets, err := r.config.AdminClient.ListStartOffsets(ctx, topic)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list start offsets for topic %s: %s", topic, err)
+		return nil, nil, fmt.Errorf("failed to list start offsets for topic %s: %w", topic, err)
 	}
 
 	endOffsets, err := r.config.AdminClient.ListEndOffsets(ctx, topic)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list end offsets for topic %s: %s", topic, err)
+		return nil, nil, fmt.Errorf("failed to list end offsets for topic %s: %w", topic, err)
 	}
 
 	return startOffsets, endOffsets, nil
@@ -192,7 +192,7 @@ func (r *ReaderManager) GetPartitionOffsets(startOffsets, endOffsets kadm.Listed
 func (r *ReaderManager) GetTopicMetadata(ctx context.Context, topic string) (*kadm.TopicDetail, error) {
 	metadata, err := r.config.AdminClient.ListTopics(ctx, topic)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch topic metadata for topic %s: %s", topic, err)
+		return nil, fmt.Errorf("failed to fetch topic metadata for topic %s: %w", topic, err)
 	}
 
 	topicDetail, exists := metadata[topic]
@@ -206,7 +206,7 @@ func (r *ReaderManager) GetTopicMetadata(ctx context.Context, topic string) (*ka
 func (r *ReaderManager) FetchCommittedOffsets(ctx context.Context, topic string) (map[int32]int64, error) {
 	offsets, err := r.config.AdminClient.FetchOffsetsForTopics(ctx, r.config.ConsumerGroupID, topic)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch committed offsets for group %s topic %s: %s", r.config.ConsumerGroupID, topic, err)
+		return nil, fmt.Errorf("failed to fetch committed offsets for group %s topic %s: %w", r.config.ConsumerGroupID, topic, err)
 	}
 
 	committedTopicOffsets := make(map[int32]int64, len(offsets[topic]))
@@ -232,14 +232,14 @@ func (r *ReaderManager) RemoveExistingConsumers(ctx context.Context, client *kgo
 		}
 		select {
 		case <-cleanupCtx.Done():
-			return fmt.Errorf("describe groups failed: %s", describeErr)
+			return fmt.Errorf("describe groups failed: %w", describeErr)
 		case <-time.After(2 * time.Second):
 		}
 	}
 
 	describedGroup := describedGroups[r.config.ConsumerGroupID]
 	if describedGroup.Err != nil && describedGroup.Err != kerr.GroupIDNotFound {
-		return fmt.Errorf("describe groups error: %s", describedGroup.Err)
+		return fmt.Errorf("describe groups error: %w", describedGroup.Err)
 	}
 
 	if len(describedGroup.Members) > 0 {
@@ -255,7 +255,7 @@ func (r *ReaderManager) RemoveExistingConsumers(ctx context.Context, client *kgo
 
 		leaveGroupResponse, leaveGroupResponseErr := leaveGroupRequest.RequestWith(cleanupCtx, client)
 		if leaveGroupResponseErr != nil {
-			return fmt.Errorf("leave group request failed: %s", leaveGroupResponseErr)
+			return fmt.Errorf("leave group request failed: %w", leaveGroupResponseErr)
 		}
 
 		if leaveGroupResponse.ErrorCode != 0 {
@@ -283,7 +283,7 @@ func (r *ReaderManager) RestartReader(readerIndex int) (*kgo.Client, error) {
 
 	newReader, err := r.CreateReader(readerID, clientID, true)
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to recreate kafka reader %d after close: %s", constants.ErrNonRetryable, readerIndex, err)
+		return nil, fmt.Errorf("%w: failed to recreate kafka reader %d after close: %w", constants.ErrNonRetryable, readerIndex, err)
 	}
 
 	r.readers[readerIndex].reader = newReader

--- a/pkg/kafka/schema_registry.go
+++ b/pkg/kafka/schema_registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/typeutils"
 	"github.com/linkedin/goavro/v2"
 )
@@ -26,7 +27,7 @@ func (c *SchemaRegistryClient) schemaRegistryGetRequest(path string) (*http.Resp
 	url := fmt.Sprintf("%s%s", c.Endpoint, path)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %s", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	// Set authentication headers (bearer token takes priority over basic auth)
@@ -51,12 +52,13 @@ func (c *SchemaRegistryClient) FetchSchema(schemaID uint32) (*types.RegisteredSc
 	// fetch schema from registry
 	resp, err := c.schemaRegistryGetRequest(fmt.Sprintf("/schemas/ids/%d", schemaID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch schema: %s", err)
+		return nil, fmt.Errorf("failed to fetch schema: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("schema registry returned status %d for schema ID %d", resp.StatusCode, schemaID)
+		return nil, registryStatusFailure(resp.StatusCode,
+			fmt.Errorf("schema registry returned status %d for schema ID %d", resp.StatusCode, schemaID))
 	}
 
 	var schemaResp struct {
@@ -64,7 +66,7 @@ func (c *SchemaRegistryClient) FetchSchema(schemaID uint32) (*types.RegisteredSc
 		SchemaType string `json:"schemaType"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&schemaResp); err != nil {
-		return nil, fmt.Errorf("failed to decode schema response: %s", err)
+		return nil, fmt.Errorf("failed to decode schema response: %w", err)
 	}
 
 	// determine schema type
@@ -81,11 +83,11 @@ func (c *SchemaRegistryClient) FetchSchema(schemaID uint32) (*types.RegisteredSc
 	if schemaType == types.SchemaTypeAvro {
 		normalizedSchema, err := typeutils.NormalizeAvroSchema(schemaResp.Schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize schema ID %d: %s", schemaID, err)
+			return nil, fmt.Errorf("failed to normalize schema ID %d: %w", schemaID, err)
 		}
 		codec, err := goavro.NewCodec(normalizedSchema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create Avro codec for schema ID %d: %s", schemaID, err)
+			return nil, fmt.Errorf("failed to create Avro codec for schema ID %d: %w", schemaID, err)
 		}
 		registered.Codec = codec
 	}
@@ -99,19 +101,52 @@ func (c *SchemaRegistryClient) FetchSchema(schemaID uint32) (*types.RegisteredSc
 func (c *SchemaRegistryClient) Validate() error {
 	resp, err := c.schemaRegistryGetRequest("/subjects")
 	if err != nil {
-		return fmt.Errorf("failed to connect to schema registry: %s", err)
+		return fmt.Errorf("failed to connect to schema registry: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("schema registry authentication failed: invalid credentials")
+		return registryStatusFailure(resp.StatusCode,
+			fmt.Errorf("schema registry authentication failed: invalid credentials"))
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("schema registry authentication failed: access forbidden")
+		return registryStatusFailure(resp.StatusCode,
+			fmt.Errorf("schema registry authentication failed: access forbidden"))
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("schema registry returned unexpected status: %d", resp.StatusCode)
+		return registryStatusFailure(resp.StatusCode,
+			fmt.Errorf("schema registry returned unexpected status: %d", resp.StatusCode))
 	}
 
 	return nil
+}
+
+// registryStatusFailure classifies a schema-registry response by its HTTP status. The registry
+// is plain HTTP with no typed errors, and the status is gone by the time the error reaches the
+// command, so it is classified here rather than in the driver. Unmapped statuses pass through.
+func registryStatusFailure(status int, err error) error {
+	var category errs.Category
+	switch {
+	case status == http.StatusUnauthorized:
+		category = errs.AuthFailed
+	case status == http.StatusForbidden:
+		category = errs.PermissionDenied
+	case status == http.StatusNotFound:
+		category = errs.ObjectNotFound
+	case status == http.StatusRequestTimeout:
+		category = errs.Timeout
+	case status == http.StatusTooManyRequests:
+		category = errs.ResourceExhausted
+	case status >= 500:
+		category = errs.NetworkUnreachable
+	default:
+		return err
+	}
+	return errs.Attach(err, errs.Failure{
+		Category:     category,
+		ClassifiedBy: errs.ClassifiedByVendor,
+		// Prefixed so it cannot be read as a Kafka protocol code, which is a bare number in
+		// the same telemetry field.
+		Code: fmt.Sprintf("schema_registry.http_%d", status),
+	})
 }

--- a/pkg/objstorage/errors.go
+++ b/pkg/objstorage/errors.go
@@ -1,0 +1,77 @@
+package objstorage
+
+import "github.com/datazip-inc/olake/utils/errs"
+
+// ServiceCodeCategories maps the error code S3 returns to a failure category. The code is the
+// service's own identifier, reported unchanged:
+// https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+//
+// Shared by all three components that reach S3 — the source (SDK v2), the parquet destination
+// (SDK v1) and the Iceberg JVM — and by S3-compatible services, which answer with the same codes.
+var ServiceCodeCategories = map[string]errs.Category{
+	// Nobody the service recognizes signed the request.
+	"InvalidAccessKeyId":    errs.AuthFailed,
+	"SignatureDoesNotMatch": errs.AuthFailed,
+	"InvalidSecurity":       errs.AuthFailed,
+	"ExpiredToken":          errs.AuthFailed,
+	"InvalidToken":          errs.AuthFailed,
+	"TokenRefreshRequired":  errs.AuthFailed,
+
+	// The identity is known; the policy says no.
+	"AccessDenied":      errs.PermissionDenied,
+	"AllAccessDisabled": errs.PermissionDenied,
+	"Forbidden":         errs.PermissionDenied, // HeadBucket answers 403 with no body
+
+	"NoSuchBucket": errs.ObjectNotFound,
+	"NoSuchKey":    errs.ObjectNotFound,
+	"NotFound":     errs.ObjectNotFound, // HeadBucket answers 404 with no body
+
+	// Wrong endpoint for this bucket, or an illegal name. Both are fixed in the config.
+	"PermanentRedirect":                  errs.ConfigInvalid,
+	"AuthorizationHeaderMalformed":       errs.ConfigInvalid,
+	"IllegalLocationConstraintException": errs.ConfigInvalid,
+	"InvalidBucketName":                  errs.ConfigInvalid,
+
+	// Throttled, not broken.
+	"SlowDown":             errs.ResourceExhausted,
+	"RequestLimitExceeded": errs.ResourceExhausted,
+	"ThrottlingException":  errs.ResourceExhausted,
+
+	// The service itself is down or erroring.
+	"ServiceUnavailable": errs.NetworkUnreachable,
+	"InternalError":      errs.NetworkUnreachable,
+
+	"RequestTimeout": errs.Timeout,
+
+	// Account-wide codes, returned by any AWS service rather than by S3. A Glue or Lake Formation
+	// catalog reports credential failures with these, under a base *Exception class that names
+	// nothing on its own.
+	"UnrecognizedClientException": errs.AuthFailed, // the security token is not valid
+	"InvalidClientTokenId":        errs.AuthFailed,
+	"ExpiredTokenException":       errs.AuthFailed,
+	"IncompleteSignature":         errs.AuthFailed,
+	"MissingAuthenticationToken":  errs.AuthFailed,
+	"AuthFailure":                 errs.AuthFailed,
+	"AccessDeniedException":       errs.PermissionDenied,
+	"EntityNotFoundException":     errs.ObjectNotFound, // Glue: no such database or table
+
+	// Glue catalog codes, returned under GlueException or as a dedicated SDK class.
+	"ConcurrentModificationException":      errs.ConcurrencyConflict,
+	"InvalidInputException":                errs.ConfigInvalid,
+	"InternalServiceException":             errs.NetworkUnreachable,
+	"InternalServerException":              errs.NetworkUnreachable,
+	"OperationTimeoutException":            errs.Timeout,
+	"ResourceNumberLimitExceededException": errs.ResourceExhausted,
+	"VersionMismatchException":             errs.ConcurrencyConflict,
+	"AlreadyExistsException":               errs.CatalogError,
+	"GlueEncryptionException":              errs.PermissionDenied,
+	"OperationNotSupportedException":       errs.UnsupportedFeature,
+	"ResourceNotFoundException":            errs.ObjectNotFound,
+	"ValidationException":                  errs.ConfigInvalid,
+
+	// SDK v1 only: raised before any request leaves the process, so no HTTP status, no v2 twin.
+	"NoCredentialProviders": errs.AuthFailed,    // the credential chain found nothing
+	"MissingRegion":         errs.ConfigInvalid, // no region configured or inferable
+	"MissingEndpoint":       errs.ConfigInvalid,
+	"RequestCanceled":       errs.Canceled,
+}

--- a/pkg/objstorage/reader_at.go
+++ b/pkg/objstorage/reader_at.go
@@ -52,7 +52,7 @@ func (r *ReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 
 	body, err := r.store.OpenRange(r.ctx, r.key, off, endByte-off+1)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read range bytes=%d-%d: %s", off, endByte, err)
+		return 0, fmt.Errorf("failed to read range bytes=%d-%d: %w", off, endByte, err)
 	}
 	defer body.Close()
 
@@ -73,7 +73,7 @@ func (r *ReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		}
 
 		if err != nil {
-			return totalRead, fmt.Errorf("failed to read response body: %s", err)
+			return totalRead, fmt.Errorf("failed to read response body: %w", err)
 		}
 	}
 

--- a/pkg/objstorage/s3.go
+++ b/pkg/objstorage/s3.go
@@ -55,7 +55,7 @@ func NewS3Store(ctx context.Context, cfg S3Config) (Store, error) {
 
 	awsCfg, err := config.LoadDefaultConfig(ctx, configOpts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config: %s", err)
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
 	var client *s3.Client
@@ -173,13 +173,13 @@ func wrapNotFound(err error) error {
 	if errors.As(err, &apiErr) {
 		code := apiErr.ErrorCode()
 		if code == "NoSuchKey" || code == "NotFound" {
-			return fmt.Errorf("%w: %s", ErrNotFound, err)
+			return fmt.Errorf("%w: %w", ErrNotFound, err)
 		}
 	}
 	// Fallback for S3-compatible services whose not-found surfaces without a
 	// typed API error code
 	if strings.Contains(err.Error(), "NoSuchKey") || strings.Contains(err.Error(), "NotFound") {
-		return fmt.Errorf("%w: %s", ErrNotFound, err)
+		return fmt.Errorf("%w: %w", ErrNotFound, err)
 	}
 	return err
 }

--- a/pkg/waljs/filter.go
+++ b/pkg/waljs/filter.go
@@ -33,11 +33,11 @@ func NewChangeFilter(typeConverter func(value interface{}, columnType string) (i
 func (c ChangeFilter) FilterWalJsChange(ctx context.Context, change []byte, OnFiltered abstract.CDCMsgFn) (*pglogrepl.LSN, int, error) {
 	var changes WALMessage
 	if err := json.NewDecoder(bytes.NewReader(change)).Decode(&changes); err != nil {
-		return nil, 0, fmt.Errorf("failed to parse change received from wal logs: %s", err)
+		return nil, 0, fmt.Errorf("failed to parse change received from wal logs: %w", err)
 	}
 	nextLSN, err := pglogrepl.ParseLSN(changes.NextLSN)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to parse received lsn: %s", err)
+		return nil, 0, fmt.Errorf("failed to parse received lsn: %w", err)
 	}
 
 	if len(changes.Change) == 0 {
@@ -72,13 +72,13 @@ func (c ChangeFilter) FilterWalJsChange(ctx context.Context, change []byte, OnFi
 		}
 
 		if err != nil {
-			return nil, rowsCount, fmt.Errorf("failed to convert change data: %s", err)
+			return nil, rowsCount, fmt.Errorf("failed to convert change data: %w", err)
 		}
 
 		// Deprecated wal2json path: bytes not tracked, pgoutput is the supported replicator.
 		if err := OnFiltered(ctx, abstract.NewCDCChange(stream, changes.Timestamp.Time, ch.Kind, changesMap,
 			map[string]any{CDCLSN: changes.NextLSN}, 0)); err != nil {
-			return nil, rowsCount, fmt.Errorf("failed to write filtered change: %s", err)
+			return nil, rowsCount, fmt.Errorf("failed to write filtered change: %w", err)
 		}
 	}
 	return &nextLSN, rowsCount, nil

--- a/pkg/waljs/pgoutput.go
+++ b/pkg/waljs/pgoutput.go
@@ -37,7 +37,7 @@ func (p *pgoutputReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, ins
 	err := pglogrepl.StartReplication(ctx, p.socket.pgConn, fmt.Sprintf("%q", p.socket.ReplicationSlot), p.socket.ConfirmedFlushLSN, pglogrepl.StartReplicationOptions{
 		PluginArgs: []string{"proto_version '1'", fmt.Sprintf("publication_names '%s'", p.publication)}})
 	if err != nil {
-		return fmt.Errorf("failed to start replication: %v", err)
+		return fmt.Errorf("failed to start replication: %w", err)
 	}
 
 	logger.Infof("pgoutput starting from lsn=%s target=%s", p.socket.ConfirmedFlushLSN, p.socket.CurrentWalPosition)
@@ -85,7 +85,7 @@ func (p *pgoutputReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, ins
 			case pglogrepl.XLogDataByteID:
 				xld, err := pglogrepl.ParseXLogData(copyData.Data[1:])
 				if err != nil {
-					return fmt.Errorf("failed to parse XLogData: %v", err)
+					return fmt.Errorf("failed to parse XLogData: %w", err)
 				}
 				p.socket.ClientXLogPos = xld.WALStart
 				if err := p.processPgoutputWAL(ctx, xld.WALData, insertFn); err != nil {
@@ -95,12 +95,12 @@ func (p *pgoutputReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, ins
 			case pglogrepl.PrimaryKeepaliveMessageByteID:
 				pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(copyData.Data[1:])
 				if err != nil {
-					return fmt.Errorf("failed to parse primary keepalive message: %v", err)
+					return fmt.Errorf("failed to parse primary keepalive message: %w", err)
 				}
 				p.socket.ClientXLogPos = pkm.ServerWALEnd
 				if pkm.ReplyRequested {
 					if err := AcknowledgeLSN(ctx, db, p.socket, true); err != nil {
-						return fmt.Errorf("failed to send standby status update: %v", err)
+						return fmt.Errorf("failed to send standby status update: %w", err)
 					}
 				}
 			default:
@@ -114,7 +114,7 @@ func (p *pgoutputReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, ins
 func (p *pgoutputReplicator) processPgoutputWAL(ctx context.Context, walData []byte, insertFn abstract.CDCMsgFn) error {
 	logicalMsg, err := pglogrepl.Parse(walData)
 	if err != nil {
-		return fmt.Errorf("failed to parse WAL data: %v", err)
+		return fmt.Errorf("failed to parse WAL data: %w", err)
 	}
 
 	switch msg := logicalMsg.(type) {

--- a/pkg/waljs/replicator.go
+++ b/pkg/waljs/replicator.go
@@ -62,7 +62,7 @@ func NewReplicator(ctx context.Context, config *Config, slot ReplicationSlot, re
 
 	cfg, err := pgconn.ParseConfig(connURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse connection url: %s", err)
+		return nil, fmt.Errorf("failed to parse connection url: %w", err)
 	}
 
 	if config.SSHClient != nil {
@@ -91,13 +91,13 @@ func NewReplicator(ctx context.Context, config *Config, slot ReplicationSlot, re
 	// Establish PostgreSQL connection
 	pgConn, err := pgconn.ConnectConfig(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create postgres connection: %s", err)
+		return nil, fmt.Errorf("failed to create postgres connection: %w", err)
 	}
 
 	// System identification
 	sysident, err := pglogrepl.IdentifySystem(ctx, pgConn)
 	if err != nil {
-		return nil, fmt.Errorf("failed to indentify system: %s", err)
+		return nil, fmt.Errorf("failed to indentify system: %w", err)
 	}
 	logger.Infof("SystemID:%s Timeline:%d XLogPos:%s Database:%s",
 		sysident.SystemID, sysident.Timeline, sysident.XLogPos, sysident.DBName)
@@ -134,7 +134,7 @@ func NewReplicator(ctx context.Context, config *Config, slot ReplicationSlot, re
 func AdvanceLSN(ctx context.Context, db *sqlx.DB, slot, currentWalPos string) error {
 	// Get replication slot position
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(AdvanceLSNTemplate, slot, currentWalPos)); err != nil {
-		return fmt.Errorf("failed to advance replication slot: %s", err)
+		return fmt.Errorf("failed to advance replication slot: %w", err)
 	}
 	logger.Debugf("advanced LSN to %s", currentWalPos)
 	return nil
@@ -151,7 +151,7 @@ func AcknowledgeLSN(ctx context.Context, db *sqlx.DB, socket *Socket, fakeAck bo
 		ReplyRequested:   false,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to send standby status message on wal position[%s]: %s", walPosition.String(), err)
+		return fmt.Errorf("failed to send standby status message on wal position[%s]: %w", walPosition.String(), err)
 	}
 
 	logger.Debugf("sent standby status message at LSN#%s", walPosition.String())
@@ -176,7 +176,7 @@ func AcknowledgeLSN(ctx context.Context, db *sqlx.DB, socket *Socket, fakeAck bo
 		case <-ticker.C:
 			slot, err := GetSlotPosition(ctx, db, socket.ReplicationSlot)
 			if err != nil {
-				return fmt.Errorf("failed to get slot position: %s", err)
+				return fmt.Errorf("failed to get slot position: %w", err)
 			}
 
 			if slot.LSN == walPosition {

--- a/pkg/waljs/waljs.go
+++ b/pkg/waljs/waljs.go
@@ -46,7 +46,7 @@ func (w *wal2jsonReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, cal
 		w.socket.ConfirmedFlushLSN,
 		pglogrepl.StartReplicationOptions{PluginArgs: pluginArguments},
 	); err != nil {
-		return fmt.Errorf("starting replication slot failed: %s", err)
+		return fmt.Errorf("starting replication slot failed: %w", err)
 	}
 	logger.Infof("Started logical replication for slot[%s] from lsn[%s] to lsn[%s]", w.socket.ReplicationSlot, w.socket.ConfirmedFlushLSN, w.socket.CurrentWalPosition)
 	messageReceived := false
@@ -70,7 +70,7 @@ func (w *wal2jsonReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, cal
 				if strings.Contains(err.Error(), "EOF") {
 					return nil
 				}
-				return fmt.Errorf("failed to receive message from wal logs: %s", err)
+				return fmt.Errorf("failed to receive message from wal logs: %w", err)
 			}
 
 			// Process only CopyData messages.
@@ -84,7 +84,7 @@ func (w *wal2jsonReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, cal
 				// For keepalive messages, process them (but no ack is sent here).
 				pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(copyData.Data[1:])
 				if err != nil {
-					return fmt.Errorf("failed to parse primary keepalive message: %s", err)
+					return fmt.Errorf("failed to parse primary keepalive message: %w", err)
 				}
 				w.socket.ClientXLogPos = pkm.ServerWALEnd
 				if pkm.ReplyRequested {
@@ -92,19 +92,19 @@ func (w *wal2jsonReplicator) StreamChanges(ctx context.Context, db *sqlx.DB, cal
 					// send fake acknowledgement
 					err := AcknowledgeLSN(ctx, db, w.socket, true)
 					if err != nil {
-						return fmt.Errorf("failed to ack lsn: %s", err)
+						return fmt.Errorf("failed to ack lsn: %w", err)
 					}
 				}
 			case pglogrepl.XLogDataByteID:
 				// Reset the idle timer on receiving WAL data.
 				xld, err := pglogrepl.ParseXLogData(copyData.Data[1:])
 				if err != nil {
-					return fmt.Errorf("failed to parse XLogData: %s", err)
+					return fmt.Errorf("failed to parse XLogData: %w", err)
 				}
 				// Process change with the provided callback.
 				nextLSN, records, err := w.socket.changeFilter.FilterWalJsChange(ctx, xld.WALData, callback)
 				if err != nil {
-					return fmt.Errorf("failed to filter change: %s", err)
+					return fmt.Errorf("failed to filter change: %w", err)
 				}
 				messageReceived = records > 0 || messageReceived
 				w.socket.ClientXLogPos = *nextLSN

--- a/protocol/check.go
+++ b/protocol/check.go
@@ -7,6 +7,7 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,8 @@ var checkCmd = &cobra.Command{
 	PreRunE: func(_ *cobra.Command, _ []string) error {
 		// If connector is not set, we are checking the destination
 		if destinationConfigPath == "not-set" && configPath == "not-set" {
-			return fmt.Errorf("no connector config or destination config provided")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing,
+				fmt.Errorf("no connector config or destination config provided"))
 		}
 
 		// check for destination config

--- a/protocol/clear.go
+++ b/protocol/clear.go
@@ -6,6 +6,7 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/spf13/cobra"
 )
@@ -15,9 +16,9 @@ var clearCmd = &cobra.Command{
 	Short: "Olake clear command to clear destination data and state for selected streams",
 	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		if destinationConfigPath == "" {
-			return fmt.Errorf("--destination not passed")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing, fmt.Errorf("--destination not passed"))
 		} else if streamsPath == "" {
-			return fmt.Errorf("--streams not passed")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing, fmt.Errorf("--streams not passed"))
 		}
 
 		destinationConfig = &types.WriterConfig{}
@@ -43,7 +44,7 @@ var clearCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		selectedStreamsMetadata, err := classifyStreams(catalog, nil, state)
 		if err != nil {
-			return fmt.Errorf("failed to get selected streams for clearing: %s", err)
+			return fmt.Errorf("failed to get selected streams for clearing: %w", err)
 		}
 		dropStreams := []types.StreamInterface{}
 		dropStreams = append(dropStreams, append(append(selectedStreamsMetadata.IncrementalStreams, selectedStreamsMetadata.FullLoadStreams...), selectedStreamsMetadata.CDCStreams...)...)
@@ -56,14 +57,14 @@ var clearCmd = &cobra.Command{
 		// clear state for selected streams
 		newState, err := connector.ClearState(dropStreams)
 		if err != nil {
-			return fmt.Errorf("error clearing state: %s", err)
+			return fmt.Errorf("error clearing state: %w", err)
 		}
 		logger.Infof("State for selected streams cleared successfully.")
 		// Setup new state after clear for connector
 		connector.SetupState(newState)
 
 		if cerr := destination.DropStreams(cmd.Context(), destinationConfig, dropStreams); cerr != nil {
-			return fmt.Errorf("failed to clear destination: %s", cerr)
+			return fmt.Errorf("failed to clear destination: %w", cerr)
 		}
 		logger.Infof("Successfully cleared destination data for selected streams.")
 		// save new state in state file

--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -9,6 +9,7 @@ import (
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/telemetry"
 	"github.com/datazip-inc/olake/utils/version"
@@ -24,7 +25,7 @@ var discoverCmd = &cobra.Command{
 			return nil
 		}
 		if configPath == "" {
-			return fmt.Errorf("--config not passed")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing, fmt.Errorf("--config not passed"))
 		}
 
 		if err := utils.UnmarshalFile(configPath, connector.GetConfigRef(), true); err != nil {
@@ -34,7 +35,7 @@ var discoverCmd = &cobra.Command{
 		viper.Set(constants.DestinationDatabasePrefix, destinationDatabasePrefix)
 		if streamsPath != "" {
 			if err := utils.UnmarshalFile(streamsPath, &catalog, false); err != nil {
-				return fmt.Errorf("failed to read streams from %s: %s", streamsPath, err)
+				return fmt.Errorf("failed to read streams from %s: %w", streamsPath, err)
 			}
 		}
 
@@ -85,18 +86,18 @@ var discoverCmd = &cobra.Command{
 func compareStreams() error {
 	var oldStreams, newStreams types.Catalog
 	if serr := utils.UnmarshalFile(streamsPath, &oldStreams, false); serr != nil {
-		return fmt.Errorf("failed to read old catalog: %s", serr)
+		return fmt.Errorf("failed to read old catalog: %w", serr)
 	}
 
 	if derr := utils.UnmarshalFile(differencePath, &newStreams, false); derr != nil {
-		return fmt.Errorf("failed to read new catalog: %s", derr)
+		return fmt.Errorf("failed to read new catalog: %w", derr)
 	}
 
 	diffCatalog := types.GetStreamsDelta(&oldStreams, &newStreams)
 	// log the difference catalog to stdout
 
 	if err := logger.FileLoggerWithPath(diffCatalog, viper.GetString(constants.DifferencePath)); err != nil {
-		return fmt.Errorf("failed to write difference streams: %s", err)
+		return fmt.Errorf("failed to write difference streams: %w", err)
 	}
 	logger.Infof("Successfully wrote stream differences")
 	message := types.Message{

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/datazip-inc/olake/drivers/abstract"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/telemetry"
 	"github.com/spf13/cobra"
@@ -153,4 +154,63 @@ func init() {
 	if err != nil {
 		logger.Fatal(err)
 	}
+}
+
+const (
+	// Codes for conditions the CLI detects itself, before any connector is reached.
+	codeFlagMissing    = "config.flag_missing"
+	codeNoValidStreams = "catalog.no_valid_streams"
+	// recovered panic as an internal error
+	codePanicRecovered = "sync.panic_recovered"
+)
+
+// recoverToError turns a panic into a classified error written through err, then re-panics so
+// safego.Recovery still prints the stack and the process still exits non-zero. Deferred by a
+// command whose result telemetry reads: a panic would otherwise leave err nil and the run would
+// be reported as a success.
+func recoverToError(err *error) {
+	if r := recover(); r != nil {
+		*err = errs.Precondition(errs.InternalError, codePanicRecovered,
+			fmt.Errorf("panic during sync: %v", r))
+		panic(r)
+	}
+}
+
+// ReportFailure classifies a failed run, reports it, and waits for the report to be delivered.
+// The wait is the point: check and discover leave through logger.Fatal, and telemetry sends in
+// the background, so without flushing the event is built and then discarded as the process dies.
+func ReportFailure(err error) {
+	if err == nil {
+		return
+	}
+
+	if telemetry.Disabled() {
+		return
+	}
+
+	// Classified here because this is the only point every failure reaches. A command's RunE
+	// misses its own PreRunE hooks, where the config is read and decrypted, and spec and
+	// clear-destination have no wrapper at all.
+	f := errs.From(errs.Classify(err))
+
+	// The classifier that recognized the error names itself. Where none did — the shared rules
+	// cannot know whose endpoint was on the far end — this falls back to the connector that
+	// ran, which a consumer tells apart by classified_by: "stdlib".
+	errorSource := f.Component
+	if errorSource == "" && connector != nil {
+		errorSource = connector.Type()
+	}
+	// Set only by sync, which is what makes this event joinable to the rest of the run's shape.
+	telemetry.TrackFailure(executedCommand(), errorSource, syncID, f)
+	telemetry.Flush()
+}
+
+// executedCommand names the subcommand that ran. Asking cobra keeps it correct when flags
+// precede the command.
+func executedCommand() string {
+	cmd, _, err := RootCmd.Find(os.Args[1:])
+	if err != nil || cmd == nil || cmd == RootCmd {
+		return "unknown"
+	}
+	return cmd.Name()
 }

--- a/protocol/root_test.go
+++ b/protocol/root_test.go
@@ -2,12 +2,18 @@ package protocol
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSignalAwareRootContextCancelsOnSignal verifies that signalAwareRootContext
@@ -108,5 +114,176 @@ func TestSignalAwareRootContextPreservesParentCancellation(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("context was not canceled after parent cancellation")
+	}
+}
+
+// runUnderRecover runs body with recoverToError deferred over an error that starts as prior.
+// It reports the error a caller would be left with and the value that continued unwinding.
+func runUnderRecover(prior error, body func()) (panicked any, err error) {
+	defer func() { panicked = recover() }()
+
+	err = prior
+	func() {
+		defer recoverToError(&err)
+		body()
+	}()
+	return panicked, err
+}
+
+// uninitialisedCounts returns a nil map through a function boundary, so the write below is a real
+// runtime panic rather than something an analyzer folds away.
+func uninitialisedCounts() map[string]int { return nil }
+
+type readStats struct{ rows int }
+
+// noStats returns a nil pointer through a function boundary, for the same reason.
+func noStats() *readStats { return nil }
+
+// nilPanicValue returns an untyped nil, so panic(nilPanicValue()) is a genuine nil panic. Go
+// 1.21+ turns that into *runtime.PanicNilError, which is what recover() then observes.
+func nilPanicValue() any { return nil }
+
+// TestRecoverToError covers the helper syncCmd defers so a panic cannot be reported as a
+// successful run: it must classify the panic, write it through the pointer, and re-panic so the
+// existing exit path is unchanged. Without a panic it must do nothing at all.
+func TestRecoverToError(t *testing.T) {
+	sentinel := errors.New("error occurred while reading records")
+	classifiedCause := errs.Precondition(errs.CDCPositionLost, "mssql.lsn_lost", errors.New("lsn gone"))
+
+	testCases := []struct {
+		name             string
+		prior            error         // the error already set when the deferred recover runs
+		body             func()        // may panic
+		expectedCategory errs.Category // empty means err must be left exactly as prior
+		expectedMessage  string        // substring an operator must still be able to read
+		expectedRePanic  any           // value safego.Recovery must see; nil skips the check
+	}{
+		// nothing panicked, so the helper must not manufacture an error
+		{
+			name: "no panic, no prior error",
+			body: func() {},
+		},
+		// nothing panicked, so an error already set must survive byte for byte
+		{
+			name:  "no panic, prior error untouched",
+			prior: sentinel,
+			body:  func() {},
+		},
+		// the reported defect: a panic left err nil and the run reported SUCCESS
+		{
+			name:             "panic with a string",
+			body:             func() { panic("connector.Read blew up") },
+			expectedRePanic:  "connector.Read blew up",
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "connector.Read blew up",
+		},
+		// a panic value that is itself an error must still be classified as the bug it is
+		{
+			name:             "panic with an error value",
+			body:             func() { panic(sentinel) },
+			expectedRePanic:  sentinel,
+			expectedCategory: errs.InternalError,
+			expectedMessage:  sentinel.Error(),
+		},
+		// a classified panic value must not have its classification promoted over the panic
+		{
+			name:             "panic with a classified error",
+			body:             func() { panic(classifiedCause) },
+			expectedRePanic:  classifiedCause,
+			expectedCategory: errs.InternalError,
+		},
+		// a panic overrides an error already set: the run crashed, it did not merely fail
+		{
+			name:             "panic over a prior error",
+			prior:            sentinel,
+			body:             func() { panic("boom") },
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "boom",
+		},
+		// non-error panic values must not break the %v formatting
+		{
+			name:             "panic with an int",
+			body:             func() { panic(42) },
+			expectedRePanic:  42,
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "42",
+		},
+		{
+			name:             "panic with a struct",
+			body:             func() { panic(struct{ Stream string }{"users"}) },
+			expectedRePanic:  struct{ Stream string }{"users"},
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "users",
+		},
+		// panic(nil) becomes *runtime.PanicNilError in Go 1.21+, so recover() still sees non-nil
+		{
+			name:             "panic with nil",
+			body:             func() { panic(nilPanicValue()) },
+			expectedCategory: errs.InternalError,
+		},
+		// the runtime panics a driver bug actually produces, rather than explicit panic() calls
+		{
+			name:             "runtime panic, nil map write",
+			body:             func() { uninitialisedCounts()["x"] = 1 },
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "nil map",
+		},
+		{
+			name:             "runtime panic, nil pointer dereference",
+			body:             func() { _ = noStats().rows },
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "nil pointer dereference",
+		},
+		{
+			name:             "runtime panic, index out of range",
+			body:             func() { s := []int{}; _ = s[len(s)] },
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "index out of range",
+		},
+		// the shape utils.Ternary(...).(error) can hit
+		{
+			name:             "runtime panic, failed type assertion",
+			body:             func() { var v any = "not an error"; _ = v.(error) },
+			expectedCategory: errs.InternalError,
+			expectedMessage:  "interface conversion",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			panicked, err := runUnderRecover(tc.prior, tc.body)
+
+			// no classification expected means nothing panicked and err is exactly what it was
+			if tc.expectedCategory == "" {
+				assert.Nil(t, panicked)
+				if tc.prior == nil {
+					assert.NoError(t, err)
+				} else {
+					assert.Same(t, tc.prior, err)
+				}
+				return
+			}
+
+			// the panic must continue so safego.Recovery still logs the stack and exits non-zero
+			assert.NotNil(t, panicked, "the panic must not be swallowed")
+			// and it must be the original value, not the classified error built from it
+			if tc.expectedRePanic != nil {
+				assert.Equal(t, tc.expectedRePanic, panicked)
+			}
+
+			require.Error(t, err)
+			got := errs.From(errs.Classify(err))
+			assert.Equal(t, tc.expectedCategory, got.Category, "category")
+			// every panic reaches the same code, so these are constant across the panic cases
+			assert.Equal(t, codePanicRecovered, got.Code, "code")
+			assert.Equal(t, "sync", got.Component, "component comes from the code prefix")
+
+			// classification must never change what an operator reads
+			assert.True(t, strings.HasPrefix(err.Error(), "panic during sync:"),
+				"message should say a panic happened, got %q", err.Error())
+			if tc.expectedMessage != "" {
+				assert.Contains(t, err.Error(), tc.expectedMessage)
+			}
+		})
 	}
 }

--- a/protocol/spec.go
+++ b/protocol/spec.go
@@ -22,13 +22,13 @@ var specCmd = &cobra.Command{
 
 		var specData map[string]interface{}
 		if err := utils.UnmarshalFile(specPath, &specData, false); err != nil {
-			return fmt.Errorf("failed to read spec file %s: %v", specPath, err)
+			return fmt.Errorf("failed to read spec file %s: %w", specPath, err)
 		}
 
 		schemaType := utils.Ternary(destinationType == "not-set", connector.Type(), destinationType).(string)
 		uiSchema, err := spec.LoadUISchema(schemaType)
 		if err != nil {
-			return fmt.Errorf("failed to get ui schema: %v", err)
+			return fmt.Errorf("failed to get ui schema: %w", err)
 		}
 
 		specSchema := map[string]interface{}{

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/datazip-inc/olake/destination"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/telemetry"
 	"github.com/datazip-inc/olake/utils/typeutils"
@@ -26,6 +27,8 @@ type StreamClassification struct {
 	IncrementalStreams []types.StreamInterface
 	FullLoadStreams    []types.StreamInterface
 	NewStreamsState    []*types.StreamState
+	// Telemetry-only: the stream breakdown of this run, counted as streams are classified.
+	Mix types.StreamMix
 }
 
 // syncCmd represents the read command
@@ -34,11 +37,11 @@ var syncCmd = &cobra.Command{
 	Short: "Olake sync command",
 	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		if configPath == "" {
-			return fmt.Errorf("--config not passed")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing, fmt.Errorf("--config not passed"))
 		} else if destinationConfigPath == "" {
-			return fmt.Errorf("--destination not passed")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing, fmt.Errorf("--destination not passed"))
 		} else if streamsPath == "" {
-			return fmt.Errorf("--catalog not passed")
+			return errs.Precondition(errs.ConfigInvalid, codeFlagMissing, fmt.Errorf("--catalog not passed"))
 		}
 
 		// unmarshal source config
@@ -87,9 +90,9 @@ var syncCmd = &cobra.Command{
 		logger.Infof("Running sync with state: %s", stateBytes)
 		return nil
 	},
-	RunE: func(cmd *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) (err error) {
 		// setup conector first
-		err := connector.Setup(cmd.Context())
+		err = connector.Setup(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -102,7 +105,7 @@ var syncCmd = &cobra.Command{
 		// get all types of selected streams
 		selectedStreamsMetadata, err := classifyStreams(catalog, streams, state)
 		if err != nil {
-			return fmt.Errorf("failed to get selected streams for clearing: %s", err)
+			return fmt.Errorf("failed to get selected streams for clearing: %w", err)
 		}
 
 		if streams == nil {
@@ -117,10 +120,10 @@ var syncCmd = &cobra.Command{
 			// get the state for modification in clearstate
 			connector.SetupState(state)
 			if state, err = connector.ClearState(dropStreams); err != nil {
-				return fmt.Errorf("error clearing state for full refresh streams: %s", err)
+				return fmt.Errorf("error clearing state for full refresh streams: %w", err)
 			}
 			if cerr := destination.DropStreams(cmd.Context(), destinationConfig, dropStreams); cerr != nil {
-				return fmt.Errorf("failed to clear destination: %s", cerr)
+				return fmt.Errorf("failed to clear destination: %w", cerr)
 			}
 		}
 
@@ -151,20 +154,24 @@ var syncCmd = &cobra.Command{
 
 		// Added this check to avoid the sleep when tracking telemetry is disabled
 		if !telemetry.Disabled() {
-			telemetry.TrackSyncStarted(syncID, selectedStreamsMetadata.SelectedStreams, selectedStreamsMetadata.FullLoadStreams, selectedStreamsMetadata.CDCStreams, connector.Type(), destinationConfig, catalog)
+			telemetry.TrackSyncStarted(syncID, selectedStreamsMetadata.Mix, connector.Type(), destinationConfig, len(catalog.Streams))
 			defer func() {
 				stats := pool.GetStats()
-				telemetry.TrackSyncCompleted(syncID, err == nil, stats.ReadCount.Load(), stats.BytesRead.Load())
+				telemetry.TrackSyncCompleted(syncID, selectedStreamsMetadata.Mix, destinationConfig, err == nil, stats.ReadCount.Load(), stats.BytesRead.Load())
 				logger.Infof("Sync completed, wait 5 seconds cleanup in progress...")
 				time.Sleep(5 * time.Second)
 			}()
 		}
 
+		// Registered after the telemetry defer so LIFO runs it first, before TrackSyncCompleted
+		// reads err. Without it a panic leaves err nil and the run reports sync_status SUCCESS.
+		defer recoverToError(&err)
+
 		stopRead := logger.TrackTiming("sync", "read records")
 		err = connector.Read(cmd.Context(), pool, selectedStreamsMetadata.FullLoadStreams, selectedStreamsMetadata.CDCStreams, selectedStreamsMetadata.IncrementalStreams)
 		stopRead()
 		if err != nil {
-			return fmt.Errorf("error occurred while reading records: %s", err)
+			return fmt.Errorf("error occurred while reading records: %w", err)
 		}
 
 		state.LogWithLock()
@@ -258,20 +265,37 @@ func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *typ
 		}
 
 		classifications.SelectedStreams = append(classifications.SelectedStreams, elem.ID())
+		// Past every skip branch, so the mix describes what this run actually syncs rather
+		// than everything the catalog configured.
+		classifications.Mix.Selected++
+		if elem.StreamMetadata.Normalization {
+			classifications.Mix.Normalized++
+		}
+		if elem.StreamMetadata.PartitionRegex != "" {
+			classifications.Mix.Partitioned++
+		}
 		switch elem.Stream.SyncMode {
 		case types.CDC, types.STRICTCDC:
+			// One read path, two counters: the sync treats them alike, telemetry does not.
+			if elem.Stream.SyncMode == types.STRICTCDC {
+				classifications.Mix.StrictCDC++
+			} else {
+				classifications.Mix.CDC++
+			}
 			classifications.CDCStreams = append(classifications.CDCStreams, elem)
 			streamState, exists := stateStreamMap[elem.ID()]
 			if exists {
 				classifications.NewStreamsState = append(classifications.NewStreamsState, streamState)
 			}
 		case types.INCREMENTAL:
+			classifications.Mix.Incremental++
 			classifications.IncrementalStreams = append(classifications.IncrementalStreams, elem)
 			streamState, exists := stateStreamMap[elem.ID()]
 			if exists {
 				classifications.NewStreamsState = append(classifications.NewStreamsState, streamState)
 			}
 		default:
+			classifications.Mix.FullRefresh++
 			classifications.FullLoadStreams = append(classifications.FullLoadStreams, elem)
 		}
 
@@ -283,7 +307,8 @@ func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *typ
 		state.Streams = classifications.NewStreamsState
 	}
 	if len(classifications.SelectedStreams) == 0 {
-		return nil, fmt.Errorf("no valid streams found in catalog")
+		return nil, errs.Precondition(errs.ConfigInvalid, codeNoValidStreams,
+			fmt.Errorf("no valid streams found in catalog"))
 	}
 
 	logger.Infof("Valid selected streams are %s", strings.Join(classifications.SelectedStreams, ", "))

--- a/protocol/sync_test.go
+++ b/protocol/sync_test.go
@@ -1,0 +1,162 @@
+package protocol
+
+import (
+	"os"
+	"testing"
+
+	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This package's init runs RootCmd.Execute, so the file logger is already pointed at ./logs
+// before a test can redirect it. classifyStreams logs its skips, which creates that directory;
+// drop it afterwards rather than leaving it in the tree.
+func discardStrayLogs(t *testing.T) {
+	t.Helper()
+	if _, err := os.Stat("logs"); err == nil {
+		return // already there before the test; not ours to remove
+	}
+	t.Cleanup(func() { _ = os.RemoveAll("logs") })
+}
+
+// stream is one configured stream in a test catalog. The metadata lives on the catalog's
+// selected_streams block, not here: classifyStreams overwrites StreamMetadata from that map.
+type stream struct {
+	name        string
+	mode        types.SyncMode
+	normalized  bool
+	partitioned bool
+	unselected  bool                // present in streams but absent from selected_streams
+	filter      *types.FilterConfig // only read when normalized, so it can be made invalid
+}
+
+// catalogOf builds the two halves classifyStreams reads: the configured streams and the
+// selected_streams metadata keyed by namespace.
+func catalogOf(streams ...stream) *types.Catalog {
+	catalog := &types.Catalog{SelectedStreams: map[string][]types.StreamMetadata{}}
+	for _, s := range streams {
+		catalog.Streams = append(catalog.Streams, &types.ConfiguredStream{
+			Stream: &types.Stream{Name: s.name, Namespace: "public", SyncMode: s.mode},
+		})
+		if s.unselected {
+			continue
+		}
+		metadata := types.StreamMetadata{StreamName: s.name, Normalization: s.normalized, FilterConfig: s.filter}
+		if s.partitioned {
+			metadata.PartitionRegex = "/{now,year}"
+		}
+		catalog.SelectedStreams["public"] = append(catalog.SelectedStreams["public"], metadata)
+	}
+	return catalog
+}
+
+// TestClassifyStreamsMix covers the counters the two sync events carry. They are counted inside
+// classifyStreams so they cannot disagree with the run, which only holds if every counter sits
+// past the skip branches: a stream that is not synced must not appear in any of them.
+func TestClassifyStreamsMix(t *testing.T) {
+	testCases := []struct {
+		name         string
+		streams      []stream
+		expectedMix  types.StreamMix
+		expectedCode string // non-empty: no stream survives, so the run fails with this code
+	}{
+		// each mode lands in its own counter, and an unknown mode falls to full refresh
+		{
+			name: "one stream per sync mode",
+			streams: []stream{
+				{name: "a", mode: types.FULLREFRESH},
+				{name: "b", mode: types.INCREMENTAL},
+				{name: "c", mode: types.CDC},
+				{name: "d", mode: types.STRICTCDC},
+			},
+			expectedMix: types.StreamMix{FullRefresh: 1, Incremental: 1, CDC: 1, StrictCDC: 1, Selected: 4},
+		},
+		// CDC and STRICTCDC share one read path; telemetry must still tell them apart
+		{
+			name: "cdc and strict cdc are counted separately",
+			streams: []stream{
+				{name: "a", mode: types.CDC},
+				{name: "b", mode: types.CDC},
+				{name: "c", mode: types.STRICTCDC},
+			},
+			expectedMix: types.StreamMix{CDC: 2, StrictCDC: 1, Selected: 3},
+		},
+		// normalization and partitioning cut across sync mode rather than replacing it
+		{
+			name: "normalized and partitioned are independent of mode",
+			streams: []stream{
+				{name: "a", mode: types.FULLREFRESH, normalized: true},
+				{name: "b", mode: types.CDC, partitioned: true},
+				{name: "c", mode: types.INCREMENTAL, normalized: true, partitioned: true},
+			},
+			expectedMix: types.StreamMix{
+				FullRefresh: 1, CDC: 1, Incremental: 1,
+				Selected: 3, Normalized: 2, Partitioned: 2,
+			},
+		},
+		// a stream missing from selected_streams is never synced, so it reaches no counter
+		{
+			name: "unselected streams are not counted",
+			streams: []stream{
+				{name: "a", mode: types.CDC},
+				{name: "b", mode: types.FULLREFRESH, unselected: true},
+				{name: "c", mode: types.INCREMENTAL, unselected: true},
+			},
+			expectedMix: types.StreamMix{CDC: 1, Selected: 1},
+		},
+		// nor does one skipped later, for a filter that cannot be applied
+		{
+			name: "streams skipped for an invalid filter are not counted",
+			streams: []stream{
+				{name: "a", mode: types.CDC},
+				{
+					name: "b", mode: types.FULLREFRESH, normalized: true,
+					filter: &types.FilterConfig{Conditions: []types.FilterCondition{{Column: ""}}},
+				},
+				{
+					name: "c", mode: types.INCREMENTAL, normalized: true,
+					filter: &types.FilterConfig{Conditions: []types.FilterCondition{
+						{Column: "x"}, {Column: "y"}, {Column: "z"},
+					}},
+				},
+			},
+			expectedMix: types.StreamMix{CDC: 1, Selected: 1},
+		},
+		// with nothing left to sync there is no mix to report, and the run fails before the
+		// sync events are sent rather than reporting a run of zero streams
+		{
+			name:         "no stream survives selection",
+			streams:      []stream{{name: "a", mode: types.CDC, unselected: true}},
+			expectedCode: codeNoValidStreams,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			discardStrayLogs(t)
+
+			got, err := classifyStreams(catalogOf(tc.streams...), nil, &types.State{})
+			if tc.expectedCode != "" {
+				require.Error(t, err)
+				assert.Nil(t, got)
+
+				failure := errs.From(errs.Classify(err))
+				assert.Equal(t, errs.ConfigInvalid, failure.Category)
+				assert.Equal(t, tc.expectedCode, failure.Code)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedMix, got.Mix)
+
+			// the property the payload is read on: every synced stream is in exactly one
+			// mode counter, so the four of them account for Selected and nothing else.
+			assert.Equal(t, got.Mix.Selected, got.Mix.FullRefresh+got.Mix.Incremental+got.Mix.CDC+got.Mix.StrictCDC,
+				"the sync-mode counters must sum to selected_streams_count")
+			assert.Equal(t, len(got.SelectedStreams), got.Mix.Selected,
+				"selected_streams_count must match the streams the sync was handed")
+		})
+	}
+}

--- a/types/catalog.go
+++ b/types/catalog.go
@@ -66,6 +66,18 @@ type Catalog struct {
 	Streams         []*ConfiguredStream         `json:"streams,omitempty"`
 }
 
+// StreamMix is the per-sync breakdown of the streams a run actually syncs. Only streams that
+// survived selection and validation are counted, so the sync-mode counters sum to Selected.
+type StreamMix struct {
+	FullRefresh int `json:"full_refresh_streams_count"`
+	Incremental int `json:"incremental_streams_count"`
+	CDC         int `json:"cdc_streams_count"`
+	StrictCDC   int `json:"strict_cdc_streams_count"`
+	Selected    int `json:"selected_streams_count"`
+	Normalized  int `json:"normalized_streams_count"`
+	Partitioned int `json:"partitioned_streams_count"`
+}
+
 func GetWrappedCatalog(streams []*Stream, driver string) *Catalog {
 	catalog := &Catalog{
 		Streams:         []*ConfiguredStream{},

--- a/utils/errs/errs.go
+++ b/utils/errs/errs.go
@@ -1,0 +1,374 @@
+// Package errs carries a failure classification alongside an error, so telemetry can report why
+// a run failed without shipping customer data: categories and codes are constants in this repo.
+//
+// The category belongs to the error, never to the line that raised it, so Classify walks the
+// chain and lets the innermost evidence win. Nothing here does I/O or returns an error of its
+// own: it runs on a path that is already failing.
+package errs
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+// Category is the closed set of failure buckets. Values are contract — they appear in telemetry
+// and dashboard queries — so adding, removing or renaming one is a breaking change.
+type Category string
+
+const (
+	// User configuration and state.
+	ConfigInvalid       Category = "config_invalid"
+	ConfigDecryptFailed Category = "config_decrypt_failed"
+	StateInvalid        Category = "state_invalid"
+
+	// Reachability.
+	DNSResolutionFailed Category = "dns_resolution_failed"
+	NetworkUnreachable  Category = "network_unreachable"
+	TLSFailed           Category = "tls_failed"
+	SSHTunnelFailed     Category = "ssh_tunnel_failed"
+	Timeout             Category = "timeout"
+
+	// Identity and rights.
+	AuthFailed       Category = "auth_failed"
+	PermissionDenied Category = "permission_denied"
+
+	// Existence and capability.
+	ObjectNotFound     Category = "object_not_found"
+	UnsupportedFeature Category = "unsupported_feature"
+
+	// Change data capture.
+	CDCPreconditionFailed Category = "cdc_precondition_failed"
+	CDCPositionLost       Category = "cdc_position_lost"
+
+	// Capacity and contention.
+	ResourceExhausted   Category = "resource_exhausted"
+	ConcurrencyConflict Category = "concurrency_conflict"
+
+	// Data movement. A rise in these is usually a regression in OLake.
+	SourceReadError       Category = "source_read_error"
+	SchemaUnsupported     Category = "schema_unsupported"
+	DestinationWriteError Category = "destination_write_error"
+	CatalogError          Category = "catalog_error"
+
+	// Lifecycle, gaps and bugs.
+	Canceled      Category = "canceled"
+	Unclassified  Category = "unclassified"
+	InternalError Category = "internal_error"
+)
+
+// How a category was decided. The share arriving as ClassifiedByDefault is the coverage metric:
+// a rise means rules are missing, not that failures changed.
+const (
+	ClassifiedByPrecondition = "precondition" // a condition OLake detected itself
+	ClassifiedByVendor       = "vendor"       // from the vendor's own error code
+	ClassifiedByStdlib       = "stdlib"       // from a Go standard library error type
+	ClassifiedByDefault      = "unclassified" // nothing matched
+)
+
+// Failure is what telemetry reports. Category and ClassifiedBy are always set and answer
+// different questions — what went wrong, and on what evidence. The rest are optional.
+type Failure struct {
+	Category     Category `json:"category"`
+	ClassifiedBy string   `json:"classified_by"`
+
+	// Code is the vendor's own code where the server gave one ("28P01", "AccessDenied"),
+	// otherwise a constant for a condition the driver detected itself
+	// ("postgres.replication_slot_missing"). One field: the two are mutually exclusive.
+	Code string `json:"code,omitempty"`
+
+	// ErrorType is the root cause's concrete type, recorded only when nothing classified the
+	// error — the sole remaining clue about which rule to write next.
+	ErrorType string `json:"error_type,omitempty"`
+
+	// Component names the connector that classified the failure — "postgres", "iceberg". A run
+	// has a source and a destination and which one failed is not otherwise recoverable. Empty
+	// where the shared rules matched, since they cannot know whose endpoint was on the far end.
+	Component string `json:"component,omitempty"`
+}
+
+// Error carries a Failure alongside the error it describes.
+type Error struct {
+	Failure
+	err error
+}
+
+// Error returns the wrapped error's message unchanged: classification must not alter what an
+// operator reads, or what a caller matching on message text sees.
+func (e *Error) Error() string { return e.err.Error() }
+
+// Unwrap keeps errors.Is and errors.As reaching the cause through the classification.
+func (e *Error) Unwrap() error { return e.err }
+
+// Attach records a classification for an existing error, keeping the original as the cause. It
+// returns error rather than *Error so nil cannot become a non-nil interface holding a nil pointer.
+func Attach(err error, f Failure) error {
+	if err == nil {
+		return nil
+	}
+	return &Error{Failure: f, err: err}
+}
+
+// Precondition classifies a condition a connector detected itself, where no vendor error exists
+// to read — a missing replication slot, an unparseable resume token, a jar that is not on disk.
+// Classified at the raise site, the only place that knows what the check was for.
+func Precondition(category Category, code string, err error) error {
+	// Codes are written "<component>.<condition>", so no second argument can disagree with them.
+	component, _, _ := strings.Cut(code, ".")
+	return Attach(err, Failure{
+		Category:     category,
+		ClassifiedBy: ClassifiedByPrecondition,
+		Code:         code,
+		Component:    component,
+	})
+}
+
+// From reports the innermost classification in err's chain: the root cause outranks anything a
+// caller added above it. Unmatched errors report Unclassified rather than InternalError, keeping
+// a missing rule distinguishable from a bug. It never panics — that would replace the real error.
+func From(err error) (f Failure) {
+	defer func() {
+		if r := recover(); r != nil {
+			f = Failure{Category: Unclassified, ClassifiedBy: ClassifiedByDefault}
+		}
+	}()
+
+	if err == nil {
+		return Failure{Category: Unclassified, ClassifiedBy: ClassifiedByDefault}
+	}
+
+	if found, ok := classificationOf(err); ok {
+		return found
+	}
+	return Failure{Category: Unclassified, ClassifiedBy: ClassifiedByDefault}
+}
+
+// maxUnwrapDepth bounds the walk so a cyclic chain cannot hang a failure report.
+const maxUnwrapDepth = 100
+
+// walk searches err for the answer accept recognizes. Two chain shapes exist: %w unwraps one
+// error at a time, so the walk keeps descending and a deeper answer replaces a shallower one;
+// errors.Join unwraps to a slice, which errors.Unwrap does not follow, so branches are searched
+// by hand and the first that answers wins. depth bounds it so a cyclic chain cannot hang.
+func walk[T any](err error, depth int, accept func(error) (T, bool)) (T, bool) {
+	var found T
+	var ok bool
+
+	for e := err; e != nil && depth < maxUnwrapDepth; e, depth = errors.Unwrap(e), depth+1 {
+		if answer, matched := accept(e); matched {
+			found, ok = answer, true
+		}
+		if joined, isJoined := e.(interface{ Unwrap() []error }); isJoined {
+			// First answering branch wins, so the result is deterministic.
+			for _, branch := range joined.Unwrap() {
+				if answer, branchOK := walk(branch, depth+1, accept); branchOK {
+					return answer, true
+				}
+			}
+			break
+		}
+	}
+	return found, ok
+}
+
+// classificationOf finds the classification closest to the root cause.
+func classificationOf(err error) (Failure, bool) {
+	return walk(err, 0, func(e error) (Failure, bool) {
+		classified, isOurs := e.(*Error)
+		if !isOurs || classified.Category == "" {
+			return Failure{}, false
+		}
+		return classified.Failure, true
+	})
+}
+
+// VendorClassifier recognizes errors from one library, returning nil for anything else so the
+// error falls through to another classifier or to the shared rules.
+type VendorClassifier func(err error) *Failure
+
+type registeredClassifier struct {
+	component string
+	classify  VendorClassifier
+}
+
+var (
+	classifiersMu sync.RWMutex
+	classifiers   []registeredClassifier
+)
+
+// Register adds a classifier for a source or destination's own error types. Each binary holds
+// one source plus its destinations and registers from init, so the set is fixed before any
+// command runs; classifiers return nil for errors they do not recognize, so several are safe.
+func Register(component string, c VendorClassifier) {
+	if c == nil {
+		return
+	}
+	classifiersMu.Lock()
+	defer classifiersMu.Unlock()
+	classifiers = append(classifiers, registeredClassifier{component: component, classify: c})
+}
+
+// Classify attaches a failure classification to err. Called once, where the error is finally
+// handled: it reads the error's structure rather than the call site, so one call at the top
+// covers everything underneath. The message and chain are untouched, and it never panics.
+func Classify(err error) (out error) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = err
+		}
+	}()
+
+	if err == nil {
+		return nil
+	}
+	// Already classified deeper in the chain; the root cause outranks anything here.
+	if From(err).Category != Unclassified {
+		return err
+	}
+
+	classifiersMu.RLock()
+	registered := classifiers
+	classifiersMu.RUnlock()
+
+	for _, rc := range registered {
+		if f := rc.classify(err); f != nil {
+			f.Component = rc.component
+			return Attach(err, *f)
+		}
+	}
+	return Attach(err, standard(err))
+}
+
+// Standard applies only the shared rules, skipping every registered classifier. It exists for
+// libraries that hold their cause in a field rather than the chain — a topology description, an
+// SDK's OrigErr — which classifiers pull out by hand and pass here.
+func Standard(err error) Failure {
+	if err == nil {
+		return Failure{Category: Unclassified, ClassifiedBy: ClassifiedByDefault}
+	}
+	return standard(err)
+}
+
+// standard classifies failures that never reached a server, so carry no vendor code. Identical
+// for every connector, which is why they live here rather than in each driver.
+func standard(err error) Failure {
+	stdlib := func(category Category) Failure {
+		return Failure{Category: category, ClassifiedBy: ClassifiedByStdlib}
+	}
+
+	// Checked before deadlines, which are timeouts.
+	if errors.Is(err, context.Canceled) {
+		return stdlib(Canceled)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return stdlib(Timeout)
+	}
+
+	// Before the generic network case: a TLS failure arrives wrapped in a network error and
+	// would otherwise be misread as unreachable.
+	var certErr *tls.CertificateVerificationError
+	var unknownAuthority x509.UnknownAuthorityError
+	var hostnameErr x509.HostnameError
+	var invalidCert x509.CertificateInvalidError
+	var recordErr tls.RecordHeaderError
+	switch {
+	case errors.As(err, &certErr), errors.As(err, &unknownAuthority),
+		errors.As(err, &hostnameErr), errors.As(err, &invalidCert),
+		errors.As(err, &recordErr):
+		return stdlib(TLSFailed)
+	}
+
+	// Two different fixes: a name that does not exist is usually a typo, a resolver that timed
+	// out is infrastructure. The category alone cannot say which.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		f := stdlib(DNSResolutionFailed)
+		switch {
+		case dnsErr.IsNotFound:
+			f.Code = "host_not_found"
+		case dnsErr.IsTimeout:
+			f.Code = "resolver_timeout"
+		}
+		return f
+	}
+
+	// A network timeout reports itself as one; checked before the refused-connection case.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return stdlib(Timeout)
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		f := stdlib(NetworkUnreachable)
+		f.Code = syscallCode(err)
+		return f
+	}
+
+	// Unclassified rather than InternalError: a missing rule is not a bug, and keeping them
+	// apart is what makes either number meaningful. The concrete type is the only clue left.
+	return Failure{
+		Category:     Unclassified,
+		ClassifiedBy: ClassifiedByDefault,
+		ErrorType:    rootType(err),
+	}
+}
+
+// syscallCode splits network_unreachable by what actually happened: a wrong port, a firewall, a
+// peer that hung up — different fixes, same category. Names rather than raw errno numbers, which
+// differ between Linux and macOS; an errno with no entry here simply reports nothing.
+func syscallCode(err error) string {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return ""
+	}
+	switch errno {
+	case syscall.ECONNREFUSED:
+		return "connection_refused"
+	case syscall.ECONNRESET:
+		return "connection_reset"
+	case syscall.ECONNABORTED:
+		return "connection_aborted"
+	case syscall.EHOSTUNREACH:
+		return "host_unreachable"
+	case syscall.ENETUNREACH:
+		return "network_unreachable"
+	case syscall.ENETDOWN:
+		return "network_down"
+	case syscall.EPIPE:
+		return "broken_pipe"
+	case syscall.ETIMEDOUT:
+		return "timed_out"
+	}
+	return ""
+}
+
+// genericErrorType is what errors.New and a %w-less fmt.Errorf produce. Every such error has it,
+// so it identifies nothing and is only reported when no branch offers anything better.
+const genericErrorType = "*errors.errorString"
+
+// namedType accepts a leaf whose concrete type identifies the failure.
+func namedType(e error) (string, bool) {
+	if _, joined := e.(interface{ Unwrap() []error }); joined || errors.Unwrap(e) != nil {
+		return "", false
+	}
+	name := fmt.Sprintf("%T", e)
+	return name, name != genericErrorType
+}
+
+// rootType names the concrete type at the bottom of the chain. The outermost is almost always
+// *fmt.wrapError, which says nothing; the root identifies the failure and is what someone reads
+// when deciding which rule to add next.
+func rootType(err error) string {
+	if name, ok := walk(err, 0, namedType); ok {
+		return name
+	}
+	// Nothing anywhere names the failure, so report the type they all share.
+	return genericErrorType
+}

--- a/utils/errs/errs_test.go
+++ b/utils/errs/errs_test.go
@@ -1,0 +1,468 @@
+package errs
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// leaf is a distinguishable concrete type, so rootType assertions cannot pass by accident.
+type leaf struct{ msg string }
+
+func (l *leaf) Error() string { return l.msg }
+
+// selfWrapper unwraps to itself, the shape maxUnwrapDepth exists to bound.
+type selfWrapper struct{ next error }
+
+func (s *selfWrapper) Error() string { return "cycle" }
+func (s *selfWrapper) Unwrap() error { return s.next }
+
+func classified(category Category, code string) error {
+	return Precondition(category, code, errors.New("cause"))
+}
+
+// TestFrom covers how a classification is found in every chain shape the codebase produces:
+// a linear %w chain, an errors.Join tree, a two-%w-verb tree, and the degenerate cases.
+func TestFrom(t *testing.T) {
+	testCases := []struct {
+		name             string
+		err              error
+		expectedCategory Category
+		expectedCode     string
+		expectedBy       string
+	}{
+		// nothing to classify
+		{
+			name:             "nil error",
+			err:              nil,
+			expectedCategory: Unclassified,
+			expectedBy:       ClassifiedByDefault,
+		},
+		// no rule matches, which is a missing rule rather than a bug
+		{
+			name:             "unmatched error",
+			err:              fmt.Errorf("wrapped: %w", &leaf{"nothing recognizes this"}),
+			expectedCategory: Unclassified,
+			expectedBy:       ClassifiedByDefault,
+		},
+		// %w descends one at a time and the root cause outranks anything above it
+		{
+			name: "linear chain, innermost wins",
+			err: Attach(
+				fmt.Errorf("while connecting: %w", classified(AuthFailed, "postgres.auth")),
+				Failure{Category: ConfigInvalid, ClassifiedBy: ClassifiedByPrecondition, Code: "outer.code"}),
+			expectedCategory: AuthFailed,
+			expectedCode:     "postgres.auth",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// three levels deep, to prove the walk does not stop after one hop
+		{
+			name: "linear chain, three levels",
+			err: fmt.Errorf("a: %w", fmt.Errorf("b: %w",
+				classified(CDCPositionLost, "mssql.lsn_lost"))),
+			expectedCategory: CDCPositionLost,
+			expectedCode:     "mssql.lsn_lost",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// errors.Join drops the nil but still returns a join node, and errors.Unwrap does not
+		// follow it: without the by-hand branch walk this classification would be invisible
+		{
+			name:             "join with a single branch",
+			err:              errors.Join(nil, classified(CDCPositionLost, "mssql.lsn_lost")),
+			expectedCategory: CDCPositionLost,
+			expectedCode:     "mssql.lsn_lost",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// two %w verbs produce *fmt.wrapErrors, a tree rather than a linear chain
+		{
+			name: "two %w verbs is a tree",
+			err: fmt.Errorf("%w: %w", errors.New("non retryable"),
+				classified(SchemaUnsupported, "kafka.bad_schema")),
+			expectedCategory: SchemaUnsupported,
+			expectedCode:     "kafka.bad_schema",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// the sentinel-first pattern used across the drivers must not shadow the real error
+		{
+			name: "sentinel first, real error second",
+			err: fmt.Errorf("%w: failed to read: %w", errors.New("sentinel"),
+				classified(SourceReadError, "s3.read_failed")),
+			expectedCategory: SourceReadError,
+			expectedCode:     "s3.read_failed",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// branches are searched in order, so the first classified one answers
+		{
+			name:             "join, first classified branch wins",
+			err:              errors.Join(classified(ConfigInvalid, "a.first"), classified(AuthFailed, "b.second")),
+			expectedCategory: ConfigInvalid,
+			expectedCode:     "a.first",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// the same two branches the other way round, pinning that order decides it
+		{
+			name:             "join, order decides the answer",
+			err:              errors.Join(classified(AuthFailed, "b.second"), classified(ConfigInvalid, "a.first")),
+			expectedCategory: AuthFailed,
+			expectedCode:     "b.second",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// an unclassified branch is skipped rather than ending the walk
+		{
+			name: "join skips unclassified branches",
+			err: errors.Join(errors.New("nothing here"), errors.New("nor here"),
+				classified(ResourceExhausted, "z.last")),
+			expectedCategory: ResourceExhausted,
+			expectedCode:     "z.last",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// nested joins: the walk has to recurse, not just look one level down
+		{
+			name: "nested joins",
+			err: errors.Join(
+				errors.Join(errors.New("a"), errors.New("b")),
+				errors.Join(errors.New("c"), classified(PermissionDenied, "iceberg.denied"))),
+			expectedCategory: PermissionDenied,
+			expectedCode:     "iceberg.denied",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// a branch deeper than the outer classification still outranks it
+		{
+			name: "join beneath an outer classification",
+			err: Attach(fmt.Errorf("wrapped: %w", errors.Join(errors.New("a"), classified(TLSFailed, "deep.tls"))),
+				Failure{Category: ConfigInvalid, ClassifiedBy: ClassifiedByPrecondition, Code: "outer"}),
+			expectedCategory: TLSFailed,
+			expectedCode:     "deep.tls",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// where no branch is classified the outer classification survives
+		{
+			name: "outer classification survives a fruitless join",
+			err: Attach(fmt.Errorf("wrapped: %w", errors.Join(errors.New("a"), errors.New("b"))),
+				Failure{Category: ConfigInvalid, ClassifiedBy: ClassifiedByPrecondition, Code: "outer.only"}),
+			expectedCategory: ConfigInvalid,
+			expectedCode:     "outer.only",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+		// a zero-valued Failure is not a classification, so the walk keeps descending
+		{
+			name:             "empty category is not a classification",
+			err:              Attach(classified(AuthFailed, "inner.real"), Failure{}),
+			expectedCategory: AuthFailed,
+			expectedCode:     "inner.real",
+			expectedBy:       ClassifiedByPrecondition,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := From(tc.err)
+			assert.Equal(t, tc.expectedCategory, got.Category, "category")
+			assert.Equal(t, tc.expectedCode, got.Code, "code")
+			assert.Equal(t, tc.expectedBy, got.ClassifiedBy, "classified_by")
+		})
+	}
+}
+
+// TestFromTerminatesAndNeverPanics covers the two guarantees From documents: a cyclic chain
+// cannot hang a failure report, and classification never replaces the real error with a panic.
+func TestFromTerminatesAndNeverPanics(t *testing.T) {
+	t.Run("cyclic chain terminates", func(t *testing.T) {
+		cyclic := &selfWrapper{}
+		cyclic.next = cyclic
+
+		done := make(chan Failure, 1)
+		go func() { done <- From(cyclic) }()
+
+		select {
+		case got := <-done:
+			assert.Equal(t, Unclassified, got.Category)
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "From did not terminate on a cyclic chain")
+		}
+	})
+
+	t.Run("chain longer than maxUnwrapDepth terminates", func(t *testing.T) {
+		deep := error(&leaf{"bottom"})
+		for i := range maxUnwrapDepth * 2 {
+			deep = fmt.Errorf("layer %d: %w", i, deep)
+		}
+		assert.NotPanics(t, func() { From(deep) })
+	})
+
+	t.Run("nil-typed pointer in the chain", func(t *testing.T) {
+		// A non-nil interface holding a nil *Error would panic on field access without recover.
+		var nilTyped *Error
+		assert.Equal(t, Unclassified, From(fmt.Errorf("wrapped: %w", error(nilTyped))).Category)
+	})
+}
+
+// TestAttachAndPrecondition covers the two constructors: nil handling, message preservation,
+// chain preservation, and the component the code prefix implies.
+func TestAttachAndPrecondition(t *testing.T) {
+	t.Run("attach nil stays a nil interface", func(t *testing.T) {
+		assert.Nil(t, Attach(nil, Failure{Category: AuthFailed}))
+	})
+
+	t.Run("message is unchanged", func(t *testing.T) {
+		cause := &leaf{"the original text"}
+		assert.Equal(t, cause.Error(), Precondition(AuthFailed, "x.y", cause).Error())
+	})
+
+	t.Run("errors.As still reaches the cause", func(t *testing.T) {
+		var target *leaf
+		require.True(t, errors.As(Precondition(AuthFailed, "x.y", &leaf{"c"}), &target))
+		assert.Equal(t, "c", target.msg)
+	})
+
+	testCases := []struct {
+		name              string
+		code              string
+		expectedComponent string
+	}{
+		// codes are written "<component>.<condition>", so the prefix names the connector
+		{name: "component from prefix", code: "mongodb.resume_token_invalid", expectedComponent: "mongodb"},
+		{name: "only the first segment", code: "s3.parser.decode", expectedComponent: "s3"},
+		// a code without the separator is a caller mistake; the whole string is at least never
+		// silently wrong about which connector it names
+		{name: "no separator", code: "nodot", expectedComponent: "nodot"},
+		{name: "empty code", code: "", expectedComponent: ""},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := From(classified(StateInvalid, tc.code))
+			assert.Equal(t, tc.expectedComponent, got.Component)
+			assert.Equal(t, tc.code, got.Code)
+		})
+	}
+}
+
+// TestStandard covers every shared stdlib rule and the ordering between them. The order is the
+// substance: a TLS failure arrives wrapped in a network error and must not read as unreachable.
+func TestStandard(t *testing.T) {
+	testCases := []struct {
+		name             string
+		err              error
+		expectedCategory Category
+		expectedCode     string
+	}{
+		// lifecycle, checked before deadlines
+		{name: "context canceled", err: context.Canceled, expectedCategory: Canceled},
+		{name: "canceled through a wrap", err: fmt.Errorf("stopped: %w", context.Canceled), expectedCategory: Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, expectedCategory: Timeout},
+
+		// TLS, checked before the generic network case
+		{name: "tls cert verification", err: &tls.CertificateVerificationError{Err: errors.New("bad")}, expectedCategory: TLSFailed},
+		{name: "x509 unknown authority", err: x509.UnknownAuthorityError{}, expectedCategory: TLSFailed},
+		{name: "x509 hostname", err: x509.HostnameError{Host: "h"}, expectedCategory: TLSFailed},
+		{name: "x509 cert invalid", err: x509.CertificateInvalidError{}, expectedCategory: TLSFailed},
+		// crypto/tls returns this by value, so a pointer target would never match a real one
+		{name: "tls record header", err: tls.RecordHeaderError{Msg: "bad"}, expectedCategory: TLSFailed},
+		// a TLS failure inside a net.OpError must not be read as unreachable
+		{
+			name:             "tls beneath a net error",
+			err:              &net.OpError{Op: "read", Err: &tls.CertificateVerificationError{Err: errors.New("x")}},
+			expectedCategory: TLSFailed,
+		},
+
+		// DNS, split by what a reader would do about it
+		{name: "dns not found", err: &net.DNSError{IsNotFound: true}, expectedCategory: DNSResolutionFailed, expectedCode: "host_not_found"},
+		{name: "dns resolver timeout", err: &net.DNSError{IsTimeout: true}, expectedCategory: DNSResolutionFailed, expectedCode: "resolver_timeout"},
+		{name: "dns, neither flag", err: &net.DNSError{}, expectedCategory: DNSResolutionFailed},
+
+		// network, with the errno naming what actually happened
+		{name: "connection refused", err: &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, expectedCategory: NetworkUnreachable, expectedCode: "connection_refused"},
+		{name: "connection reset", err: &net.OpError{Op: "read", Err: syscall.ECONNRESET}, expectedCategory: NetworkUnreachable, expectedCode: "connection_reset"},
+		{name: "connection aborted", err: &net.OpError{Op: "read", Err: syscall.ECONNABORTED}, expectedCategory: NetworkUnreachable, expectedCode: "connection_aborted"},
+		{name: "host unreachable", err: &net.OpError{Op: "dial", Err: syscall.EHOSTUNREACH}, expectedCategory: NetworkUnreachable, expectedCode: "host_unreachable"},
+		{name: "network unreachable", err: &net.OpError{Op: "dial", Err: syscall.ENETUNREACH}, expectedCategory: NetworkUnreachable, expectedCode: "network_unreachable"},
+		{name: "network down", err: &net.OpError{Op: "dial", Err: syscall.ENETDOWN}, expectedCategory: NetworkUnreachable, expectedCode: "network_down"},
+		{name: "broken pipe", err: &net.OpError{Op: "write", Err: syscall.EPIPE}, expectedCategory: NetworkUnreachable, expectedCode: "broken_pipe"},
+		// net.Error.Timeout() is checked before the socket cases, so this never reaches syscallCode
+		{name: "errno that reports a timeout", err: &net.OpError{Op: "dial", Err: syscall.ETIMEDOUT}, expectedCategory: Timeout},
+		// an errno with no entry reports nothing rather than a raw number
+		{name: "errno with no entry", err: &net.OpError{Op: "dial", Err: syscall.EACCES}, expectedCategory: NetworkUnreachable},
+		{name: "op error with an opaque cause", err: &net.OpError{Op: "dial", Err: errors.New("opaque")}, expectedCategory: NetworkUnreachable},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Standard(tc.err)
+			assert.Equal(t, tc.expectedCategory, got.Category, "category")
+			assert.Equal(t, tc.expectedCode, got.Code, "code")
+			assert.Equal(t, ClassifiedByStdlib, got.ClassifiedBy, "classified_by")
+			assert.Empty(t, got.ErrorType, "error_type is only reported when nothing matched")
+		})
+	}
+
+	t.Run("nil error", func(t *testing.T) {
+		got := Standard(nil)
+		assert.Equal(t, Unclassified, got.Category)
+		assert.Equal(t, ClassifiedByDefault, got.ClassifiedBy)
+	})
+}
+
+// TestRootType covers the error_type field, which is reported only when nothing classified the
+// error and is therefore the sole remaining clue about which rule to write next.
+func TestRootType(t *testing.T) {
+	specific := fmt.Errorf("wrapped: %w", &leaf{"specific"})
+
+	testCases := []struct {
+		name              string
+		err               error
+		expectedErrorType string
+	}{
+		// the outermost is almost always *fmt.wrapError, which says nothing
+		{name: "reaches the leaf through a chain", err: fmt.Errorf("a: %w", fmt.Errorf("b: %w", &leaf{"x"})), expectedErrorType: "*errs.leaf"},
+		{name: "bare error", err: errors.New("x"), expectedErrorType: genericErrorType},
+		// joined branches are searched, so a branch bottoming out in errors.New cannot mask a
+		// specific type beside it
+		{name: "join, specific type second", err: errors.Join(errors.New("generic"), specific), expectedErrorType: "*errs.leaf"},
+		{name: "join, specific type first", err: errors.Join(specific, errors.New("generic")), expectedErrorType: "*errs.leaf"},
+		{name: "nested join", err: errors.Join(errors.New("a"), errors.Join(errors.New("b"), specific)), expectedErrorType: "*errs.leaf"},
+		// nothing better on offer, so the generic type is reported rather than nothing
+		{name: "join, nothing specific anywhere", err: errors.Join(errors.New("a"), errors.New("b")), expectedErrorType: genericErrorType},
+		// two %w verbs are the same tree shape
+		{name: "two %w verbs", err: fmt.Errorf("%w: %w", errors.New("a"), specific), expectedErrorType: "*errs.leaf"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Standard(tc.err)
+			require.Equal(t, Unclassified, got.Category, "these inputs must reach the default branch")
+			assert.Equal(t, tc.expectedErrorType, got.ErrorType)
+		})
+	}
+}
+
+// TestClassify covers the entry point ReportFailure uses: it must not override a deeper
+// classification, must fall through to the shared rules, and must never alter the message.
+func TestClassify(t *testing.T) {
+	t.Run("nil stays nil", func(t *testing.T) {
+		assert.Nil(t, Classify(nil))
+	})
+
+	t.Run("message is unchanged", func(t *testing.T) {
+		original := errors.New("exact operator text")
+		assert.Equal(t, original.Error(), Classify(original).Error())
+	})
+
+	t.Run("a deeper classification is kept", func(t *testing.T) {
+		inner := classified(CDCPreconditionFailed, "postgres.slot_missing")
+		got := From(Classify(fmt.Errorf("setup failed: %w", inner)))
+		assert.Equal(t, CDCPreconditionFailed, got.Category)
+		assert.Equal(t, "postgres.slot_missing", got.Code)
+	})
+
+	t.Run("falls through to the shared rules", func(t *testing.T) {
+		got := From(Classify(fmt.Errorf("dial: %w", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED})))
+		assert.Equal(t, NetworkUnreachable, got.Category)
+		assert.Equal(t, ClassifiedByStdlib, got.ClassifiedBy)
+		assert.Equal(t, "connection_refused", got.Code)
+	})
+
+	t.Run("unmatched reports the concrete type", func(t *testing.T) {
+		got := From(Classify(fmt.Errorf("wrapped: %w", &leaf{"x"})))
+		assert.Equal(t, Unclassified, got.Category)
+		assert.Equal(t, ClassifiedByDefault, got.ClassifiedBy)
+		assert.Equal(t, "*errs.leaf", got.ErrorType)
+	})
+
+	t.Run("classifying twice is stable", func(t *testing.T) {
+		once := Classify(context.Canceled)
+		assert.Equal(t, From(once), From(Classify(once)))
+	})
+}
+
+// isolateClassifiers restores the registry when the test ends. Register appends to a package
+// global that every later Classify call walks, so a test classifier left behind — a panicking
+// one above all — would otherwise run for the rest of the binary.
+func isolateClassifiers(t *testing.T) {
+	t.Helper()
+
+	classifiersMu.Lock()
+	previous := classifiers
+	classifiersMu.Unlock()
+
+	t.Cleanup(func() {
+		classifiersMu.Lock()
+		defer classifiersMu.Unlock()
+		classifiers = previous
+	})
+}
+
+// TestRegister covers the per-connector classifiers: the component is stamped from the
+// registration, a nil classifier is ignored, and an unrecognized error still reaches the
+// shared rules.
+func TestRegister(t *testing.T) {
+	isolateClassifiers(t)
+
+	Register("testcomponent", func(err error) *Failure {
+		var l *leaf
+		if errors.As(err, &l) && l.msg == "registered" {
+			return &Failure{Category: CatalogError, ClassifiedBy: ClassifiedByVendor, Code: "tc.1"}
+		}
+		return nil
+	})
+	Register("nilclassifier", nil)
+
+	t.Run("component is stamped from the registration", func(t *testing.T) {
+		got := From(Classify(fmt.Errorf("wrapped: %w", &leaf{"registered"})))
+		assert.Equal(t, CatalogError, got.Category)
+		assert.Equal(t, ClassifiedByVendor, got.ClassifiedBy)
+		assert.Equal(t, "testcomponent", got.Component)
+	})
+
+	t.Run("an unrecognized error falls through", func(t *testing.T) {
+		assert.Equal(t, Canceled, From(Classify(context.Canceled)).Category)
+	})
+
+	t.Run("a panicking classifier cannot replace the real error", func(t *testing.T) {
+		Register("panicking", func(err error) *Failure {
+			var l *leaf
+			if errors.As(err, &l) && l.msg == "trips the classifier" {
+				panic("classifier blew up")
+			}
+			return nil
+		})
+		original := fmt.Errorf("wrapped: %w", &leaf{"trips the classifier"})
+		assert.NotPanics(t, func() {
+			assert.Same(t, original, Classify(original), "the original error is returned unchanged")
+		})
+	})
+
+	t.Run("shared rules leave the component empty", func(t *testing.T) {
+		// They cannot know whose endpoint was on the far end.
+		assert.Empty(t, From(Classify(&net.OpError{Op: "dial", Err: syscall.ECONNREFUSED})).Component)
+	})
+}
+
+// TestClassifiedByDefaultAccompaniesUnclassified pins the invariant every classifier relies on:
+// the value reported when no rule matched, and that it never carries a real category.
+func TestClassifiedByDefaultAccompaniesUnclassified(t *testing.T) {
+	assert.Equal(t, "unclassified", ClassifiedByDefault,
+		"the value reaches telemetry as classified_by and dashboards query it")
+
+	for _, err := range []error{
+		nil,
+		errors.New("x"),
+		fmt.Errorf("wrapped: %w", &leaf{"x"}),
+		errors.Join(errors.New("a"), errors.New("b")),
+	} {
+		// Unconditional: a guarded assertion would silently pass if ClassifiedBy stopped
+		// reporting the default, which is the regression worth catching.
+		got := From(err)
+		assert.Equal(t, ClassifiedByDefault, got.ClassifiedBy, "nothing here matches a rule")
+		assert.Equal(t, Unclassified, got.Category,
+			"classified_by=%q must only ever accompany an unclassified category", ClassifiedByDefault)
+	}
+}

--- a/utils/ssh.go
+++ b/utils/ssh.go
@@ -7,7 +7,19 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/datazip-inc/olake/utils/errs"
 	"golang.org/x/crypto/ssh"
+)
+
+// Codes for conditions this package detects itself, where the error alone cannot say the address
+// that failed was the bastion and not the database.
+const (
+	codeSSHConfigInvalid = "ssh.config_invalid"
+	codeSSHKeyInvalid    = "ssh.private_key_invalid"
+	codeSSHDialFailed    = "ssh.dial_failed"
+	codeSSHHostNotFound  = "ssh.host_not_found"
+	codeSSHDialTimeout   = "ssh.dial_timeout"
+	codeSSHUnreachable   = "ssh.unreachable"
 )
 
 type SSHConfig struct {
@@ -42,7 +54,8 @@ func (c *SSHConfig) Validate() error {
 func (c *SSHConfig) SetupSSHConnection() (*ssh.Client, error) {
 	err := c.Validate()
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate ssh config: %s", err)
+		return nil, errs.Precondition(errs.ConfigInvalid, codeSSHConfigInvalid,
+			fmt.Errorf("failed to validate ssh config: %w", err))
 	}
 	var authMethods []ssh.AuthMethod
 
@@ -53,7 +66,8 @@ func (c *SSHConfig) SetupSSHConnection() (*ssh.Client, error) {
 	if c.PrivateKey != "" {
 		signer, err := ParsePrivateKey(c.PrivateKey, c.Passphrase)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse SSH private key: %s", err)
+			return nil, errs.Precondition(errs.SSHTunnelFailed, codeSSHKeyInvalid,
+				fmt.Errorf("failed to parse SSH private key: %w", err))
 		}
 		authMethods = append(authMethods, ssh.PublicKeys(signer))
 	}
@@ -70,7 +84,18 @@ func (c *SSHConfig) SetupSSHConnection() (*ssh.Client, error) {
 	bastionAddr := net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
 	sshClient, err := ssh.Dial("tcp", bastionAddr, sshCfg)
 	if err != nil {
-		return nil, fmt.Errorf("ssh dial bastion: %s", err)
+		// Splits ssh_tunnel_failed by what the dial error hit.
+		code := codeSSHDialFailed
+		switch errs.Standard(err).Category {
+		case errs.DNSResolutionFailed:
+			code = codeSSHHostNotFound
+		case errs.Timeout:
+			code = codeSSHDialTimeout
+		case errs.NetworkUnreachable:
+			code = codeSSHUnreachable
+		}
+		return nil, errs.Precondition(errs.SSHTunnelFailed, code,
+			fmt.Errorf("ssh dial bastion: %w", err))
 	}
 
 	return sshClient, nil

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/version"
 	"github.com/spf13/viper"
@@ -28,6 +29,8 @@ const (
 	userIDFile            = "user_id"
 	ipNotFoundPlaceholder = "NA"
 	proxTrackURL          = "https://analytics.olake.io/mp/track"
+	// flushTimeout bounds how long a failing command waits for its report to leave the process.
+	flushTimeout = 5 * time.Second
 )
 
 type Telemetry struct {
@@ -44,6 +47,13 @@ var telemetry *Telemetry
 var (
 	disabledOnce sync.Once
 	disabled     bool
+
+	// initDone closes once Init's background setup finishes. Init does network calls, so an
+	// event sent right after start would otherwise find telemetry nil and be dropped silently.
+	initDone = make(chan struct{})
+
+	// inflight tracks handed-off events so a command about to exit can wait for them.
+	inflight sync.WaitGroup
 )
 
 // Disabled reports whether telemetry is turned off via the TELEMETRY_DISABLED env var.
@@ -69,6 +79,7 @@ type LocationInfo struct {
 
 func Init() {
 	go func() {
+		defer close(initDone)
 		// check for disable
 		if Disabled() {
 			return
@@ -104,11 +115,44 @@ func Init() {
 	}()
 }
 
-func TrackDiscover(streamCount int, sourceType string) {
+// send runs an event in the background, recording it so Flush can wait for it. Panics are
+// contained: one here would otherwise kill the command being reported on.
+func send(name string, build func()) {
+	inflight.Add(1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Infof("recovered from panic while sending %s event: %v", name, r)
+			}
+			inflight.Done()
+		}()
+		<-initDone
 		if telemetry == nil {
 			return
 		}
+		build()
+	}()
+}
+
+// Flush waits for handed-off events. Commands call it before exiting:
+func Flush() {
+	if Disabled() {
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		inflight.Wait()
+	}()
+	select {
+	case <-done:
+	case <-time.After(flushTimeout):
+		logger.Debugf("telemetry flush timed out after %s", flushTimeout)
+	}
+}
+
+func TrackDiscover(streamCount int, sourceType string) {
+	send("discover", func() {
 		props := map[string]interface{}{
 			"stream_count": streamCount,
 			"source_type":  sourceType,
@@ -116,55 +160,105 @@ func TrackDiscover(streamCount int, sourceType string) {
 		if err := telemetry.sendEvent("Discover - CLI", props); err != nil {
 			logger.Debugf("Failed to send Discover event: %v", err)
 		}
-	}()
+	})
 }
 
-func TrackSyncStarted(syncID string, selectedStreams []string, fullLoadStreams, cdcStreams []types.StreamInterface, sourceType string, destinationConfig *types.WriterConfig, catalog *types.Catalog) {
-	go func() {
-		if telemetry == nil {
-			return
-		}
-		catalogType := ""
-		if string(destinationConfig.Type) == "ICEBERG" {
-			catalogType = destinationConfig.WriterConfig.(map[string]interface{})["catalog_type"].(string)
-		}
+// addStreamMix copies the per-sync stream breakdown onto an event. It rides on both sync
+// events, which are lost independently, and seven integers are cheap.
+func addStreamMix(props map[string]interface{}, mix types.StreamMix) {
+	props["full_refresh_streams_count"] = mix.FullRefresh
+	props["incremental_streams_count"] = mix.Incremental
+	props["cdc_streams_count"] = mix.CDC
+	props["strict_cdc_streams_count"] = mix.StrictCDC
+	props["selected_streams_count"] = mix.Selected
+	props["normalized_streams_count"] = mix.Normalized
+	props["partitioned_streams_count"] = mix.Partitioned
+}
+
+// destinationShape reads the destination type and catalog type from the destination config
+func destinationShape(destinationConfig *types.WriterConfig) (destinationType, catalogType string) {
+	if destinationConfig == nil {
+		return "", ""
+	}
+	destinationType = string(destinationConfig.Type)
+	if destinationConfig.Type != types.Iceberg {
+		return destinationType, ""
+	}
+	if writerConfig, ok := destinationConfig.WriterConfig.(map[string]interface{}); ok {
+		catalogType, _ = writerConfig["catalog_type"].(string)
+	}
+	return destinationType, catalogType
+}
+
+func TrackSyncStarted(syncID string, mix types.StreamMix, sourceType string, destinationConfig *types.WriterConfig, configuredStreams int) {
+	destinationType, catalogType := destinationShape(destinationConfig)
+
+	send("sync started", func() {
 		props := map[string]interface{}{
-			"sync_start":          time.Now(),
-			"sync_id":             syncID,
-			"stream_count":        len(catalog.Streams),
-			"selected_count":      len(selectedStreams),
-			"full_load_streams":   len(fullLoadStreams),
-			"cdc_streams":         len(cdcStreams),
-			"source_type":         sourceType,
-			"destination_type":    string(destinationConfig.Type),
-			"catalog_type":        catalogType,
-			"normalized_streams":  countNormalizedStreams(catalog),
-			"partitioned_streams": countPartitionedStreams(catalog),
+			"sync_start":       time.Now(),
+			"sync_id":          syncID,
+			"stream_count":     configuredStreams,
+			"source_type":      sourceType,
+			"destination_type": destinationType,
+			"catalog_type":     catalogType,
 		}
+		addStreamMix(props, mix)
 
 		if err := telemetry.sendEvent("Sync Started - CLI", props); err != nil {
 			logger.Debugf("Failed to send SyncStarted event: %v", err)
 		}
-	}()
+	})
 }
 
-func TrackSyncCompleted(syncID string, status bool, records, bytesRead int64) {
-	go func() {
-		if telemetry == nil {
-			return
-		}
+func TrackSyncCompleted(syncID string, mix types.StreamMix, destinationConfig *types.WriterConfig, status bool, records, bytesRead int64) {
+	destinationType, catalogType := destinationShape(destinationConfig)
+
+	send("sync completed", func() {
 		props := map[string]interface{}{
-			"sync_id":        syncID,
-			"sync_end":       time.Now(),
-			"sync_status":    utils.Ternary(status, "SUCCESS", "FAILED").(string),
-			"records_synced": records,
-			"bytes_read":     bytesRead,
+			"sync_id":          syncID,
+			"sync_end":         time.Now(),
+			"sync_status":      utils.Ternary(status, "SUCCESS", "FAILED").(string),
+			"records_synced":   records,
+			"bytes_read":       bytesRead,
+			"destination_type": destinationType,
+			"catalog_type":     catalogType,
 		}
+		addStreamMix(props, mix)
 
 		if err := telemetry.sendEvent("Sync Completed - CLI", props); err != nil {
 			logger.Debugf("Failed to send SyncCompleted event: %v", err)
 		}
-	}()
+	})
+}
+
+// TrackFailure reports why a command failed. The payload is a classification, not a
+// description: every field is a constant from this repo or a code the vendor defines, so no
+// config value, server message or user input can reach it. Absent fields are normal.
+func TrackFailure(command, errorSource, syncID string, f errs.Failure) {
+	send("failure - cli", func() {
+		// The rest of the run's shape is on the sync events, reachable through sync_id.
+		props := map[string]interface{}{
+			"command":       command,
+			"error_source":  errorSource,
+			"category":      string(f.Category),
+			"classified_by": f.ClassifiedBy,
+		}
+		// Absent for every command except sync.
+		if syncID != "" {
+			props["sync_id"] = syncID
+		}
+		// Only send what exists: an absent code is a legitimate slice, not a value to fake.
+		if f.Code != "" {
+			props["code"] = f.Code
+		}
+		if f.ErrorType != "" {
+			props["error_type"] = f.ErrorType
+		}
+
+		if err := telemetry.sendEvent("Failure - CLI", props); err != nil {
+			logger.Debugf("Failed to send Failure event: %v", err)
+		}
+	})
 }
 
 func (t *Telemetry) sendEvent(eventName string, props map[string]interface{}) error {
@@ -226,7 +320,9 @@ func (t *Telemetry) sendEvent(eventName string, props map[string]interface{}) er
 
 func getOutboundIP() string {
 	ip := []byte(ipNotFoundPlaceholder)
-	resp, err := http.Get("https://api.ipify.org?format=text")
+	// Timeout to the client so that init dosen't hang forever
+	client := http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("https://api.ipify.org?format=text")
 
 	if err != nil {
 		return string(ip)
@@ -287,26 +383,4 @@ func getLocationFromIP(ctx context.Context, ip string) (LocationInfo, error) {
 		Region:  info.Region,
 		City:    info.City,
 	}, nil
-}
-
-func countNormalizedStreams(catalog *types.Catalog) int {
-	var count int
-	_ = utils.ForEach(catalog.Streams, func(s *types.ConfiguredStream) error {
-		if s.StreamMetadata.Normalization {
-			count++
-		}
-		return nil
-	})
-	return count
-}
-
-func countPartitionedStreams(catalog *types.Catalog) int {
-	var count int
-	_ = utils.ForEach(catalog.Streams, func(s *types.ConfiguredStream) error {
-		if s.StreamMetadata.PartitionRegex != "" {
-			count++
-		}
-		return nil
-	})
-	return count
 }

--- a/utils/telemetry/telemetry_test.go
+++ b/utils/telemetry/telemetry_test.go
@@ -1,0 +1,523 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/datazip-inc/olake/constants"
+	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils/errs"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureTransport stands in for the analytics endpoint so an event can be inspected without
+// leaving the process. Nothing here reaches the network.
+type captureTransport struct {
+	mu     sync.Mutex
+	bodies [][]byte
+	status int
+	err    error
+}
+
+func (c *captureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if r.Body != nil {
+		body, _ := io.ReadAll(r.Body)
+		c.bodies = append(c.bodies, body)
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	status := c.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// events returns the decoded properties of each captured event, keyed by event name.
+func (c *captureTransport) events(t *testing.T) []map[string]any {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make([]map[string]any, 0, len(c.bodies))
+	for _, body := range c.bodies {
+		var payload struct {
+			Event      string         `json:"event"`
+			Properties map[string]any `json:"properties"`
+		}
+		require.NoError(t, json.Unmarshal(body, &payload))
+		payload.Properties["__event"] = payload.Event
+		out = append(out, payload.Properties)
+	}
+	return out
+}
+
+// stubClient points the package-level client at the capture, standing in for what Init builds.
+// Init itself is never called from a unit test: it makes two network calls.
+func stubClient(t *testing.T) *captureTransport {
+	t.Helper()
+	capture := &captureTransport{}
+	previous := telemetry
+	telemetry = &Telemetry{
+		httpClient: &http.Client{Transport: capture},
+		userID:     "test-user",
+		platform:   platformInfo{OS: "testos", Arch: "testarch", OlakeVersion: "v0.0.0", DeviceCPU: "1 cores"},
+		ipAddress:  ipNotFoundPlaceholder,
+	}
+	t.Cleanup(func() { telemetry = previous })
+	return capture
+}
+
+// initDoneOnce puts the package in the state Init would leave it in, without Init's network
+// calls. A channel can only be closed once, so every test shares this.
+var initDoneOnce sync.Once
+
+func markInitDone() { initDoneOnce.Do(func() { close(initDone) }) }
+
+// drain waits for handed-off events the way Flush does, minus Flush's Disabled short-circuit.
+// Tests must not depend on whether TELEMETRY_DISABLED happens to be set in the environment.
+func drain() { inflight.Wait() }
+
+// TestSendEventCommonProperties pins the properties every event carries. These names are read by
+// dashboards, so a rename is a breaking change that no compiler catches.
+func TestSendEventCommonProperties(t *testing.T) {
+	capture := stubClient(t)
+	require.NoError(t, telemetry.sendEvent("Test Event - CLI", map[string]any{"custom": 1}))
+
+	events := capture.events(t)
+	require.Len(t, events, 1)
+	props := events[0]
+
+	for _, key := range []string{
+		"os", "arch", "olake_version", "num_cpu", "service", "ip_address",
+		"location", "distinct_id", "time", "event_original_name",
+	} {
+		assert.Contains(t, props, key, "common property %q is missing", key)
+	}
+	assert.Equal(t, "Test Event - CLI", props["__event"])
+	assert.Equal(t, "Test Event - CLI", props["event_original_name"])
+	assert.Equal(t, float64(1), props["custom"], "caller properties survive the merge")
+}
+
+// TestSendEventErrors covers the two failure modes: a client that was never built, and an
+// endpoint that answers with a non-2xx status.
+func TestSendEventErrors(t *testing.T) {
+	t.Run("nil client", func(t *testing.T) {
+		empty := &Telemetry{}
+		assert.Error(t, empty.sendEvent("X", nil))
+	})
+
+	t.Run("non-2xx status", func(t *testing.T) {
+		capture := stubClient(t)
+		capture.status = http.StatusInternalServerError
+		assert.Error(t, telemetry.sendEvent("X", nil))
+	})
+
+	t.Run("transport failure", func(t *testing.T) {
+		capture := stubClient(t)
+		capture.err = errors.New("no route to host")
+		assert.Error(t, telemetry.sendEvent("X", nil))
+	})
+
+	t.Run("nil properties are allowed", func(t *testing.T) {
+		stubClient(t)
+		assert.NoError(t, telemetry.sendEvent("X", nil))
+	})
+}
+
+// TestEventPropertyNames pins the property names each tracked event emits. Renaming one silently
+// zeroes the corresponding dashboard series, with no schema change to explain it.
+func TestEventPropertyNames(t *testing.T) {
+	markInitDone()
+
+	mix := types.StreamMix{
+		FullRefresh: 1, Incremental: 2, CDC: 3, StrictCDC: 4,
+		Selected: 5, Normalized: 6, Partitioned: 7,
+	}
+	destination := &types.WriterConfig{Type: types.Iceberg, WriterConfig: map[string]any{"catalog_type": "glue"}}
+
+	// Distinct values, so a counter wired to the wrong key is caught rather than matching by
+	// coincidence. Both sync events carry the same seven.
+	streamMixProps := map[string]any{
+		"full_refresh_streams_count": mix.FullRefresh,
+		"incremental_streams_count":  mix.Incremental,
+		"cdc_streams_count":          mix.CDC,
+		"strict_cdc_streams_count":   mix.StrictCDC,
+		"selected_streams_count":     mix.Selected,
+		"normalized_streams_count":   mix.Normalized,
+		"partitioned_streams_count":  mix.Partitioned,
+	}
+
+	testCases := []struct {
+		name           string
+		track          func()
+		expectedKeys   []string
+		expectedValues map[string]any // checked by value, not just presence
+	}{
+		{
+			name:         "discover",
+			track:        func() { TrackDiscover(9, "postgres") },
+			expectedKeys: []string{"stream_count", "source_type"},
+		},
+		{
+			name:  "sync started",
+			track: func() { TrackSyncStarted("sync-1", mix, "postgres", destination, 11) },
+			expectedKeys: []string{
+				"sync_start", "sync_id", "stream_count", "source_type", "destination_type", "catalog_type",
+			},
+			expectedValues: streamMixProps,
+		},
+		{
+			name:  "sync completed",
+			track: func() { TrackSyncCompleted("sync-1", mix, destination, false, 100, 2048) },
+			expectedKeys: []string{
+				"sync_id", "sync_end", "sync_status", "records_synced", "bytes_read",
+				"destination_type", "catalog_type",
+			},
+			expectedValues: streamMixProps,
+		},
+		{
+			name: "failure",
+			track: func() {
+				TrackFailure("sync", "postgres", "sync-1", errs.Failure{
+					Category: errs.AuthFailed, ClassifiedBy: errs.ClassifiedByVendor,
+					Code: "28P01", ErrorType: "*pgconn.PgError",
+				})
+			},
+			expectedKeys: []string{"command", "error_source", "category", "classified_by", "sync_id", "code", "error_type"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := stubClient(t)
+			tc.track()
+			drain()
+
+			events := capture.events(t)
+			require.Len(t, events, 1, "exactly one event should have been sent")
+			for _, key := range tc.expectedKeys {
+				assert.Contains(t, events[0], key, "property %q is missing", key)
+			}
+			// EqualValues: the payload has been through JSON, so counters arrive as float64.
+			for key, expected := range tc.expectedValues {
+				assert.EqualValues(t, expected, events[0][key], "property %q", key)
+			}
+		})
+	}
+}
+
+// TestTrackFailureOmitsAbsentFields covers the deliberate choice not to fake a value: an absent
+// code is a legitimate slice in a dashboard, not an empty string to be counted.
+func TestTrackFailureOmitsAbsentFields(t *testing.T) {
+	markInitDone()
+
+	testCases := []struct {
+		name           string
+		syncID         string
+		failure        errs.Failure
+		expectedAbsent []string
+	}{
+		{
+			name:           "no sync id outside sync",
+			syncID:         "",
+			failure:        errs.Failure{Category: errs.ConfigInvalid, ClassifiedBy: errs.ClassifiedByPrecondition},
+			expectedAbsent: []string{"sync_id", "code", "error_type"},
+		},
+		{
+			name:           "unclassified carries the type but no code",
+			syncID:         "",
+			failure:        errs.Failure{Category: errs.Unclassified, ClassifiedBy: errs.ClassifiedByDefault, ErrorType: "*errors.errorString"},
+			expectedAbsent: []string{"sync_id", "code"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := stubClient(t)
+			TrackFailure("check", "postgres", tc.syncID, tc.failure)
+			drain()
+
+			events := capture.events(t)
+			require.Len(t, events, 1)
+			for _, key := range tc.expectedAbsent {
+				assert.NotContains(t, events[0], key, "property %q should be omitted, not empty", key)
+			}
+			assert.Equal(t, string(tc.failure.Category), events[0]["category"])
+		})
+	}
+}
+
+// TestDestinationShape covers reading the destination type and catalog type off a writer config,
+// including the shapes that would panic on a bare type assertion.
+func TestDestinationShape(t *testing.T) {
+	testCases := []struct {
+		name                string
+		config              *types.WriterConfig
+		expectedDestination string
+		expectedCatalog     string
+	}{
+		// no destination at all, e.g. a discover run
+		{name: "nil config", config: nil},
+		// catalog_type is an iceberg concept only
+		{
+			name:                "iceberg with a catalog",
+			config:              &types.WriterConfig{Type: types.Iceberg, WriterConfig: map[string]any{"catalog_type": "glue"}},
+			expectedDestination: string(types.Iceberg),
+			expectedCatalog:     "glue",
+		},
+		{
+			name:                "iceberg without a catalog key",
+			config:              &types.WriterConfig{Type: types.Iceberg, WriterConfig: map[string]any{}},
+			expectedDestination: string(types.Iceberg),
+		},
+		// a writer config of an unexpected shape must not panic
+		{
+			name:                "iceberg with a non-map writer config",
+			config:              &types.WriterConfig{Type: types.Iceberg, WriterConfig: "not-a-map"},
+			expectedDestination: string(types.Iceberg),
+		},
+		{
+			name:                "iceberg with a non-string catalog type",
+			config:              &types.WriterConfig{Type: types.Iceberg, WriterConfig: map[string]any{"catalog_type": 42}},
+			expectedDestination: string(types.Iceberg),
+		},
+		// every other destination reports no catalog
+		{
+			name:                "parquet reports no catalog",
+			config:              &types.WriterConfig{Type: types.Parquet, WriterConfig: map[string]any{"catalog_type": "ignored"}},
+			expectedDestination: string(types.Parquet),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			destination, catalog := destinationShape(tc.config)
+			assert.Equal(t, tc.expectedDestination, destination)
+			assert.Equal(t, tc.expectedCatalog, catalog)
+		})
+	}
+}
+
+// TestSendContainsPanics covers the guarantee send documents: a panic while reporting must not
+// kill the command being reported on, and must still release Flush.
+func TestSendContainsPanics(t *testing.T) {
+	markInitDone()
+	stubClient(t)
+
+	assert.NotPanics(t, func() {
+		send("boom", func() { panic("event build failed") })
+		drain()
+	})
+
+	t.Run("a later event still sends", func(t *testing.T) {
+		capture := stubClient(t)
+		require.NoError(t, telemetry.sendEvent("After Panic - CLI", nil))
+		assert.Len(t, capture.events(t), 1)
+	})
+}
+
+// TestFlush covers what Flush is for: the command exits immediately after it returns, so an
+// event still in flight would be discarded as the process dies. When telemetry is off there is
+// nothing to wait for and it short-circuits before touching the WaitGroup.
+func TestFlush(t *testing.T) {
+	markInitDone()
+	stubClient(t)
+
+	t.Run("returns immediately with nothing in flight", func(t *testing.T) {
+		start := time.Now()
+		Flush()
+		assert.Less(t, time.Since(start), 200*time.Millisecond)
+	})
+
+	t.Run("waits for a handed-off event", func(t *testing.T) {
+		// Forced on rather than skipped when TELEMETRY_DISABLED is set, so the branch is
+		// covered in either environment.
+		withDisabled(t, false, func() {
+			ran := make(chan struct{})
+			send("slow", func() {
+				time.Sleep(150 * time.Millisecond)
+				close(ran)
+			})
+
+			Flush()
+			select {
+			case <-ran:
+			default:
+				require.Fail(t, "Flush returned before the event finished")
+			}
+		})
+	})
+}
+
+// withDisabled runs body with Disabled() reporting want. The value is cached behind a sync.Once,
+// so once that has fired Disabled() simply returns the cached bool — setting it directly drives
+// both branches in one run, in either environment, without copying the Once.
+func withDisabled(t *testing.T, want bool, body func()) {
+	t.Helper()
+	_ = Disabled() // ensure the Once has fired, so the cached value is what Disabled() returns
+
+	previous := disabled
+	t.Cleanup(func() { disabled = previous })
+
+	disabled = want
+	require.Equal(t, want, Disabled())
+	body()
+}
+
+// TestFlushShortCircuitsWhenDisabled covers the guard at the top of Flush. With telemetry off
+// there is nothing in flight to wait for, so it must return without touching the WaitGroup —
+// which is what keeps a disabled run from paying the flush budget.
+func TestFlushShortCircuitsWhenDisabled(t *testing.T) {
+	markInitDone()
+	stubClient(t)
+
+	withDisabled(t, true, func() {
+		release := make(chan struct{})
+		send("blocked", func() { <-release })
+
+		start := time.Now()
+		Flush()
+		assert.Less(t, time.Since(start), 100*time.Millisecond,
+			"Flush must not wait when telemetry is disabled")
+
+		close(release)
+		drain()
+	})
+}
+
+// TestSendSkipsWhenClientIsMissing covers the guard in send: when Init found telemetry disabled
+// the client is never built, and an event must be dropped rather than dereference a nil.
+func TestSendSkipsWhenClientIsMissing(t *testing.T) {
+	markInitDone()
+
+	previous := telemetry
+	telemetry = nil
+	t.Cleanup(func() { telemetry = previous })
+
+	ran := false
+	assert.NotPanics(t, func() {
+		send("orphan", func() { ran = true })
+		drain()
+	})
+	assert.False(t, ran, "the event body must not run without a client")
+}
+
+// TestTrackEventsSurviveASendFailure covers the error branch each Track function has: a refused
+// endpoint is logged and swallowed, never returned to the command being reported on.
+func TestTrackEventsSurviveASendFailure(t *testing.T) {
+	markInitDone()
+
+	mix := types.StreamMix{FullRefresh: 1, Selected: 1}
+	destination := &types.WriterConfig{Type: types.Parquet}
+
+	testCases := []struct {
+		name  string
+		track func()
+	}{
+		{name: "discover", track: func() { TrackDiscover(1, "postgres") }},
+		{name: "sync started", track: func() { TrackSyncStarted("s", mix, "postgres", destination, 1) }},
+		{name: "sync completed", track: func() { TrackSyncCompleted("s", mix, destination, true, 1, 1) }},
+		{name: "failure", track: func() { TrackFailure("sync", "postgres", "s", errs.Failure{Category: errs.AuthFailed}) }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := stubClient(t)
+			capture.status = http.StatusServiceUnavailable
+
+			assert.NotPanics(t, func() {
+				tc.track()
+				drain()
+			})
+			assert.Len(t, capture.events(t), 1, "the attempt is still made, the failure is only logged")
+		})
+	}
+}
+
+// TestSendEventRejectsUnmarshalableProperties covers the marshal error branch: a property that
+// cannot be encoded must surface as an error rather than send a malformed body.
+func TestSendEventRejectsUnmarshalableProperties(t *testing.T) {
+	capture := stubClient(t)
+
+	err := telemetry.sendEvent("Bad - CLI", map[string]any{"ch": make(chan int)})
+
+	require.Error(t, err)
+	assert.Empty(t, capture.bodies, "nothing may be sent when the payload cannot be built")
+}
+
+// TestGetUserID covers the distinct_id every event carries. It is read from disk when present,
+// so the trimming and the generated fallback both have to hold: a changed id splits one user
+// into two in every dashboard.
+func TestGetUserID(t *testing.T) {
+	testCases := []struct {
+		name       string
+		fileBody   string // written to <config folder>/user_id.txt; empty means no file
+		writeFile  bool
+		expectedID string // empty means a fresh id is generated instead
+	}{
+		// the file is written by a previous run and read back verbatim
+		{name: "plain id from file", fileBody: "abc123", writeFile: true, expectedID: "abc123"},
+		// logger.FileLogger writes JSON, so the id comes back quoted and must be trimmed
+		{name: "quoted id is trimmed", fileBody: `"abc123"`, writeFile: true, expectedID: "abc123"},
+		// an empty file is still a successful read, so it is honored rather than regenerated
+		{name: "empty file", fileBody: "", writeFile: true, expectedID: ""},
+		// first run on this machine
+		{name: "no file, id is generated", writeFile: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			viper.Set(constants.ConfigFolder, dir)
+			t.Cleanup(func() { viper.Set(constants.ConfigFolder, "") })
+
+			if tc.writeFile {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, userIDFile+".txt"), []byte(tc.fileBody), 0o600))
+			}
+
+			got := getUserID()
+
+			if tc.writeFile {
+				assert.Equal(t, tc.expectedID, got)
+				return
+			}
+			// a generated id is 32 hex characters, and must differ from the empty string
+			assert.Len(t, got, 32)
+			assert.Regexp(t, "^[0-9a-f]{32}$", got)
+		})
+	}
+}
+
+// TestGeneratedUserIDPersists covers the round trip that keeps one machine one user: the first call generates and writes the id, later calls read it back through logger.FileLogger's JSON quotes.
+func TestGeneratedUserIDPersists(t *testing.T) {
+	dir := t.TempDir()
+	viper.Set(constants.ConfigFolder, dir)
+	t.Cleanup(func() { viper.Set(constants.ConfigFolder, "") })
+
+	generated := getUserID()
+	require.Regexp(t, "^[0-9a-f]{32}$", generated)
+
+	written, err := os.ReadFile(filepath.Join(dir, userIDFile+".txt"))
+	require.NoError(t, err, "the id must be written for the next run to find")
+	assert.Equal(t, generated, strings.Trim(string(written), `"`), "what is written is what was returned")
+
+	assert.Equal(t, generated, getUserID(), "a later call must read the file, not generate a new id")
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/datazip-inc/olake/constants"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/goccy/go-json"
 	"github.com/oklog/ulid"
@@ -167,25 +168,31 @@ func CheckIfFilesExists(files ...string) error {
 // }
 
 func UnmarshalFile(file string, dest any, credsFile bool) error {
+	// Classified here because nothing further up can tell a missing file from an unreadable
+	// one from a wrong encryption key.
 	if err := CheckIfFilesExists(file); err != nil {
-		return err
+		return errs.Precondition(errs.ConfigInvalid, "config.file_unreadable", err)
 	}
 	data, err := os.ReadFile(file)
 	if err != nil {
-		return fmt.Errorf("file not found : %s", err)
+		return errs.Precondition(errs.ConfigInvalid, "config.file_unreadable",
+			fmt.Errorf("file not found : %w", err))
 	}
 	decryptedJSON := data
 	// Use the encryption package to decrypt JSON
 	if credsFile && viper.GetString(constants.EncryptionKey) != "" {
 		dConfig, err := Decrypt(string(data))
 		if err != nil {
-			return fmt.Errorf("failed to decrypt config file[%s]: %s", file, err)
+			// A wrong or missing --encryption-key, not a malformed config.
+			return errs.Precondition(errs.ConfigDecryptFailed, "config.decrypt_failed",
+				fmt.Errorf("failed to decrypt config file[%s]: %w", file, err))
 		}
 		decryptedJSON = []byte(dConfig)
 	}
 	err = json.Unmarshal(decryptedJSON, dest)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal file[%s]: %s", file, err)
+		return errs.Precondition(errs.ConfigInvalid, "config.malformed_json",
+			fmt.Errorf("failed to unmarshal file[%s]: %w", file, err))
 	}
 	return nil
 }


### PR DESCRIPTION
removed unused dependency

- `testcontainers-bom` 
- 4 `org.testcontainers` dependencies (`testcontainers`, `mysql`, `mongodb`, `minio`)
- `aws-java-sdk-bundle` (test scope)
- `mockito-core`

fixes #1133 