### PR TITLE
chore(ci): add composite actions to dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,14 +46,13 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions/buildx"
-      - "/.github/actions/detect-drivers"
-      - "/.github/actions/driver-deps"
-      - "/.github/actions/go-caches"
-      - "/.github/actions/iceberg-jar"
+      - "/.github/actions/*"
     target-branch: "staging"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    groups:
+      github-actions:
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,13 @@ updates:
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/buildx"
+      - "/.github/actions/detect-drivers"
+      - "/.github/actions/driver-deps"
+      - "/.github/actions/go-caches"
+      - "/.github/actions/iceberg-jar"
     target-branch: "staging"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Updated .github/dependabot.yml to use a directories array, adding all composite actions under .github/actions/ to the dependabot scan schedule.

fixes #1132
## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [X] N/A (bug fix, refactor, or test changes only)