### PR TITLE
feat: upsert mode in Kafka(source)

### DIFF
--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -173,39 +173,41 @@ func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) er
 		}
 
 		writer.data = append(writer.data, rec)
-		recordOpType := rec.OlakeColumns[constants.OpType].(string)
 		recordOlakeID := rec.OlakeColumns[constants.OlakeID].(string)
 		filePosition := writer.dataWriter.currentRowCount + int64(len(writer.data)-1)
 
 		if w.indexThread != nil {
-			if err := w.indexRecord(writer, recordOlakeID, recordOpType, filePosition); err != nil {
+			if err := w.indexRecord(writer, recordOlakeID, rec.OlakeColumns, filePosition); err != nil {
 				return err
 			}
-		} else if w.upsertMode && (recordOpType == "d" || recordOpType == "u" || recordOpType == "i") {
-			if _, exists := writer.olakeIDPosition[recordOlakeID]; !exists {
-				// first time, add to equality deletes and track position
-				writer.equalityDeletes = append(writer.equalityDeletes, recordOlakeID)
-				writer.olakeIDPosition[recordOlakeID] = PositionalDelete{
-					FilePath: writer.dataWriter.filePath,
-					Position: filePosition,
-				}
-			} else {
-				// duplicates, add prev position to positional deletes (n-1 logic)
-				// the latest (nth) occurrence is kept in the map but not added to deletes
-				prev := writer.olakeIDPosition[recordOlakeID]
-				writer.positionalDeletes = append(writer.positionalDeletes, PositionalDelete{
-					FilePath: prev.FilePath,
-					Position: prev.Position,
-				})
-				writer.olakeIDPosition[recordOlakeID] = PositionalDelete{
-					FilePath: writer.dataWriter.filePath,
-					Position: filePosition,
+		} else if w.upsertMode {
+			recordOpType := rec.OlakeColumns[constants.OpType].(string)
+			if recordOpType == "d" || recordOpType == "u" || recordOpType == "i" {
+				if _, exists := writer.olakeIDPosition[recordOlakeID]; !exists {
+					// first time, add to equality deletes and track position
+					writer.equalityDeletes = append(writer.equalityDeletes, recordOlakeID)
+					writer.olakeIDPosition[recordOlakeID] = PositionalDelete{
+						FilePath: writer.dataWriter.filePath,
+						Position: filePosition,
+					}
+				} else {
+					// duplicates, add prev position to positional deletes (n-1 logic)
+					// the latest (nth) occurrence is kept in the map but not added to deletes
+					prev := writer.olakeIDPosition[recordOlakeID]
+					writer.positionalDeletes = append(writer.positionalDeletes, PositionalDelete{
+						FilePath: prev.FilePath,
+						Position: prev.Position,
+					})
+					writer.olakeIDPosition[recordOlakeID] = PositionalDelete{
+						FilePath: writer.dataWriter.filePath,
+						Position: filePosition,
+					}
 				}
 			}
 		}
 
 		// Normalise "i" → "c" in the data file so downstream consumers see a consistent op type.
-		if recordOpType == "i" {
+		if rec.OlakeColumns[constants.OpType] == "i" {
 			rec.OlakeColumns[constants.OpType] = "c"
 		}
 	}
@@ -214,8 +216,9 @@ func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) er
 }
 
 // search for index for the record and emmit pos when found
-func (w *ArrowWriter) indexRecord(writer *Writer, olakeID, opType string, filePosition int64) error {
-	if w.upsertMode && (opType != "r" && opType != "c") {
+func (w *ArrowWriter) indexRecord(writer *Writer, olakeID string, olakeColumns map[string]any, filePosition int64) error {
+	opType := olakeColumns[constants.OpType].(string)
+	if w.upsertMode && opType != "r" {
 		previous, found, err := w.indexThread.Lookup(olakeID)
 		if err != nil {
 			return fmt.Errorf("failed to look up row[%s] in index: %s", olakeID, err)
@@ -225,6 +228,11 @@ func (w *ArrowWriter) indexRecord(writer *Writer, olakeID, opType string, filePo
 				FilePath: previous.FilePath,
 				Position: previous.Position,
 			})
+			if opType != "d" {
+				olakeColumns[constants.OpType] = "u"
+			}
+		} else if opType == "u" {
+			olakeColumns[constants.OpType] = "c"
 		}
 	}
 

--- a/destination/iceberg/legacy-writer/writer.go
+++ b/destination/iceberg/legacy-writer/writer.go
@@ -55,6 +55,32 @@ func (w *LegacyWriter) Write(ctx context.Context, records []types.RawRecord) err
 			continue
 		}
 
+		opType := record.OlakeColumns[constants.OpType].(string)
+		var deleteFilePath *string
+		var deletePosition *int64
+
+		// check if we need to write pos for the current record
+		if w.indexThread != nil && (opType != "r") {
+			olakeID := record.OlakeColumns[constants.OlakeID].(string)
+			previous, found, err := w.indexThread.Lookup(olakeID)
+			if err != nil {
+				return fmt.Errorf("failed to look up row[%s] in index: %s", olakeID, err)
+			}
+			if found {
+				filePath := previous.FilePath
+				position := previous.Position
+				deleteFilePath = &filePath
+				deletePosition = &position
+				if opType != "d" {
+					opType = "u"
+				}
+			} else if opType == "u" {
+				opType = "c"
+			}
+			record.OlakeColumns[constants.OpType] = opType
+			record.Data[constants.OpType] = opType
+		}
+
 		protoColumnsValue := make([]*proto.IcebergPayload_IceRecord_FieldValue, 0, len(protoSchema))
 		for _, field := range protoSchema {
 			val, exist := record.Data[field.Key]
@@ -73,25 +99,11 @@ func (w *LegacyWriter) Write(ctx context.Context, records []types.RawRecord) err
 			continue
 		}
 
-		opType := record.OlakeColumns[constants.OpType].(string)
 		iceRecord := &proto.IcebergPayload_IceRecord{
-			Fields:     protoColumnsValue,
-			RecordType: opType,
-		}
-
-		// check if we need to write pos for the current record
-		if w.indexThread != nil && (opType != "r" && opType != "c") {
-			olakeID := record.OlakeColumns[constants.OlakeID].(string)
-			previous, found, err := w.indexThread.Lookup(olakeID)
-			if err != nil {
-				return fmt.Errorf("failed to look up row[%s] in index: %s", olakeID, err)
-			}
-			if found {
-				filePath := previous.FilePath
-				position := previous.Position
-				iceRecord.DeleteFilePath = &filePath
-				iceRecord.DeletePosition = &position
-			}
+			Fields:         protoColumnsValue,
+			RecordType:     opType,
+			DeleteFilePath: deleteFilePath,
+			DeletePosition: deletePosition,
 		}
 
 		protoRecords = append(protoRecords, iceRecord)

--- a/drivers/kafka/go.mod
+++ b/drivers/kafka/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/datazip-inc/olake v0.0.0-00010101000000-000000000000
 	github.com/dlclark/regexp2 v1.11.5
 	github.com/linkedin/goavro/v2 v2.15.0
+	github.com/stretchr/testify v1.11.1
 	github.com/twmb/franz-go v1.21.1
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 )
@@ -51,6 +52,7 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
@@ -93,6 +95,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect

--- a/drivers/kafka/internal/cdc.go
+++ b/drivers/kafka/internal/cdc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/datazip-inc/olake/constants"
@@ -28,6 +29,19 @@ func (k *Kafka) ChangeStreamConfig() (bool, bool, bool) {
 func (k *Kafka) PreCDC(ctx context.Context, streams []types.StreamInterface) error {
 	if len(streams) == 0 {
 		return fmt.Errorf("no valid streams found for CDC")
+	}
+
+	// Upsert: set SourceDefinedPrimaryKey from dedup_keys
+	for _, stream := range streams {
+		cfg, err := UpsertConfigFrom(stream.Self().StreamMetadata)
+		if err != nil {
+			return fmt.Errorf("stream[%s]: %s", stream.ID(), err)
+		}
+		if !cfg.Enabled {
+			continue
+		}
+		stream.GetStream().SourceDefinedPrimaryKey = types.NewSet(cfg.DedupKeys...)
+		logger.Infof("stream[%s]: upsert dedup keys %v", stream.ID(), cfg.DedupKeys)
 	}
 
 	var groupID string
@@ -116,14 +130,105 @@ func (k *Kafka) StreamChanges(ctx context.Context, readerID int, metadataStates 
 				fmt.Errorf("missing partition Metadata for topic %s partition %d", record.Message.Topic, record.Message.Partition))
 		}
 
-		// process the change if data is present
-		if record.Data != nil {
-			// Raw wire bytes: len(Key) + len(Value). Headers are excluded — they
-			// carry protocol metadata (schema IDs, trace context), not user data.
-			err := processFn(ctx, abstract.NewCDCChange(currentPartitionMeta.Stream, record.Message.Timestamp, "create",
-				record.Data, nil, int64(len(record.Message.Key)+len(record.Message.Value))))
-			if err != nil {
-				return false, err
+		stream := currentPartitionMeta.Stream
+		cfg, err := UpsertConfigFrom(stream.Self().StreamMetadata)
+		if err != nil {
+			return false, err
+		}
+		bytesRead := int64(len(record.Message.Key) + len(record.Message.Value))
+		if !cfg.Enabled {
+			//append only
+			if record.Data != nil {
+				if err := processFn(ctx, abstract.NewCDCChange(stream, record.Message.Timestamp, "create", record.Data, nil, bytesRead)); err != nil {
+					return false, err
+				}
+			}
+		} else {
+			// upsert
+			kafkaKey := ""
+			if record.Data != nil {
+				if kKey, ok := record.Data[Key].(string); ok {
+					kafkaKey = kKey
+				}
+			}
+			if kafkaKey == "" && len(record.Message.Key) > 0 {
+				kafkaKey = k.canonicalizeKafkaKey(string(record.Message.Key))
+			}
+
+			appendByOffsetPartition := func(data map[string]any) error {
+				if data == nil {
+					data = map[string]any{}
+				}
+				data[Partition] = record.Message.Partition
+				data[Offset] = record.Message.Offset
+				if kafkaKey != "" {
+					data[Key] = kafkaKey
+				}
+				olakeID := utils.GetKeysHash(data, Offset, Partition)
+				extraColumns := map[string]any{
+					constants.OlakeID: olakeID,
+				}
+				logger.Warnf("appending with offset/partition - olake_id for topic=%s partition=%d offset=%d", record.Message.Topic, record.Message.Partition, record.Message.Offset)
+				return processFn(ctx, abstract.NewCDCChange(stream, record.Message.Timestamp, "create", data, extraColumns, bytesRead))
+			}
+
+			if record.Message.Value == nil {
+				if cfg.AllowTombstoneDeletes {
+					//dedup is only _kafka_key (present and not null) - tombstone deletes are valid
+					data, err := cfg.checkDedupKeysExist(record.Data, kafkaKey, record.KeyFields)
+					if err != nil {
+						//key - null
+						if errors.Is(err, errNullDedupKeys) {
+							return false, fmt.Errorf("stream[%s] offset=%d: %w", stream.ID(), record.Message.Offset, err)
+						}
+						// key - absent
+					} else {
+						extraColumns := map[string]any{
+							constants.OlakeID: cfg.generateOlakeIDFromExistingKeys(data),
+						}
+						if err := processFn(ctx, abstract.NewCDCChange(stream, record.Message.Timestamp, "delete", data, extraColumns, bytesRead)); err != nil {
+							return false, err
+						}
+					}
+				} else {
+					//upsert only -- null value is appended by _kafka_key (no deletes)
+					if kafkaKey != "" {
+						data := map[string]any{
+							Partition: record.Message.Partition,
+							Offset:    record.Message.Offset,
+							Key:       kafkaKey,
+						}
+						// olake_id - with kafka_key string
+						extraColumns := map[string]any{
+							constants.OlakeID: kafkaKey,
+						}
+						if err := processFn(ctx, abstract.NewCDCChange(stream, record.Message.Timestamp, "create", data, extraColumns, bytesRead)); err != nil {
+							return false, err
+						}
+					}
+					// null, null - avoid
+				}
+			} else if record.Data != nil {
+				// Non null value: Upsert when atleast one selected dedup key exist, all absent - append, all null - fail sync
+				data, err := cfg.checkDedupKeysExist(record.Data, kafkaKey, record.KeyFields)
+				if err != nil {
+					// all present dedup fields null - fail sync
+					if errors.Is(err, errNullDedupKeys) {
+						return false, fmt.Errorf("stream[%s] offset=%d: %w", stream.ID(), record.Message.Offset, err)
+					}
+					// no selected dedup fields is present - append
+					if err := appendByOffsetPartition(record.Data); err != nil {
+						return false, err
+					}
+				} else {
+					// atleast one non-null - upsert (partial null/empty/whitespace included in hash)
+					extraColumns := map[string]any{
+						constants.OlakeID: cfg.generateOlakeIDFromExistingKeys(data),
+					}
+					if err := processFn(ctx, abstract.NewCDCChange(stream, record.Message.Timestamp, "update", data, extraColumns, bytesRead)); err != nil {
+						return false, err
+					}
+				}
 			}
 		}
 
@@ -279,7 +384,7 @@ func (k *Kafka) processKafkaMessages(ctx context.Context, reader *kgo.Client, st
 			}
 
 			message := iter.Next()
-			data, key, err := k.parseKafkaData(message)
+			data, key, keyFields, err := k.parseKafkaData(message)
 			if err != nil {
 				logger.Warnf("failed to parse message of topic: %s, partition: %d, offset %d, error: %s", message.Topic, message.Partition, message.Offset, err)
 			} else if data != nil {
@@ -293,7 +398,7 @@ func (k *Kafka) processKafkaMessages(ctx context.Context, reader *kgo.Client, st
 				}
 			}
 
-			stopProcessing, err := stopProcessFn(types.KafkaRecord{Data: data, Message: message})
+			stopProcessing, err := stopProcessFn(types.KafkaRecord{Data: data, KeyFields: keyFields, Message: message})
 			if err != nil {
 				return err
 			}
@@ -304,7 +409,29 @@ func (k *Kafka) processKafkaMessages(ctx context.Context, reader *kgo.Client, st
 	}
 }
 
-func (k *Kafka) parseKafkaData(message *kgo.Record) (map[string]interface{}, string, error) {
+// canonicalizeKafkaKey - normalize _kafka_key string
+func (k *Kafka) canonicalizeKafkaKey(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return raw
+	}
+	if raw[0] != '{' {
+		return raw
+	}
+	var m map[string]interface{}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&m); err != nil {
+		return raw
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return raw
+	}
+	return string(b)
+}
+
+func (k *Kafka) parseKafkaData(message *kgo.Record) (map[string]interface{}, string, map[string]interface{}, error) {
 	// helper to parse data bytes (value or key)
 	parseData := func(data []byte) (interface{}, error) {
 		// if data is not in confluent wire format, it is assumed to be standard json currently
@@ -341,41 +468,51 @@ func (k *Kafka) parseKafkaData(message *kgo.Record) (map[string]interface{}, str
 	if message.Value != nil {
 		valDecoded, err := parseData(message.Value)
 		if err != nil {
-			return nil, "", err
+			return nil, "", nil, err
 		}
 		if vm, ok := valDecoded.(map[string]interface{}); ok {
 			messageValue = vm
 		} else {
-			return nil, "", fmt.Errorf("expected format for message value is not supported, got %s of type %T", valDecoded, valDecoded)
+			return nil, "", nil, fmt.Errorf("expected format for message value is not supported, got %s of type %T", valDecoded, valDecoded)
 		}
 	}
 
 	// 2. Parse Message Key
 	var keyValue string
+	var keyFields map[string]interface{}
 	if len(message.Key) > 0 {
 		parsedKey, err := parseData(message.Key)
 		if err != nil {
 			// standard fallback: raw key as string
-			keyValue = string(message.Key)
+			keyValue = k.canonicalizeKafkaKey(string(message.Key))
 		} else {
 			switch v := parsedKey.(type) {
 			case string:
-				keyValue = v
+				keyValue = k.canonicalizeKafkaKey(v)
 			case []byte:
-				keyValue = string(v)
+				keyValue = k.canonicalizeKafkaKey(string(v))
+			case map[string]interface{}:
+				keyFields = v
+				keyJSON, msgErr := json.Marshal(v)
+				if msgErr != nil {
+					logger.Warnf("failed to marshal decoded key at offset %d: %s, using raw string", message.Offset, msgErr)
+					keyValue = k.canonicalizeKafkaKey(string(message.Key))
+				} else {
+					keyValue = string(keyJSON)
+				}
 			default:
-				bytes, err := json.Marshal(v)
+				keyJSON, err := json.Marshal(v)
 				if err != nil {
 					logger.Warnf("failed to marshal decoded key at offset %d: %s, using raw string", message.Offset, err)
-					keyValue = string(message.Key)
+					keyValue = k.canonicalizeKafkaKey(string(message.Key))
 				} else {
-					keyValue = string(bytes)
+					keyValue = k.canonicalizeKafkaKey(string(keyJSON))
 				}
 			}
 		}
 	}
 
-	return messageValue, keyValue, nil
+	return messageValue, keyValue, keyFields, nil
 }
 
 // decode kafka json message

--- a/drivers/kafka/internal/upsert.go
+++ b/drivers/kafka/internal/upsert.go
@@ -1,0 +1,107 @@
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/datazip-inc/olake/types"
+	"github.com/datazip-inc/olake/utils"
+)
+
+var errNullDedupKeys = errors.New("all dedup keys are null")
+
+type UpsertConfig struct {
+	Enabled               bool
+	DedupKeys             []string
+	AllowTombstoneDeletes bool
+}
+
+func NewUpsertConfig(meta types.StreamMetadata, dedupKeys []string) (UpsertConfig, error) {
+	// case 1 - dedup key is only _kafka_key -- upsert + tombstone deletes on
+	// case 2 - dedup key selection [_kafka_key(choice) + columns] -- upsert only (no tombstones)
+	cfg := UpsertConfig{
+		Enabled:               !meta.AppendMode,
+		DedupKeys:             dedupKeys,
+		AllowTombstoneDeletes: isKafkaKeyOnlyDedup(dedupKeys),
+	}
+	return cfg, cfg.Validate()
+}
+
+func UpsertConfigFrom(meta types.StreamMetadata) (UpsertConfig, error) {
+	return NewUpsertConfig(meta, meta.DedupKeys)
+}
+
+// isKafkaKeyOnlyDedup: checks if user selects only _kafka_key as dedup key
+// need to enable upsert +  delete; anything else is upsert only
+func isKafkaKeyOnlyDedup(dedupKeys []string) bool {
+	return len(dedupKeys) == 1 && dedupKeys[0] == Key
+}
+
+func (c UpsertConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if len(c.DedupKeys) == 0 {
+		return fmt.Errorf("upsert mode: dedup key is required")
+	}
+	for _, key := range c.DedupKeys {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("upsert mode: dedup key contains an empty field name")
+		}
+	}
+	return nil
+}
+
+func (c UpsertConfig) checkDedupKeysExist(data map[string]any, kafkaKey string, keyFields map[string]any) (map[string]any, error) {
+	if data == nil {
+		data = map[string]any{}
+	}
+	for _, pk := range c.DedupKeys {
+		if _, ok := data[pk]; ok {
+			continue
+		}
+		//from parsed JSON key
+		if keyFields != nil {
+			if val, ok := keyFields[pk]; ok {
+				data[pk] = val
+				continue
+			}
+		}
+		if pk == Key && kafkaKey != "" {
+			data[pk] = kafkaKey
+			continue
+		}
+	}
+
+	anyPresent := false
+	anyNonNull := false
+	for _, pk := range c.DedupKeys {
+		val, ok := data[pk]
+		if !ok {
+			continue
+		}
+		anyPresent = true
+		if val != nil {
+			anyNonNull = true
+		}
+	}
+	if anyNonNull {
+		return data, nil
+	}
+	if anyPresent {
+		return nil, errNullDedupKeys
+	}
+
+	return nil, fmt.Errorf("missing dedup keys")
+}
+
+func (c UpsertConfig) generateOlakeIDFromExistingKeys(data map[string]any) string {
+	existing := make([]string, 0, len(c.DedupKeys))
+	for _, pk := range c.DedupKeys {
+		if _, ok := data[pk]; ok {
+			existing = append(existing, pk)
+		}
+	}
+	return utils.GetKeysHash(data, existing...)
+}

--- a/drivers/kafka/internal/upsert_test.go
+++ b/drivers/kafka/internal/upsert_test.go
@@ -1,0 +1,328 @@
+package driver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/datazip-inc/olake/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsKafkaKeyOnlyDedup(t *testing.T) {
+	tests := []struct {
+		name                 string
+		dedupKeys            []string
+		wantModeOnlyKafkaKey bool
+	}{
+		{
+			name:                 "only _kafka_key",
+			dedupKeys:            []string{Key},
+			wantModeOnlyKafkaKey: true,
+		},
+		{
+			name:                 "column id is not just _kafka_key",
+			dedupKeys:            []string{"id"},
+			wantModeOnlyKafkaKey: false,
+		},
+		{
+			name:                 "_kafka_key + column id is not just _kafka_key",
+			dedupKeys:            []string{Key, "id"},
+			wantModeOnlyKafkaKey: false,
+		},
+		{
+			name:                 "empty is under category not just _kafka_key",
+			dedupKeys:            nil,
+			wantModeOnlyKafkaKey: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantModeOnlyKafkaKey, isKafkaKeyOnlyDedup(tt.dedupKeys))
+		})
+	}
+}
+
+func TestNewUpsertConfig(t *testing.T) {
+	tests := []struct {
+		name                 string
+		meta                 types.StreamMetadata
+		dedupKeys            []string
+		wantErr              bool
+		wantEnabled          bool
+		wantTombstoneDeletes bool
+	}{
+		{
+			name:                 "append mode skips dedup validation",
+			meta:                 types.StreamMetadata{AppendMode: true},
+			dedupKeys:            nil,
+			wantErr:              false,
+			wantEnabled:          false,
+			wantTombstoneDeletes: false,
+		},
+		{
+			name:      "upsert empty dedup keys errors",
+			meta:      types.StreamMetadata{AppendMode: false},
+			dedupKeys: nil,
+			wantErr:   true,
+		},
+		{
+			name:      "upsert whitespace dedup key errors",
+			meta:      types.StreamMetadata{AppendMode: false},
+			dedupKeys: []string{"  "},
+			wantErr:   true,
+		},
+		{
+			name:                 "only kafka key enables tombstone deletes",
+			meta:                 types.StreamMetadata{AppendMode: false},
+			dedupKeys:            []string{Key},
+			wantErr:              false,
+			wantEnabled:          true,
+			wantTombstoneDeletes: true,
+		},
+		{
+			name:                 "message column dedup is upsert only",
+			meta:                 types.StreamMetadata{AppendMode: false},
+			dedupKeys:            []string{"id"},
+			wantErr:              false,
+			wantEnabled:          true,
+			wantTombstoneDeletes: false,
+		},
+		{
+			name:                 "kafka key + column as dedup",
+			meta:                 types.StreamMetadata{AppendMode: false},
+			dedupKeys:            []string{Key, "id"},
+			wantErr:              false,
+			wantEnabled:          true,
+			wantTombstoneDeletes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewUpsertConfig(tt.meta, tt.dedupKeys)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnabled, cfg.Enabled)
+			assert.Equal(t, tt.wantTombstoneDeletes, cfg.AllowTombstoneDeletes)
+		})
+	}
+}
+
+func TestCheckDedupKeysExist(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         UpsertConfig
+		data        map[string]any
+		kafkaKey    string
+		keyFields   map[string]any
+		wantErr     error
+		wantMissing bool
+		check       func(t *testing.T, data map[string]any)
+	}{
+		{
+			name: "value has id with empty kafka key",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"id":   "101",
+				"name": "sam",
+				"age":  20,
+			},
+			check: func(t *testing.T, data map[string]any) {
+				assert.Equal(t, "101", data["id"])
+			},
+		},
+		{
+			name: "value has id with kafka key present",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"id":   "101",
+				"name": "sam",
+				"age":  20,
+			},
+			kafkaKey: "random_key",
+		},
+		{
+			name: "Id(passed as dedup key) is missing, dedup not taken from kafka key",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"name": "noId",
+				"age":  2000,
+			},
+			kafkaKey:    "1222",
+			wantMissing: true,
+		},
+		{
+			name: "all selected dedup are null -- fail",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"id":   nil,
+				"name": "sam",
+				"age":  20,
+			},
+			wantErr: errNullDedupKeys,
+		},
+		{
+			name: "dedup key = kafka key(nil) -- fails",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{Key},
+			},
+			data: map[string]any{
+				Key: nil,
+			},
+			wantErr: errNullDedupKeys,
+		},
+		{
+			name: "selected dedup field value is empty string - works",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"id":   "",
+				"name": "sam",
+				"age":  20,
+			},
+		},
+		{
+			name: "dedupe fields some are absent",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id", "name"},
+			},
+			data: map[string]any{
+				"id":  "101",
+				"age": 20,
+			},
+			check: func(t *testing.T, data map[string]any) {
+				_, ok := data["name"]
+				assert.False(t, ok, "absent name must stay absent")
+			},
+		},
+		{
+			name: "dedupe fields are partial null",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id", "name"},
+			},
+			data: map[string]any{
+				"id":   "101",
+				"name": nil,
+				"age":  20,
+			},
+		},
+		{
+			name: "all selected fields are present and all null - fail",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id", "name"},
+			},
+			data: map[string]any{
+				"id":   nil,
+				"name": nil,
+				"age":  20,
+			},
+			wantErr: errNullDedupKeys,
+		},
+		{
+			name: "fill id from keyFields",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"name": nil,
+				"age":  20,
+			},
+			keyFields: map[string]any{
+				"id": "101",
+			},
+			check: func(t *testing.T, data map[string]any) {
+				assert.Equal(t, "101", data["id"])
+			},
+		},
+		{
+			name: "fill _kafka_key from kafkaKey(string of Key)",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{Key},
+			},
+			data:     nil,
+			kafkaKey: "key1",
+			check: func(t *testing.T, data map[string]any) {
+				assert.Equal(t, "key1", data[Key])
+			},
+		},
+		{
+			name: "empty kafkaKey doesnot fill _kafka_key(part of data)",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{Key},
+			},
+			data:        nil,
+			kafkaKey:    "",
+			wantMissing: true,
+		},
+		{
+			name: "nil data and no field names present",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data:        nil,
+			wantMissing: true,
+		},
+		{
+			name: "value from data over value from keyFields(from JSON of Key)",
+			cfg: UpsertConfig{
+				Enabled:   true,
+				DedupKeys: []string{"id"},
+			},
+			data: map[string]any{
+				"id":   "from-value",
+				"name": nil,
+				"age":  20,
+			},
+			keyFields: map[string]any{
+				"id": "from-key",
+			},
+			check: func(t *testing.T, data map[string]any) {
+				assert.Equal(t, "from-value", data["id"])
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.cfg.checkDedupKeysExist(tt.data, tt.kafkaKey, tt.keyFields)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			if tt.wantMissing {
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, errNullDedupKeys))
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, data)
+			}
+		})
+	}
+}

--- a/tests/kafka/kafka_test.go
+++ b/tests/kafka/kafka_test.go
@@ -108,3 +108,11 @@ func TestKafkaRebalance(t *testing.T) {
 	t.Parallel()
 	kafkaJSONBaseConfig(t).TestRebalance(t)
 }
+
+func TestKafkaUpsert(t *testing.T) {
+	t.Parallel()
+	cfg := kafkaJSONBaseConfig(t)
+	cfg.DedupKeys = []string{"_kafka_key"}
+	cfg.IsolateSuite(t, "upsert")
+	cfg.TestSync(t)
+}

--- a/tests/kafka/kafka_util_test.go
+++ b/tests/kafka/kafka_util_test.go
@@ -82,6 +82,10 @@ var (
 	jsonUpdatedValue = []byte(`{"int_value": 100,"float_value": 99.99,"boolean": true,"timestamp_value": "2026-03-22T14:30:00Z","string_value": "test_string", "col_excluded": 101, "col_included": 102}`)
 	jsonFilterValue  = []byte(`{"string_value": "","float_value": 99.99,"col_excluded": 101}`)
 
+	upsertKey    = []byte(`{"key":"upsert-key"}`)
+	upsertAdd    = []byte(`{"int_value": 100,"float_value": 99.99,"boolean": true,"timestamp_value": "2026-03-22T14:30:00Z","string_value": "test_string", "col_excluded": 101}`)
+	upsertUpdate = []byte(`{"int_value": 100,"float_value": 99.99,"boolean": true,"timestamp_value": "2026-03-22T14:30:00Z","string_value": "test_string", "col_excluded": 101, "col_included": 102}`)
+
 	// Avro
 	avroKey   = []byte(`{"key":"avro-key"}`)
 	avroValue = map[string]interface{}{
@@ -189,6 +193,18 @@ func ExecuteQueryJSON(ctx context.Context, t *testing.T, conf *testutils.TestCon
 	case "stop_rebalance":
 		stopRebalanceTrigger()
 		t.Logf("stopped rebalance trigger consumer")
+
+	case "upsert_add":
+		writeMessagesWithRetry(ctx, t, client, &kgo.Record{Key: upsertKey, Value: upsertAdd, Partition: 0})
+		t.Logf("Added 1 message to topic '%s' on partition %d", topic, 0)
+
+	case "upsert_update":
+		writeMessagesWithRetry(ctx, t, client, &kgo.Record{Key: upsertKey, Value: upsertUpdate, Partition: 0})
+		t.Logf("Added 1 updated message to topic '%s' on partition %d", topic, 0)
+
+	case "upsert_tombstone":
+		writeMessagesWithRetry(ctx, t, client, &kgo.Record{Key: upsertKey, Value: nil, Partition: 0})
+		t.Logf("Deleted 1 message from topic '%s' on partition %d", topic, 0)
 
 	default:
 		t.Fatalf("unsupported operation: %s", operation)

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -961,7 +961,7 @@ func (cfg *IntegrationTest) testIcebergFullLoadAndCDC(
 				name:      "CDC - strict - insert",
 				operation: "",
 				useState:  false,
-				opSymbol:  Ternary(upsert, "u", "c").(string),
+				opSymbol:  "c",
 				expected:  cfg.ExpectedData,
 			},
 			{
@@ -1087,7 +1087,7 @@ func (cfg *IntegrationTest) testParquetFullLoadAndCDC(
 				name:      "CDC - strict - insert",
 				operation: "",
 				useState:  false,
-				opSymbol:  Ternary(upsert, "u", "c").(string),
+				opSymbol:  "u",
 				expected:  cfg.ExpectedData,
 			},
 			{

--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -51,6 +51,7 @@ type IntegrationTest struct {
 	PartitionRegex                   string
 	FilterConfig                     string
 	ColumnToExclude                  string
+	DedupKeys                        []string
 }
 
 type PerformanceTest struct {
@@ -692,7 +693,12 @@ func GetBackfillStreamsFromCDC(cdcStreams []string) []string {
 func (cfg *IntegrationTest) resetTable(ctx context.Context, t *testing.T) error {
 	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "drop")
 	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "create")
-	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "add")
+	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, Ternary(len(cfg.DedupKeys) > 0, "upsert_add", "add").(string))
+	if len(cfg.DedupKeys) > 0 {
+		if err := resetStateFile(cfg.TestConfig); err != nil {
+			return err
+		}
+	}
 	if cfg.TestConfig.Driver == string(constants.DB2) {
 		// to populate stats for DB2
 		cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "populate-stats")
@@ -948,6 +954,32 @@ func (cfg *IntegrationTest) testIcebergFullLoadAndCDC(
 	}
 
 	testCases := Ternary(cfg.TestConfig.Driver == string(constants.Kafka), kafkaTestCases, dbTestCases).([]syncTestCase)
+	upsert := len(cfg.DedupKeys) > 0
+	if upsert {
+		testCases = []syncTestCase{
+			{
+				name:      "CDC - strict - insert",
+				operation: "",
+				useState:  false,
+				opSymbol:  Ternary(upsert, "u", "c").(string),
+				expected:  cfg.ExpectedData,
+			},
+			{
+				name:      "CDC - strict - update",
+				operation: "upsert_update",
+				useState:  true,
+				opSymbol:  "u",
+				expected:  cfg.ExpectedUpdatedData,
+			},
+			{
+				name:      "CDC - strict - delete",
+				operation: "upsert_tombstone",
+				useState:  true,
+				opSymbol:  "d",
+				expected:  nil,
+			},
+		}
+	}
 
 	// Run each test case
 	for _, tc := range testCases {
@@ -1048,6 +1080,32 @@ func (cfg *IntegrationTest) testParquetFullLoadAndCDC(
 	}
 
 	testCases := Ternary(cfg.TestConfig.Driver == string(constants.Kafka), kafkaTestCases, dbTestCases).([]syncTestCase)
+	upsert := len(cfg.DedupKeys) > 0
+	if upsert {
+		testCases = []syncTestCase{
+			{
+				name:      "CDC - strict - insert",
+				operation: "",
+				useState:  false,
+				opSymbol:  Ternary(upsert, "u", "c").(string),
+				expected:  cfg.ExpectedData,
+			},
+			{
+				name:      "CDC - strict - update",
+				operation: "upsert_update",
+				useState:  true,
+				opSymbol:  "u",
+				expected:  cfg.ExpectedUpdatedData,
+			},
+			{
+				name:      "CDC - strict - delete",
+				operation: "upsert_tombstone",
+				useState:  true,
+				opSymbol:  "d",
+				expected:  nil,
+			},
+		}
+	}
 
 	// Run each test case
 	for _, tc := range testCases {
@@ -1721,12 +1779,18 @@ func (cfg *IntegrationTest) TestSync(t *testing.T) {
 
 	seedCatalogFromTestStreams(t, cfg.TestConfig, currentTestTable)
 
+	if len(cfg.DedupKeys) > 0 {
+		if err := setStreamUpsert(cfg.TestConfig, cfg.Namespace, currentTestTable, cfg.DedupKeys); err != nil {
+			t.Fatalf("failed to set stream upsert: %s", err)
+		}
+	}
+
 	// 1. Query on test table; drop first so an aborted run's leftovers cannot survive
 	// the CREATE IF NOT EXISTS
 	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "drop")
 	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "create")
 	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "clean")
-	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, "add")
+	cfg.ExecuteQuery(ctx, t, cfg.TestConfig, Ternary(len(cfg.DedupKeys) > 0, "upsert_add", "add").(string))
 
 	// 2. Enable normalization, partition regex, filter and column exclusion in streams.json
 	if err := updateSelectedStreams(cfg.TestConfig, cfg.Namespace, cfg.PartitionRegex, cfg.FilterConfig, []string{currentTestTable}, cfg.ColumnToExclude); err != nil {
@@ -2489,4 +2553,32 @@ func normalizeToTime(v interface{}) (time.Time, bool) {
 	default:
 		return time.Time{}, false
 	}
+}
+
+func setStreamUpsert(cfg *TestConfig, namespace, table string, dedupKeys []string) error {
+	keys := make([]interface{}, 0, len(dedupKeys))
+	for _, k := range dedupKeys {
+		keys = append(keys, k)
+	}
+	return editJSONFile(cfg.HostCatalogPath, func(doc map[string]interface{}) error {
+		selected, _ := doc["selected_streams"].(map[string]interface{})
+		namespaceStreams, ok := selected[namespace].([]interface{})
+		if !ok {
+			return fmt.Errorf("namespace %q missing in selected streams", namespace)
+		}
+		matched := false
+		for _, raw := range namespaceStreams {
+			s, ok := raw.(map[string]interface{})
+			if !ok || fmt.Sprint(s["stream_name"]) != table {
+				continue
+			}
+			s["append_mode"] = false
+			s["dedup_keys"] = keys
+			matched = true
+		}
+		if !matched {
+			return fmt.Errorf("stream %q not found in namespace %q", table, namespace)
+		}
+		return nil
+	})
 }

--- a/types/catalog.go
+++ b/types/catalog.go
@@ -339,6 +339,7 @@ func GetStreamsDelta(oldStreams, newStreams *Catalog) *Catalog {
 					(oldMetadata.UseSourceColumnNames != newMetadata.UseSourceColumnNames) ||
 					!reflect.DeepEqual(oldMetadata.FilterConfig, newMetadata.FilterConfig) ||
 					(oldMetadata.AppendMode != newMetadata.AppendMode) ||
+					!reflect.DeepEqual(oldMetadata.DedupKeys, newMetadata.DedupKeys) ||
 					(oldStream.Stream.SyncMode != newStream.Stream.SyncMode) ||
 					(oldStream.Stream.DestinationDatabase != newStream.Stream.DestinationDatabase) ||
 					(oldStream.Stream.DestinationTable != newStream.Stream.DestinationTable) ||

--- a/types/catalog.go
+++ b/types/catalog.go
@@ -60,6 +60,8 @@ type StreamMetadata struct {
 	//new filter input
 	FilterConfig    *FilterConfig    `json:"filter_config,omitempty"`
 	SelectedColumns *SelectedColumns `json:"selected_columns"`
+
+	DedupKeys []string `json:"dedup_keys,omitempty"`
 }
 
 type Catalog struct {

--- a/types/kafka_types.go
+++ b/types/kafka_types.go
@@ -30,8 +30,9 @@ type PartitionKey struct {
 
 // KafkaRecord represents a record (data + message) from a Kafka partition
 type KafkaRecord struct {
-	Data    map[string]interface{}
-	Message *kgo.Record
+	Data      map[string]interface{}
+	KeyFields map[string]interface{}
+	Message   *kgo.Record
 }
 
 // RegisteredSchema holds the schema information

--- a/types/stream_configured.go
+++ b/types/stream_configured.go
@@ -298,6 +298,9 @@ func (s *ConfiguredStream) NormalizationEnabled() bool {
 }
 
 func (s *ConfiguredStream) GetUpdateType() UpdateType {
+	if !s.StreamMetadata.AppendMode && len(s.StreamMetadata.DedupKeys) > 0 {
+		return UpdateTypePosition
+	}
 	if s.StreamMetadata.UpdateType == "" {
 		return UpdateTypeEquality
 	}


### PR DESCRIPTION
# Description

Added source side **Kafka Upsert** support with Iceberg positional deletes

When `append_mode` is `false` and `dedup_keys` are set on streams
- Records with at least one non-null selected dedup field upsert via `_olake_id` derived from those keys
- Missing selected dedup fields append (offset/partition identity)
- All selected dedup fields present but **null** fail the sync
- Mode A (`dedup_keys = ["_kafka_key"]` only): Upsert + Kafka tombstones deletes
- Mode B (`dedup_keys = selected fields`): Upsert only

Upsert streams force update_type=pos

[PRD](https://datazip.atlassian.net/wiki/spaces/PD/pages/654704668/Kafka+Upsert+Mode+Support)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Locally tested Upsert cases
- [x] Unit tests
- [x]  Integration tests for Upsert


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

