### PR TITLE
fix: exit code for check fail

### DIFF
--- a/protocol/check.go
+++ b/protocol/check.go
@@ -36,7 +36,7 @@ var checkCmd = &cobra.Command{
 
 		return nil
 	},
-	RunE: func(cmd *cobra.Command, _ []string) error {
+	Run: func(cmd *cobra.Command, _ []string) {
 		err := func() error {
 			// If connector is not set, we are checking the destination
 			if destinationConfigPath != "not-set" {
@@ -57,9 +57,8 @@ var checkCmd = &cobra.Command{
 			return nil
 		}()
 
-		// Report the outcome as a connection-status message, then surface any failure through
-		// the exit code: returning a non-nil error makes RootCmd.Execute() call logger.Fatal,
-		// so `check` exits non-zero on a failed connection instead of always exiting 0.
+		// A failed connection is a successful check: the verdict is this message, not the exit
+		// code. Exiting non-zero fails the caller's activity before it ever parses the message.
 		message := types.Message{
 			Type: types.ConnectionStatusMessage,
 			ConnectionStatus: &types.StatusRow{
@@ -71,6 +70,9 @@ var checkCmd = &cobra.Command{
 			message.ConnectionStatus.Status = types.ConnectionFailed
 		}
 		logger.Info(message)
-		return err
+
+		// Reported here because check exits zero: RegisterDriver's hook only fires on a returned
+		// error. PreRunE failures still reach it, so this cannot double-report.
+		ReportFailure(err)
 	},
 }

--- a/protocol/check.go
+++ b/protocol/check.go
@@ -36,6 +36,7 @@ var checkCmd = &cobra.Command{
 
 		return nil
 	},
+	// TODO: switch back to returning err once the worker handling is added for non-zero exit.
 	Run: func(cmd *cobra.Command, _ []string) {
 		err := func() error {
 			// If connector is not set, we are checking the destination

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -176,9 +176,8 @@ func recoverToError(err *error) {
 	}
 }
 
-// ReportFailure classifies a failed run, reports it, and waits for the report to be delivered.
-// The wait is the point: check and discover leave through logger.Fatal, and telemetry sends in
-// the background, so without flushing the event is built and then discarded as the process dies.
+// ReportFailure classifies and reports a failed run, blocking until sent: telemetry sends in the
+// background and the process exits right after. check calls it directly: FAILED status, nil error.
 func ReportFailure(err error) {
 	if err == nil {
 		return


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`check` reports the connection verdict as a `CONNECTION_STATUS` message. Since #1024 flipped it from `Run` to `RunE`, a failed connection also propagated an error, so `RootCmd.Execute()` hit `logger.Fatal` and the process exited 1.

That exit code broke the UI's error reporting. The worker's activity fails on a non-zero container exit, so `ExtractWorkflowResponse` returns before it ever parses `connectionStatus`, and the handler replaces the real cause with `failed to verify credentials: workflow execution failed: ...`. The actual message — e.g. `dial tcp 10.10.10.10:1234: i/o timeout` — was written to `olake.log` and dropped on the floor.

A failed connection is a *successful* check: the command did its job and produced a verdict. Only a failure that prevents a verdict (unparseable config, missing flag) should exit non-zero. This reverts `check` to `Run` so the verdict travels in the message, not the exit code.

Reverting alone would lose the failure telemetry added in #1117, since `ReportFailure` is only reached from `RegisterDriver` when a command returns an error. `check` now calls `ReportFailure(err)` directly. Cobra skips `Run` entirely when `PreRunE` fails, so `PreRunE` errors still reach the shared hook and this cannot double-report.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Sent a successful connection check using postgres runs fine
- [ ] Ran check, a now stopped postgres config, reported in telemetry as well as logs as info

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):