### PR TITLE
fix: map Iceberg REST auth type

### DIFF
--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -116,7 +116,7 @@ func (c *Config) Validate() error {
 	if c.CatalogType == "biglake" {
 		c.RestAuthType = "org.apache.iceberg.gcp.auth.GoogleAuthManager"
 	}
-	c.RestAuthType = icebergRESTAuthType(c.RestAuthType)
+	c.RestAuthType = olakeAuthTypeToIcebergAuthType(c.RestAuthType)
 	if slices.Contains(constants.RESTCatalogs, string(c.CatalogType)) {
 		c.CatalogType = RestCatalog
 	}
@@ -204,10 +204,8 @@ func (c *Config) Validate() error {
 	return utils.Validate(c)
 }
 
-func icebergRESTAuthType(authType string) string {
+func olakeAuthTypeToIcebergAuthType(authType string) string {
 	switch strings.ToLower(strings.TrimSpace(authType)) {
-	case "":
-		return ""
 	case "oauth2", "oauth2 u2m", "oauth2 m2m", "token", "token federation",
 		"personal access token (pat)", "pat":
 		return "oauth2"
@@ -221,6 +219,7 @@ func icebergRESTAuthType(authType string) string {
 		if strings.Contains(authType, ".") && !strings.Contains(authType, " ") {
 			return authType
 		}
+		logger.Warnf("unmapped rest_auth_type %q. Iceberg rest.auth.type omitted", authType)
 		return ""
 	}
 }

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -116,6 +116,7 @@ func (c *Config) Validate() error {
 	if c.CatalogType == "biglake" {
 		c.RestAuthType = "org.apache.iceberg.gcp.auth.GoogleAuthManager"
 	}
+	c.RestAuthType = icebergRESTAuthType(c.RestAuthType)
 	if slices.Contains(constants.RESTCatalogs, string(c.CatalogType)) {
 		c.CatalogType = RestCatalog
 	}
@@ -201,4 +202,25 @@ func (c *Config) Validate() error {
 		c.ServerHost = "localhost"
 	}
 	return utils.Validate(c)
+}
+
+func icebergRESTAuthType(authType string) string {
+	switch strings.ToLower(strings.TrimSpace(authType)) {
+	case "":
+		return ""
+	case "oauth2", "oauth2 u2m", "oauth2 m2m", "token", "token federation",
+		"personal access token (pat)", "pat":
+		return "oauth2"
+	case "none":
+		return "none"
+	case "sigv4":
+		return "sigv4"
+	case "google", "gcp":
+		return "google"
+	default:
+		if strings.Contains(authType, ".") && !strings.Contains(authType, " ") {
+			return authType
+		}
+		return ""
+	}
 }


### PR DESCRIPTION
# Description

Iceberg treats `rest.auth.type` as an AuthManager scheme (`oauth2`, `none`, `sigv4`, `google`, `basic`) or a Java class name. 
This maps UI labels to Iceberg values in destination.
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Locally tested for Unity auth type(PAT)

## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)



