### PR TITLE
fix: allow numbers in iceberg catalog names

### DIFF
--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -53,7 +53,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "jdbc_url": {
@@ -126,7 +126,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "hive_uri": {
@@ -194,7 +194,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "iceberg_s3_path": {
@@ -305,7 +305,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "rest_auth_type": {
@@ -401,7 +401,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "rest_auth_type": {
@@ -514,7 +514,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "rest_auth_type": {
@@ -577,7 +577,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "rest_auth_type": {
@@ -694,7 +694,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "rest_auth_type": {
@@ -800,7 +800,7 @@
                 "catalog_name": {
                   "type": "string",
                   "title": "Catalog Name",
-                  "pattern": "^[a-z_]+$",
+                  "pattern": "^[a-z0-9_]+$",
                   "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
                 },
                 "rest_catalog_url": {


### PR DESCRIPTION
Fixes #1032

## Description

Iceberg destination specs currently restrict `catalog_name` using:

`^[a-z_]+$`

This causes valid catalog names containing numbers, such as
`olake_iceberg2`, to fail UI validation even though they are accepted
through the CLI/backend.

This PR updates the catalog name pattern to:

`^[a-z0-9_]+$`

across all Iceberg catalog configurations.

## Validation

### Before fix
`olake_iceberg2` is rejected by the Catalog Name field.

https://drive.google.com/file/d/1rEWgiIL2IyHatBJooCYZ-WKm7yE31YRH/view?usp=drive_link

### After fix
Built a custom OLake driver from this branch and verified that
`olake_iceberg2` passes Catalog Name validation.

https://drive.google.com/file/d/1rP_YhcaOT3Kn6xss849v7G1LGuPwGnuD/view?usp=sharing

### ensure nothing breaks
sync run

https://drive.google.com/file/d/1QAul_PVfQUUqGQ0rx5OOFad2KLkwWBRJ/view?usp=drive_link

## Testing

- Validated `destination/iceberg/resources/spec.json`
- Tested the custom driver through the OLake UI
- Confirmed catalog names containing numbers are accepted