### PR TITLE
fix: deduplication in Arrow CDC when insert+update in same sync

### DIFF
--- a/destination/iceberg/arrow-writer/writer.go
+++ b/destination/iceberg/arrow-writer/writer.go
@@ -181,7 +181,7 @@ func (w *ArrowWriter) extract(ctx context.Context, records []types.RawRecord) er
 			if err := w.indexRecord(writer, recordOlakeID, recordOpType, filePosition); err != nil {
 				return err
 			}
-		} else if w.upsertMode && (recordOpType == "d" || recordOpType == "u" || recordOpType == "i") {
+		} else if w.upsertMode && (recordOpType == "d" || recordOpType == "u" || recordOpType == "i" || recordOpType == "c") {
 			if _, exists := writer.olakeIDPosition[recordOlakeID]; !exists {
 				// first time, add to equality deletes and track position
 				writer.equalityDeletes = append(writer.equalityDeletes, recordOlakeID)


### PR DESCRIPTION
# Description
Fixes iceberg arrow writer duplicating rows when live CDC has INSERT and UPDATE for same `id` in same sync.


Fixes #1189

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Before: MySQL CDC with Iceberg/JDBC. `arrow_writes=true`, `upsert mode`. While CDC running with insert and update in same sync (`rows = 2 x ids` for records inserted and updated) 
- [x] After: MySQL CDC with Iceberg/JDBC. `arrow_writes=true`, `upsert mode`. While CDC running with insert and update in same sync (`rows = ids`)


# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->
Issue: <img width="997" height="234" alt="image" src="https://github.com/user-attachments/assets/ab12c570-5afd-41ae-8a12-45aa564eb63c" />

<img width="1002" height="402" alt="image" src="https://github.com/user-attachments/assets/60c50f9b-dff0-4325-95cb-3afc124b4cd9" />


## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)
