### PR TITLE
feat: Support Horizon catalog

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -100,4 +100,5 @@ var RESTCatalogs = []string{
 	"unity",
 	"polaris",
 	"biglake",
+	"horizon",
 }

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -116,6 +116,7 @@ func (c *Config) Validate() error {
 	if c.CatalogType == "biglake" {
 		c.RestAuthType = "org.apache.iceberg.gcp.auth.GoogleAuthManager"
 	}
+	c.RestAuthType = icebergRESTAuthType(c.RestAuthType)
 	if slices.Contains(constants.RESTCatalogs, string(c.CatalogType)) {
 		c.CatalogType = RestCatalog
 	}
@@ -201,4 +202,25 @@ func (c *Config) Validate() error {
 		c.ServerHost = "localhost"
 	}
 	return utils.Validate(c)
+}
+
+func icebergRESTAuthType(authType string) string {
+	switch strings.ToLower(strings.TrimSpace(authType)) {
+	case "":
+		return ""
+	case "oauth2", "oauth2 u2m", "oauth2 m2m", "token", "token federation",
+		"personal access token (pat)", "pat":
+		return "oauth2"
+	case "none":
+		return "none"
+	case "sigv4":
+		return "sigv4"
+	case "google", "gcp":
+		return "google"
+	default:
+		if strings.Contains(authType, ".") && !strings.Contains(authType, " ") {
+			return authType
+		}
+		return ""
+	}
 }

--- a/destination/iceberg/config.go
+++ b/destination/iceberg/config.go
@@ -86,6 +86,10 @@ type Config struct {
 	// Required by BigLake for request routing/billing (sent as the x-goog-user-project header).
 	GCPProjectID string `json:"gcp_project_id,omitempty"`
 
+	// Horizon
+	RESTAccessDelegation              string `json:"rest_access_delegation,omitempty"`
+	SnowflakeWorkloadIdentityProvider string `json:"snowflake_workload_identity_provider,omitempty"`
+
 	UseArrowWrites bool `json:"arrow_writes,omitempty"`
 }
 
@@ -116,7 +120,11 @@ func (c *Config) Validate() error {
 	if c.CatalogType == "biglake" {
 		c.RestAuthType = "org.apache.iceberg.gcp.auth.GoogleAuthManager"
 	}
-	c.RestAuthType = icebergRESTAuthType(c.RestAuthType)
+	// Horizon requires access delegation
+	if c.CatalogType == "horizon" {
+		c.RESTAccessDelegation = "vended-credentials"
+	}
+	c.RestAuthType = olakeAuthTypeToIcebergAuthType(c.RestAuthType)
 	if slices.Contains(constants.RESTCatalogs, string(c.CatalogType)) {
 		c.CatalogType = RestCatalog
 	}
@@ -204,12 +212,12 @@ func (c *Config) Validate() error {
 	return utils.Validate(c)
 }
 
-func icebergRESTAuthType(authType string) string {
+func olakeAuthTypeToIcebergAuthType(authType string) string {
 	switch strings.ToLower(strings.TrimSpace(authType)) {
-	case "":
-		return ""
 	case "oauth2", "oauth2 u2m", "oauth2 m2m", "token", "token federation",
-		"personal access token (pat)", "pat":
+		"personal access token (pat)", "pat", "external oauth",
+		"key-pair authentication", "programmatic access token (pat)",
+		"workload identity federation(wif)/oidc":
 		return "oauth2"
 	case "none":
 		return "none"
@@ -221,6 +229,7 @@ func icebergRESTAuthType(authType string) string {
 		if strings.Contains(authType, ".") && !strings.Contains(authType, " ") {
 			return authType
 		}
+		logger.Warnf("unmapped rest_auth_type %q. Iceberg rest.auth.type omitted", authType)
 		return ""
 	}
 }

--- a/destination/iceberg/java_client.go
+++ b/destination/iceberg/java_client.go
@@ -95,6 +95,9 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool, gcpC
 		addMapKeyIfNotEmpty("gcp.auth.scopes", config.GCPAuthScopes)
 		// BigLake requires this header for request routing/billing.
 		addMapKeyIfNotEmpty("header.x-goog-user-project", config.GCPProjectID)
+		//Horizon
+		addMapKeyIfNotEmpty("header.X-Iceberg-Access-Delegation", config.RESTAccessDelegation)
+		addMapKeyIfNotEmpty("header.X-Snowflake-Workload-Identity-Provider", config.SnowflakeWorkloadIdentityProvider)
 	default:
 		return nil, errs.Precondition(errs.ConfigInvalid, codeUnsupportedCatalogType,
 			fmt.Errorf("unsupported catalog type: %s", config.CatalogType))
@@ -109,6 +112,10 @@ func getServerConfigJSON(config *Config, port int, arrowWriterEnabled bool, gcpC
 	// Configure region for AWS S3
 	if config.Region != "" {
 		serverConfig["s3.region"] = config.Region
+		// Horizon - same value as Snowflake client.region
+		if config.RESTAccessDelegation != "" {
+			serverConfig["client.region"] = config.Region
+		}
 	} else if config.S3Endpoint == "" && config.CatalogType == GlueCatalog {
 		logger.Warnf("No region explicitly provided for Glue catalog, the Java process will attempt to use region from AWS environment")
 	}

--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -875,23 +875,6 @@
                   "title": "Snowflake Database",
                   "description": "Snowflake database name used as Iceberg Warehouse"
                 },
-                "s3_endpoint": {
-                  "type": "string",
-                  "title": "S3 Endpoint",
-                  "description": "Specifies the endpoint URL for S3 compatible services (like MinIO)"
-                },
-                "aws_secret_key": {
-                  "type": "string",
-                  "format": "password",
-                  "title": "AWS Secret Key",
-                  "description": "The AWS secret key for S3 authentication-typically 40+ characters long"
-                },
-                "aws_access_key": {
-                  "type": "string",
-                  "format": "password",
-                  "title": "AWS Access Key",
-                  "description": "The AWS access key for authenticating S3 requests, typically a 20-character alphanumeric string"
-                },
                 "aws_region": {
                   "type": "string",
                   "title": "Cloud Storage Region",

--- a/destination/iceberg/resources/spec.json
+++ b/destination/iceberg/resources/spec.json
@@ -20,7 +20,8 @@
             "s3tables",
             "unity",
             "polaris",
-            "biglake"
+            "biglake",
+            "horizon"
           ],
           "default": "glue",
           "title": "Catalog Type",
@@ -809,7 +810,7 @@
                   "description": "Endpoint URL for the Big Lake REST catalog service"
                 },
                 "iceberg_s3_path": {
-                  "title":"BigLake Catalog Path",
+                  "title": "BigLake Catalog Path",
                   "description": "Path to your BigLake catalog"
                 },
                 "rest_auth_type": {
@@ -842,6 +843,152 @@
                 "rest_catalog_url",
                 "gcp_service_account_json"
               ]
+            },
+            {
+              "properties": {
+                "catalog_type": {
+                  "const": "horizon"
+                },
+                "catalog_name": {
+                  "type": "string",
+                  "title": "Catalog Name",
+                  "pattern": "^[a-z_]+$",
+                  "description": "Name of the Iceberg catalog OLake Go registers tables under. Defaults to olake_iceberg if left empty."
+                },
+                "rest_auth_type": {
+                  "type": "string",
+                  "title": "Authentication Type",
+                  "enum": [
+                    "External OAuth",
+                    "Key-Pair Authentication",
+                    "Programmatic Access Token (PAT)",
+                    "Workload Identity Federation(WIF)/OIDC"
+                  ],
+                  "description": "Methods to obtain access token for Horizon Iceberg REST Catalog API"
+                },
+                "rest_catalog_url": {
+                  "type": "string",
+                  "title": "Horizon Iceberg REST Catalog URI",
+                  "description": "Snowflake Horizon Catalog REST API endpoint"
+                },
+                "iceberg_s3_path": {
+                  "title": "Snowflake Database",
+                  "description": "Snowflake database name used as Iceberg Warehouse"
+                },
+                "s3_endpoint": {
+                  "type": "string",
+                  "title": "S3 Endpoint",
+                  "description": "Specifies the endpoint URL for S3 compatible services (like MinIO)"
+                },
+                "aws_secret_key": {
+                  "type": "string",
+                  "format": "password",
+                  "title": "AWS Secret Key",
+                  "description": "The AWS secret key for S3 authentication-typically 40+ characters long"
+                },
+                "aws_access_key": {
+                  "type": "string",
+                  "format": "password",
+                  "title": "AWS Access Key",
+                  "description": "The AWS access key for authenticating S3 requests, typically a 20-character alphanumeric string"
+                },
+                "aws_region": {
+                  "type": "string",
+                  "title": "Cloud Storage Region",
+                  "description": "Snowflake client.region (e.g. eastus2)"
+                },
+                "scope": {
+                  "type": "string",
+                  "title": "Session Role Scope",
+                  "description": "Snowflake session role scope in the format of 'session:role:<role>' (space separated for more than one)"
+                }
+              },
+              "required": [
+                "rest_catalog_url",
+                "rest_auth_type",
+                "aws_region",
+                "scope"
+              ],
+              "dependencies": {
+                "rest_auth_type": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "rest_auth_type": {
+                          "const": "External OAuth"
+                        },
+                        "token": {
+                          "type": "string",
+                          "format": "password",
+                          "title": "External OAuth Token",
+                          "description": "Bearer access token for token-based authentication"
+                        }
+                      },
+                      "required": [
+                        "token"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "rest_auth_type": {
+                          "const": "Key-Pair Authentication"
+                        },
+                        "credential": {
+                          "type": "string",
+                          "title": "Key-pair JWT",
+                          "description": "JWT signed with your snowflake key pair used as iceberg credential"
+                        },
+                        "oauth2_uri": {
+                          "type": "string",
+                          "title": "OAuth2 Token Endpoint",
+                          "description": "OAuth token endpoint URL (e.g. `https://<account_identifier>.snowflakecomputing.com/polaris/api/catalog/v1/oauth/tokens`)"
+                        }
+                      },
+                      "required": [
+                        "credential",
+                        "oauth2_uri"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "rest_auth_type": {
+                          "const": "Programmatic Access Token (PAT)"
+                        },
+                        "credential": {
+                          "type": "string",
+                          "title": "Programmatic Access Token",
+                          "description": "Snowflake PAT used as iceberg credential"
+                        }
+                      },
+                      "required": [
+                        "credential"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "rest_auth_type": {
+                          "const": "Workload Identity Federation(WIF)/OIDC"
+                        },
+                        "credential": {
+                          "type": "string",
+                          "title": "OIDC Token",
+                          "description": "Short lived OIDC token used as iceberg credential"
+                        },
+                        "snowflake_workload_identity_provider": {
+                          "type": "string",
+                          "title": "Workload Identity Provider",
+                          "default": "OIDC",
+                          "description": "Snowflake header X-Snowflake-Workload-Identity-Provider. (e.g. 'OIDC')"
+                        }
+                      },
+                      "required": [
+                        "credential",
+                        "snowflake_workload_identity_provider"
+                      ]
+                    }
+                  ]
+                }
+              }
             },
             {
               "properties": {

--- a/utils/spec/uischema.go
+++ b/utils/spec/uischema.go
@@ -502,6 +502,7 @@ const IcebergUISchema = `{
       { "iceberg_s3_path": 12, "s3_endpoint": 12},
       { "credential": 12, "oauth2_uri": 12 },
       { "scope": 12, "token": 12 },
+      { "snowflake_workload_identity_provider": 24 },
       { "no_identifier_fields": 24 },
       { "aws_access_key": 12, "aws_secret_key": 12 },
       { "aws_region": 12, "s3_path_style": 12 },
@@ -554,7 +555,8 @@ const IcebergUISchema = `{
         "S3 Tables",
         "Unity",
         "Polaris",
-        "Big Lake"
+        "Big Lake",
+        "Horizon"
       ]
     },
     "ui:options": {


### PR DESCRIPTION
# Description

Support **Snowflake Horizon Catalog** as an Iceberg REST Catalog
Supported Authentication Types
- Programmtic Access Token (PAT)
- Key Pair Authentication
- External OAuth
- Workload Identity Federation (WIF)/OIDC

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Locally tested - Snowflake Horizon with Olake `kafka driver` for following authentication types: 
- [x] PAT - service user + PAT(`ROLE_RESTRICTION`)
- [x] Key Pair - `RSA_PUBLIC_KEY`, RS256 JWT from private key as credential
- [x] External OAuth - external IdP for bearer-token (EntraID)
- [x] Workload Identity Federation - with Microsoft EntraID App Registration, provider `OIDC`

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [x] Documentation Link: [https://olake.io/docs/writers/iceberg/catalog/rest/]
- [ ] N/A (bug fix, refactor, or test changes only)
