### PR TITLE
feat: source type in telemetry sync completed event and more config conditions

### DIFF
--- a/drivers/db2/internal/config.go
+++ b/drivers/db2/internal/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 type Config struct {
@@ -64,19 +65,21 @@ func (c *Config) BuildTunnelDSN(localPort int) string {
 
 func (c *Config) Validate() error {
 	if c.Host == "" {
-		return fmt.Errorf("empty host name")
+		return errs.Precondition(errs.ConfigInvalid, codeHostMissing, fmt.Errorf("empty host name"))
 	}
 
 	if c.Port <= 0 || c.Port > 65535 {
-		return fmt.Errorf("invalid port number: must be between 1 and 65535")
+		return errs.Precondition(errs.ConfigInvalid, codePortInvalid,
+			fmt.Errorf("invalid port number: must be between 1 and 65535"))
 	}
 
 	if c.Username == "" {
-		return fmt.Errorf("username is required")
+		return errs.Precondition(errs.ConfigInvalid, codeUsernameMissing, fmt.Errorf("username is required"))
 	}
 
 	if c.Database == "" {
-		return fmt.Errorf("database name is required")
+		return errs.Precondition(errs.ConfigInvalid, codeDatabaseMissing,
+			fmt.Errorf("database name is required"))
 	}
 
 	if c.MaxThreads <= 0 {

--- a/drivers/db2/internal/errors.go
+++ b/drivers/db2/internal/errors.go
@@ -7,9 +7,13 @@ import (
 	go_ibm_db "github.com/ibmdb/go_ibm_db"
 )
 
-// The one condition this driver detects itself: Db2 has no change feed, so there is no
-// replication state to validate.
-const codeCDCUnsupported = "db2.cdc_unsupported"
+const (
+	codeCDCUnsupported  = "db2.cdc_unsupported"
+	codeHostMissing     = "db2.host_missing"
+	codePortInvalid     = "db2.port_invalid"
+	codeUsernameMissing = "db2.username_missing"
+	codeDatabaseMissing = "db2.database_missing"
+)
 
 // sqlStateCategories maps a Db2 SQLSTATE to a failure category. Two spaces arrive here: Db2's
 // own, and the ODBC/CLI layer's (08S01, HYT00, IM002, 42S02), raised before Db2 is reached.

--- a/drivers/kafka/internal/config.go
+++ b/drivers/kafka/internal/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/pkg/kafka"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 type Config struct {
@@ -29,19 +30,23 @@ type ProtocolConfig struct {
 
 func (c *Config) Validate() error {
 	if c.BootstrapServers == "" {
-		return fmt.Errorf("bootstrap_servers is required")
+		return errs.Precondition(errs.ConfigInvalid, codeBootstrapServersMissing,
+			fmt.Errorf("bootstrap_servers is required"))
 	}
 
 	if c.Protocol.SecurityProtocol == "" {
-		return fmt.Errorf("security_protocol must be one of: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL")
+		return errs.Precondition(errs.ConfigInvalid, codeSecurityProtocolMissing,
+			fmt.Errorf("security_protocol must be one of: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL"))
 	}
 
 	if c.Protocol.SecurityProtocol == "SASL_PLAINTEXT" || c.Protocol.SecurityProtocol == "SASL_SSL" {
 		if c.Protocol.SASLMechanism == "" {
-			return fmt.Errorf("sasl_mechanism must be either PLAIN or SCRAM-SHA-512")
+			return errs.Precondition(errs.ConfigInvalid, codeSASLMechanismMissing,
+				fmt.Errorf("sasl_mechanism must be either PLAIN or SCRAM-SHA-512"))
 		}
 		if c.Protocol.SASLJAASConfig == "" {
-			return fmt.Errorf("sasl_jaas_config must be provided")
+			return errs.Precondition(errs.ConfigInvalid, codeSASLJAASConfigMissing,
+				fmt.Errorf("sasl_jaas_config must be provided"))
 		}
 	}
 
@@ -49,19 +54,22 @@ func (c *Config) Validate() error {
 		if c.Protocol.SSL != nil {
 			// Server CA is always required
 			if c.Protocol.SSL.ServerCA == "" {
-				return fmt.Errorf("server_ca must be provided")
+				return errs.Precondition(errs.ConfigInvalid, codeServerCAMissing,
+					fmt.Errorf("server_ca must be provided"))
 			}
 
 			// Client Cert and Key are required together for mTLS
 			if (c.Protocol.SSL.ClientCert != "") != (c.Protocol.SSL.ClientKey != "") {
-				return fmt.Errorf("both client_cert and client_key must be provided together for mTLS")
+				return errs.Precondition(errs.ConfigInvalid, codeClientKeypairIncomplete,
+					fmt.Errorf("both client_cert and client_key must be provided together for mTLS"))
 			}
 		}
 	}
 
 	if c.SchemaRegistry != nil {
 		if c.SchemaRegistry.Endpoint == "" {
-			return fmt.Errorf("schema registry endpoint is required")
+			return errs.Precondition(errs.ConfigInvalid, codeSchemaRegistryEndpointMissing,
+				fmt.Errorf("schema registry endpoint is required"))
 		}
 	}
 
@@ -73,5 +81,5 @@ func (c *Config) Validate() error {
 		c.RetryCount = constants.DefaultRetryCount
 	}
 
-	return utils.Validate(c)
+	return errs.Precondition(errs.ConfigInvalid, codeConfigValidationFailed, utils.Validate(c))
 }

--- a/drivers/kafka/internal/errors.go
+++ b/drivers/kafka/internal/errors.go
@@ -11,11 +11,19 @@ import (
 // Codes for conditions this driver detects itself. All but the first are state that no longer
 // lines up with the broker — visible only by comparing our destination metadata against Kafka.
 const (
-	codeBackfillUnsupported     = "kafka.backfill_unsupported"
-	codeMetadataStateInvalid    = "kafka.metadata_state_invalid"
-	codeConsumerGroupMismatch   = "kafka.consumer_group_mismatch"
-	codeOffsetMismatch          = "kafka.offset_mismatch"
-	codePartitionMetadataAbsent = "kafka.partition_metadata_absent"
+	codeBackfillUnsupported           = "kafka.backfill_unsupported"
+	codeMetadataStateInvalid          = "kafka.metadata_state_invalid"
+	codeConsumerGroupMismatch         = "kafka.consumer_group_mismatch"
+	codeOffsetMismatch                = "kafka.offset_mismatch"
+	codePartitionMetadataAbsent       = "kafka.partition_metadata_absent"
+	codeBootstrapServersMissing       = "kafka.bootstrap_servers_missing"
+	codeSecurityProtocolMissing       = "kafka.security_protocol_missing"
+	codeSASLMechanismMissing          = "kafka.sasl_mechanism_missing"
+	codeSASLJAASConfigMissing         = "kafka.sasl_jaas_config_missing"
+	codeServerCAMissing               = "kafka.server_ca_missing"
+	codeClientKeypairIncomplete       = "kafka.client_keypair_incomplete"
+	codeSchemaRegistryEndpointMissing = "kafka.schema_registry_endpoint_missing"
+	codeConfigValidationFailed        = "kafka.config_validation_failed"
 )
 
 // kerrCategories maps a Kafka protocol error code to a failure category; trailing names are as

--- a/drivers/mongodb/internal/config.go
+++ b/drivers/mongodb/internal/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 type Config struct {
@@ -94,19 +95,19 @@ func (c *Config) buildTLSConfig() (*tls.Config, error) {
 
 func (c *Config) Validate() error {
 	if len(c.Hosts) == 0 {
-		return fmt.Errorf("hosts is required")
+		return errs.Precondition(errs.ConfigInvalid, codeHostsMissing, fmt.Errorf("hosts is required"))
 	}
 
 	if c.Database == "" {
-		return fmt.Errorf("database is required")
+		return errs.Precondition(errs.ConfigInvalid, codeDatabaseMissing, fmt.Errorf("database is required"))
 	}
 
 	if !c.UseIAM {
 		if c.Username == "" {
-			return fmt.Errorf("username is required")
+			return errs.Precondition(errs.ConfigInvalid, codeUsernameMissing, fmt.Errorf("username is required"))
 		}
 		if c.AuthDB == "" {
-			return fmt.Errorf("authdb is required")
+			return errs.Precondition(errs.ConfigInvalid, codeAuthDBMissing, fmt.Errorf("authdb is required"))
 		}
 		// Password is optional — staging allowed password-less URIs (X509, OIDC, username-only).
 		// MongoDB rejects at connect time if the mechanism actually needs a password.
@@ -130,5 +131,5 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("failed to validate ssl config: %w", err)
 	}
 
-	return utils.Validate(c)
+	return errs.Precondition(errs.ConfigInvalid, codeConfigValidationFailed, utils.Validate(c))
 }

--- a/drivers/mongodb/internal/errors.go
+++ b/drivers/mongodb/internal/errors.go
@@ -14,8 +14,13 @@ import (
 // Codes for conditions this driver detects itself; the resume token is the only state it
 // validates before asking the server.
 const (
-	codeResumeTokenMissing = "mongodb.resume_token_missing" // #nosec G101 -- a failure code, not a credential
-	codeResumeTokenInvalid = "mongodb.resume_token_invalid" // #nosec G101 -- a failure code, not a credential
+	codeResumeTokenMissing     = "mongodb.resume_token_missing" // #nosec G101 -- a failure code, not a credential
+	codeResumeTokenInvalid     = "mongodb.resume_token_invalid" // #nosec G101 -- a failure code, not a credential
+	codeHostsMissing           = "mongodb.hosts_missing"
+	codeDatabaseMissing        = "mongodb.database_missing"
+	codeUsernameMissing        = "mongodb.username_missing"
+	codeAuthDBMissing          = "mongodb.authdb_missing"
+	codeConfigValidationFailed = "mongodb.config_validation_failed"
 )
 
 // commandCodeCategories maps a MongoDB server error code to a failure category. Codes marked

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 // Config represents the configuration for connecting to a MSSQL database.
@@ -39,7 +40,7 @@ func (p *PrimaryConfig) Validate() error {
 	if err := validateSQLConnection(p.Host, p.Port, p.Username, p.Password, true); err != nil {
 		return err
 	}
-	return utils.Validate(p)
+	return errs.Precondition(errs.ConfigInvalid, codePrimaryConfigValidationFailed, utils.Validate(p))
 }
 
 // Validate checks and normalises MSSQL configuration.
@@ -48,7 +49,8 @@ func (c *Config) Validate() error {
 		return err
 	}
 	if c.Database == "" {
-		return fmt.Errorf("database is required")
+		return errs.Precondition(errs.ConfigInvalid, codeDatabaseMissing,
+			fmt.Errorf("database is required"))
 	}
 
 	if c.MaxThreads <= 0 {
@@ -76,25 +78,34 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	return utils.Validate(c)
+	return errs.Precondition(errs.ConfigInvalid, codeConfigValidationFailed, utils.Validate(c))
 }
 
 func validateSQLConnection(host string, port int, username, password string, isPrimaryNode bool) error {
 	prefix := utils.Ternary(isPrimaryNode, "primary_config: ", "").(string)
+	// Codes carry the same scope the message does: the primary block is a separate field to fix.
+	code := func(condition string) string {
+		return "mssql." + utils.Ternary(isPrimaryNode, "primary_", "").(string) + condition
+	}
 	if host == "" {
-		return fmt.Errorf("%sempty host name", prefix)
+		return errs.Precondition(errs.ConfigInvalid, code("host_missing"),
+			fmt.Errorf("%sempty host name", prefix))
 	}
 	if strings.Contains(host, "https") || strings.Contains(host, "http") {
-		return fmt.Errorf("%shost should not contain http or https", prefix)
+		return errs.Precondition(errs.ConfigInvalid, code("host_scheme_included"),
+			fmt.Errorf("%shost should not contain http or https", prefix))
 	}
 	if port <= 0 || port > 65535 {
-		return fmt.Errorf("%sinvalid port number: must be between 1 and 65535", prefix)
+		return errs.Precondition(errs.ConfigInvalid, code("port_invalid"),
+			fmt.Errorf("%sinvalid port number: must be between 1 and 65535", prefix))
 	}
 	if username == "" {
-		return fmt.Errorf("%susername is required", prefix)
+		return errs.Precondition(errs.ConfigInvalid, code("username_missing"),
+			fmt.Errorf("%susername is required", prefix))
 	}
 	if password == "" {
-		return fmt.Errorf("%spassword is required", prefix)
+		return errs.Precondition(errs.ConfigInvalid, code("password_missing"),
+			fmt.Errorf("%spassword is required", prefix))
 	}
 	return nil
 }

--- a/drivers/mssql/internal/config.go
+++ b/drivers/mssql/internal/config.go
@@ -84,27 +84,25 @@ func (c *Config) Validate() error {
 func validateSQLConnection(host string, port int, username, password string, isPrimaryNode bool) error {
 	prefix := utils.Ternary(isPrimaryNode, "primary_config: ", "").(string)
 	// Codes carry the same scope the message does: the primary block is a separate field to fix.
-	code := func(condition string) string {
-		return "mssql." + utils.Ternary(isPrimaryNode, "primary_", "").(string) + condition
-	}
+	code := func(main, primary string) string { return utils.Ternary(isPrimaryNode, primary, main).(string) }
 	if host == "" {
-		return errs.Precondition(errs.ConfigInvalid, code("host_missing"),
+		return errs.Precondition(errs.ConfigInvalid, code(codeHostMissing, codePrimaryHostMissing),
 			fmt.Errorf("%sempty host name", prefix))
 	}
 	if strings.Contains(host, "https") || strings.Contains(host, "http") {
-		return errs.Precondition(errs.ConfigInvalid, code("host_scheme_included"),
+		return errs.Precondition(errs.ConfigInvalid, code(codeHostSchemeIncluded, codePrimaryHostSchemeIncluded),
 			fmt.Errorf("%shost should not contain http or https", prefix))
 	}
 	if port <= 0 || port > 65535 {
-		return errs.Precondition(errs.ConfigInvalid, code("port_invalid"),
+		return errs.Precondition(errs.ConfigInvalid, code(codePortInvalid, codePrimaryPortInvalid),
 			fmt.Errorf("%sinvalid port number: must be between 1 and 65535", prefix))
 	}
 	if username == "" {
-		return errs.Precondition(errs.ConfigInvalid, code("username_missing"),
+		return errs.Precondition(errs.ConfigInvalid, code(codeUsernameMissing, codePrimaryUsernameMissing),
 			fmt.Errorf("%susername is required", prefix))
 	}
 	if password == "" {
-		return errs.Precondition(errs.ConfigInvalid, code("password_missing"),
+		return errs.Precondition(errs.ConfigInvalid, code(codePasswordMissing, codePrimaryPasswordMissing),
 			fmt.Errorf("%spassword is required", prefix))
 	}
 	return nil

--- a/drivers/mssql/internal/errors.go
+++ b/drivers/mssql/internal/errors.go
@@ -11,10 +11,13 @@ import (
 // Codes for conditions this driver detects itself. Capture instances are catalog rows, so CDC
 // prerequisites are validated up front and those failures carry no server error.
 const (
-	codeCDCNotEnabledOnTable  = "mssql.cdc_not_enabled_on_table"
-	codeLSNBeforeCaptureStart = "mssql.lsn_before_capture_instance"
-	codeLSNUnavailable        = "mssql.lsn_unavailable"
-	codeMetadataStateInvalid  = "mssql.metadata_state_invalid"
+	codeCDCNotEnabledOnTable          = "mssql.cdc_not_enabled_on_table"
+	codeLSNBeforeCaptureStart         = "mssql.lsn_before_capture_instance"
+	codeLSNUnavailable                = "mssql.lsn_unavailable"
+	codeMetadataStateInvalid          = "mssql.metadata_state_invalid"
+	codeDatabaseMissing               = "mssql.database_missing"
+	codeConfigValidationFailed        = "mssql.config_validation_failed"
+	codePrimaryConfigValidationFailed = "mssql.primary_config_validation_failed"
 )
 
 // errorNumberCategories maps a SQL Server error number to a failure category. No code table

--- a/drivers/mssql/internal/errors.go
+++ b/drivers/mssql/internal/errors.go
@@ -11,12 +11,26 @@ import (
 // Codes for conditions this driver detects itself. Capture instances are catalog rows, so CDC
 // prerequisites are validated up front and those failures carry no server error.
 const (
-	codeCDCNotEnabledOnTable          = "mssql.cdc_not_enabled_on_table"
-	codeLSNBeforeCaptureStart         = "mssql.lsn_before_capture_instance"
-	codeLSNUnavailable                = "mssql.lsn_unavailable"
-	codeMetadataStateInvalid          = "mssql.metadata_state_invalid"
-	codeDatabaseMissing               = "mssql.database_missing"
-	codeConfigValidationFailed        = "mssql.config_validation_failed"
+	codeCDCNotEnabledOnTable  = "mssql.cdc_not_enabled_on_table"
+	codeLSNBeforeCaptureStart = "mssql.lsn_before_capture_instance"
+	codeLSNUnavailable        = "mssql.lsn_unavailable"
+	codeMetadataStateInvalid  = "mssql.metadata_state_invalid"
+
+	// Connection preconditions, checked before a connection is opened.
+	codeHostMissing            = "mssql.host_missing"
+	codeHostSchemeIncluded     = "mssql.host_scheme_included"
+	codePortInvalid            = "mssql.port_invalid"
+	codeUsernameMissing        = "mssql.username_missing"
+	codePasswordMissing        = "mssql.password_missing"
+	codeDatabaseMissing        = "mssql.database_missing"
+	codeConfigValidationFailed = "mssql.config_validation_failed"
+
+	// The primary replica is a second connection block with its own fields
+	codePrimaryHostMissing            = "mssql.primary_host_missing"
+	codePrimaryHostSchemeIncluded     = "mssql.primary_host_scheme_included"
+	codePrimaryPortInvalid            = "mssql.primary_port_invalid"
+	codePrimaryUsernameMissing        = "mssql.primary_username_missing"
+	codePrimaryPasswordMissing        = "mssql.primary_password_missing" // #nosec G101 -- a failure code, not a credential
 	codePrimaryConfigValidationFailed = "mssql.primary_config_validation_failed"
 )
 

--- a/drivers/mysql/internal/config.go
+++ b/drivers/mysql/internal/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 // Config represents the configuration for connecting to a MySQL database
@@ -89,22 +90,24 @@ func (c *Config) buildTLSConfig() (*tls.Config, error) {
 // Validate checks the configuration for any missing or invalid fields
 func (c *Config) Validate() error {
 	if c.Host == "" {
-		return fmt.Errorf("empty host name")
+		return errs.Precondition(errs.ConfigInvalid, codeHostMissing, fmt.Errorf("empty host name"))
 	} else if strings.Contains(c.Host, "https") || strings.Contains(c.Host, "http") {
-		return fmt.Errorf("host should not contain http or https: %s", c.Host)
+		return errs.Precondition(errs.ConfigInvalid, codeHostSchemeIncluded,
+			fmt.Errorf("host should not contain http or https: %s", c.Host))
 	}
 
 	// Validate port
 	if c.Port <= 0 || c.Port > 65535 {
-		return fmt.Errorf("invalid port number: must be between 1 and 65535")
+		return errs.Precondition(errs.ConfigInvalid, codePortInvalid,
+			fmt.Errorf("invalid port number: must be between 1 and 65535"))
 	}
 
 	// Validate required fields
 	if c.Username == "" {
-		return fmt.Errorf("username is required")
+		return errs.Precondition(errs.ConfigInvalid, codeUsernameMissing, fmt.Errorf("username is required"))
 	}
 	if c.Password == "" {
-		return fmt.Errorf("password is required")
+		return errs.Precondition(errs.ConfigInvalid, codePasswordMissing, fmt.Errorf("password is required"))
 	}
 
 	// Optional database name, default to 'mysql'
@@ -127,13 +130,7 @@ func (c *Config) Validate() error {
 		if err := c.SSLConfiguration.Validate(); err != nil {
 			return fmt.Errorf("failed to validate SSL config: %w", err)
 		}
-
-		if c.SSLConfiguration.Mode == utils.SSLModeVerifyCA || c.SSLConfiguration.Mode == utils.SSLModeVerifyFull {
-			if c.SSLConfiguration.ServerCA == "" {
-				return fmt.Errorf("'ssl.server_ca' is required for verify-ca and verify-full modes")
-			}
-		}
 	}
 
-	return utils.Validate(c)
+	return errs.Precondition(errs.ConfigInvalid, codeConfigValidationFailed, utils.Validate(c))
 }

--- a/drivers/mysql/internal/errors.go
+++ b/drivers/mysql/internal/errors.go
@@ -11,12 +11,17 @@ import (
 
 // Codes for conditions this driver detects itself, where the server never named the failure.
 const (
-	codeGlobalStateInvalid   = "mysql.global_state_invalid"
-	codeServerIDMissing      = "mysql.server_id_missing"
-	codeMetadataStateInvalid = "mysql.metadata_state_invalid"
-	codePortInvalid          = "mysql.port_invalid"
-	codeTableNotVisible      = "mysql.table_not_visible"
-	codeCDCUnsupported       = "mysql.cdc_unsupported"
+	codeGlobalStateInvalid     = "mysql.global_state_invalid"
+	codeServerIDMissing        = "mysql.server_id_missing"
+	codeMetadataStateInvalid   = "mysql.metadata_state_invalid"
+	codePortInvalid            = "mysql.port_invalid"
+	codeTableNotVisible        = "mysql.table_not_visible"
+	codeCDCUnsupported         = "mysql.cdc_unsupported"
+	codeHostMissing            = "mysql.host_missing"
+	codeHostSchemeIncluded     = "mysql.host_scheme_included"
+	codeUsernameMissing        = "mysql.username_missing"
+	codePasswordMissing        = "mysql.password_missing"
+	codeConfigValidationFailed = "mysql.config_validation_failed"
 )
 
 // errnoCategories maps a MySQL server error number to a failure category. Numbers are stable

--- a/drivers/oracle/internal/config.go
+++ b/drivers/oracle/internal/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	go_ora "github.com/sijms/go-ora/v2"
 )
 
@@ -54,21 +55,24 @@ func (c *Config) connectionString() string {
 // Validate checks the configuration for any missing or invalid fields
 func (c *Config) Validate() error {
 	if c.Host == "" {
-		return fmt.Errorf("empty host name")
+		return errs.Precondition(errs.ConfigInvalid, codeHostMissing, fmt.Errorf("empty host name"))
 	} else if strings.Contains(c.Host, "https") || strings.Contains(c.Host, "http") {
-		return fmt.Errorf("host should not contain http or https: %s", c.Host)
+		return errs.Precondition(errs.ConfigInvalid, codeHostSchemeIncluded,
+			fmt.Errorf("host should not contain http or https: %s", c.Host))
 	}
 
 	// Validate port
 	if c.Port <= 0 || c.Port > 65535 {
-		return fmt.Errorf("invalid port number: must be between 1 and 65535")
+		return errs.Precondition(errs.ConfigInvalid, codePortInvalid,
+			fmt.Errorf("invalid port number: must be between 1 and 65535"))
 	}
 	// Validate required fields
 	if c.Username == "" {
-		return fmt.Errorf("username is required")
+		return errs.Precondition(errs.ConfigInvalid, codeUsernameMissing, fmt.Errorf("username is required"))
 	}
 	if c.ServiceName == "" && c.SID == "" {
-		return fmt.Errorf("service_name or sid is required")
+		return errs.Precondition(errs.ConfigInvalid, codeServiceNameOrSIDMissing,
+			fmt.Errorf("service_name or sid is required"))
 	}
 
 	// Set default number of threads if not provided
@@ -85,5 +89,5 @@ func (c *Config) Validate() error {
 	if err != nil {
 		return fmt.Errorf("failed to validate ssl config: %w", err)
 	}
-	return utils.Validate(c)
+	return errs.Precondition(errs.ConfigInvalid, codeConfigValidationFailed, utils.Validate(c))
 }

--- a/drivers/oracle/internal/errors.go
+++ b/drivers/oracle/internal/errors.go
@@ -8,6 +8,16 @@ import (
 	"github.com/sijms/go-ora/v2/network"
 )
 
+// Codes for conditions this driver detects itself, where the server never named the failure.
+const (
+	codeHostMissing             = "oracle.host_missing"
+	codeHostSchemeIncluded      = "oracle.host_scheme_included"
+	codePortInvalid             = "oracle.port_invalid"
+	codeUsernameMissing         = "oracle.username_missing"
+	codeServiceNameOrSIDMissing = "oracle.service_name_or_sid_missing"
+	codeConfigValidationFailed  = "oracle.config_validation_failed"
+)
+
 // oraCodeCategories maps an Oracle error number to a failure category. Entries marked "go-ora"
 // are taken from the driver's own translate() and Bad() tables, so telemetry agrees with what
 // the library treats as an unusable connection.

--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/datazip-inc/olake/pkg/waljs"
 	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/jackc/pglogrepl"
 	"github.com/jmoiron/sqlx"
@@ -18,7 +19,8 @@ import (
 
 func (p *Postgres) prepareWALJSConfig(streams ...types.StreamInterface) (*waljs.Config, error) {
 	if !p.CDCSupport {
-		return nil, fmt.Errorf("invalid call; %s not running in CDC mode", p.Type())
+		return nil, errs.Precondition(errs.CDCPreconditionFailed, codeCDCNotConfigured,
+			fmt.Errorf("invalid call; %s not running in CDC mode", p.Type()))
 	}
 
 	tlsConfig, err := p.config.buildTLSConfig()
@@ -63,7 +65,8 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 	var postgresGlobalState waljs.WALState
 	rawGlobalState := p.state.GetGlobal()
 	if err := utils.Unmarshal(rawGlobalState.State, &postgresGlobalState); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal global state: %w", err)
+		return nil, errs.Precondition(errs.StateInvalid, codeGlobalStateUnreadable,
+			fmt.Errorf("failed to unmarshal global state: %w", err))
 	}
 
 	var metadataCommittedLSN string
@@ -77,17 +80,20 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 		if stMtState, ok := rawMtState.(string); ok {
 			var mtState waljs.WALState
 			if err := json.Unmarshal([]byte(stMtState), &mtState); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal metadata state: %w", err)
+				return nil, errs.Precondition(errs.StateInvalid, codeMetadataStateUnreadable,
+					fmt.Errorf("failed to unmarshal metadata state: %w", err))
 			}
 
 			// Recovery is only needed when metadata is strictly AHEAD of state .
 			parsedMetaLSN, err := pglogrepl.ParseLSN(mtState.LSN)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse metadata LSN %q: %w", mtState.LSN, err)
+				return nil, errs.Precondition(errs.StateInvalid, codeMetadataLSNUnparseable,
+					fmt.Errorf("failed to parse metadata LSN %q: %w", mtState.LSN, err))
 			}
 			parsedStateLSN, err := pglogrepl.ParseLSN(postgresGlobalState.LSN)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse global state LSN %q: %w", postgresGlobalState.LSN, err)
+				return nil, errs.Precondition(errs.StateInvalid, codeGlobalLSNUnparseable,
+					fmt.Errorf("failed to parse global state LSN %q: %w", postgresGlobalState.LSN, err))
 			}
 			if parsedMetaLSN > parsedStateLSN {
 				// metadata ahead of state: genuine crash-recovery path
@@ -96,7 +102,8 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 			}
 			// state >= metadata: blank sync scenario — stream forward normally
 		} else {
-			return nil, fmt.Errorf("failed to typecast metadata state of type[%T] to string", rawMtState)
+			return nil, errs.Precondition(errs.StateInvalid, codeMetadataStateNotString,
+				fmt.Errorf("failed to typecast metadata state of type[%T] to string", rawMtState))
 		}
 	}
 
@@ -109,7 +116,8 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 		// recovery sync required: read up to the LSN stored in the Iceberg metadata
 		parsed, err := pglogrepl.ParseLSN(metadataCommittedLSN)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse recovery LSN %q: %w", metadataCommittedLSN, err)
+			return nil, errs.Precondition(errs.StateInvalid, codeMetadataLSNUnparseable,
+				fmt.Errorf("failed to parse recovery LSN %q: %w", metadataCommittedLSN, err))
 		}
 		recoveryLSN = &parsed
 
@@ -150,7 +158,7 @@ func (p *Postgres) StreamChanges(ctx context.Context, _ int, metadataStates map[
 	slotAtMetadataLSN := recoveryLSN != nil && slot.LSN == *recoveryLSN
 	if len(remainingStreams) > 0 && !slotAtMetadataLSN {
 		if err := validateGlobalState(postgresGlobalState, slot.LSN); err != nil {
-			return nil, fmt.Errorf("%s: invalid global state: %w", constants.ErrNonRetryable, err)
+			return nil, fmt.Errorf("%w: invalid global state: %w", constants.ErrNonRetryable, err)
 		}
 	} else {
 		logger.Infof("all streams already committed in destination, skipping state LSN validation")
@@ -219,12 +227,14 @@ func validateReplicationSlot(ctx context.Context, conn *sqlx.DB, slotName string
 	}
 
 	if slot.SlotType != "logical" {
-		return fmt.Errorf("only logical slots are supported: %s", slot.SlotType)
+		return errs.Precondition(errs.CDCPreconditionFailed, codeSlotTypeUnsupported,
+			fmt.Errorf("only logical slots are supported: %s", slot.SlotType))
 	}
 
 	logger.Debugf("replication slot[%s] with pluginType[%s] found", slotName, slot.Plugin)
 	if slot.Plugin == "pgoutput" && publication == "" {
-		return fmt.Errorf("publication is required for pgoutput")
+		return errs.Precondition(errs.CDCPreconditionFailed, codePublicationMissing,
+			fmt.Errorf("publication is required for pgoutput"))
 	}
 	return nil
 }
@@ -232,16 +242,19 @@ func validateReplicationSlot(ctx context.Context, conn *sqlx.DB, slotName string
 func validateGlobalState(postgresGlobalState waljs.WALState, confirmedFlushLSN pglogrepl.LSN) error {
 	// global state exist check for cursor and cursor mismatch
 	if postgresGlobalState.LSN == "" {
-		return fmt.Errorf("%w: lsn is empty, please proceed with clear destination", constants.ErrNonRetryable)
+		return errs.Precondition(errs.StateInvalid, codeGlobalLSNMissing,
+			fmt.Errorf("lsn is empty, please proceed with clear destination"))
 	}
 	parsed, err := pglogrepl.ParseLSN(postgresGlobalState.LSN)
 	if err != nil {
-		return fmt.Errorf("failed to parse stored lsn[%s]: %w", postgresGlobalState.LSN, err)
+		return errs.Precondition(errs.StateInvalid, codeGlobalLSNUnparseable,
+			fmt.Errorf("failed to parse stored lsn[%s]: %w", postgresGlobalState.LSN, err))
 	}
 	// failing sync when lsn mismatch found (from state and confirmed flush lsn), as otherwise on backfill, duplication of data will occur
 	// suggesting to proceed with clear destination
 	if parsed != confirmedFlushLSN {
-		return fmt.Errorf("%w: lsn mismatch, please proceed with clear destination. lsn saved in state [%s] current lsn [%s]", constants.ErrNonRetryable, parsed, confirmedFlushLSN)
+		return errs.Precondition(errs.StateInvalid, codeLSNMismatch,
+			fmt.Errorf("lsn mismatch, please proceed with clear destination. lsn saved in state [%s] current lsn [%s]", parsed, confirmedFlushLSN))
 	}
 	return nil
 }

--- a/drivers/postgres/internal/config.go
+++ b/drivers/postgres/internal/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 type Config struct {
@@ -36,14 +37,16 @@ type CDC struct {
 
 func (c *Config) Validate() error {
 	if c.Host == "" {
-		return fmt.Errorf("empty host name")
+		return errs.Precondition(errs.ConfigInvalid, codeHostMissing, fmt.Errorf("empty host name"))
 	} else if strings.Contains(c.Host, "https") || strings.Contains(c.Host, "http") {
-		return fmt.Errorf("host should not contain http or https")
+		return errs.Precondition(errs.ConfigInvalid, codeHostSchemeIncluded,
+			fmt.Errorf("host should not contain http or https"))
 	}
 
 	// Validate port
 	if c.Port <= 0 || c.Port > 65535 {
-		return fmt.Errorf("invalid port number: must be between 1 and 65535")
+		return errs.Precondition(errs.ConfigInvalid, codePortInvalid,
+			fmt.Errorf("invalid port number: must be between 1 and 65535"))
 	}
 
 	// default number of threads
@@ -89,7 +92,8 @@ func (c *Config) Validate() error {
 
 	for i, s := range c.Schemas {
 		if strings.TrimSpace(s) == "" {
-			return fmt.Errorf("schemas[%d] must not be blank", i)
+			return errs.Precondition(errs.ConfigInvalid, codeSchemaBlank,
+				fmt.Errorf("schemas[%d] must not be blank", i))
 		}
 	}
 

--- a/drivers/postgres/internal/errors.go
+++ b/drivers/postgres/internal/errors.go
@@ -9,7 +9,21 @@ import (
 
 // Codes for conditions this driver detects itself, where the server never named the failure.
 const (
-	codeReplicationSlotMissing = "postgres.replication_slot_missing"
+	codeReplicationSlotMissing  = "postgres.replication_slot_missing"
+	codeSlotTypeUnsupported     = "postgres.slot_type_unsupported"
+	codePublicationMissing      = "postgres.publication_missing"
+	codeGlobalStateUnreadable   = "postgres.global_state_unreadable"
+	codeGlobalLSNMissing        = "postgres.global_state_lsn_missing"
+	codeGlobalLSNUnparseable    = "postgres.global_state_lsn_unparseable"
+	codeMetadataStateUnreadable = "postgres.metadata_state_unreadable"
+	codeMetadataStateNotString  = "postgres.metadata_state_not_string"
+	codeMetadataLSNUnparseable  = "postgres.metadata_lsn_unparseable"
+	codeLSNMismatch             = "postgres.lsn_mismatch"
+	codeCDCNotConfigured        = "postgres.cdc_not_configured"
+	codeHostMissing             = "postgres.host_missing"
+	codeHostSchemeIncluded      = "postgres.host_scheme_included"
+	codePortInvalid             = "postgres.port_invalid"
+	codeSchemaBlank             = "postgres.schema_blank"
 )
 
 // sqlStateCategories maps a PostgreSQL SQLSTATE to a failure category. SQLSTATE rather than the

--- a/drivers/s3/internal/config.go
+++ b/drivers/s3/internal/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/drivers/s3/internal/pkg/parser"
+	"github.com/datazip-inc/olake/utils/errs"
 )
 
 // FileFormat represents the format of files in S3
@@ -71,23 +72,27 @@ type Config struct {
 func (c *Config) Validate() error {
 	// Validate bucket name
 	if c.BucketName == "" {
-		return fmt.Errorf("bucket_name is required")
+		return errs.Precondition(errs.ConfigInvalid, codeBucketNameMissing,
+			fmt.Errorf("bucket_name is required"))
 	}
 
 	// Validate region (only if not using custom endpoint)
 	if c.Endpoint == "" && c.Region == "" {
-		return fmt.Errorf("region is required when not using custom endpoint")
+		return errs.Precondition(errs.ConfigInvalid, codeRegionMissing,
+			fmt.Errorf("region is required when not using custom endpoint"))
 	}
 
 	// Validate credentials - both must be provided together or omitted together
 	// If omitted, the driver will fall back to default credential chain (IAM roles, env vars, etc.)
 	if (c.AccessKeyID != "" && c.SecretAccessKey == "") || (c.AccessKeyID == "" && c.SecretAccessKey != "") {
-		return fmt.Errorf("access_key_id and secret_access_key must be provided together or both omitted (for IAM role authentication)")
+		return errs.Precondition(errs.ConfigInvalid, codeCredentialsIncomplete,
+			fmt.Errorf("access_key_id and secret_access_key must be provided together or both omitted (for IAM role authentication)"))
 	}
 
 	// Validate file format
 	if c.FileFormat == "" {
-		return fmt.Errorf("file_format is required (%v)", supportedFileFormats)
+		return errs.Precondition(errs.ConfigInvalid, codeFileFormatMissing,
+			fmt.Errorf("file_format is required (%v)", supportedFileFormats))
 	}
 
 	validFormat := false
@@ -98,7 +103,8 @@ func (c *Config) Validate() error {
 		}
 	}
 	if !validFormat {
-		return fmt.Errorf("invalid file_format: must be %v", supportedFileFormats)
+		return errs.Precondition(errs.ConfigInvalid, codeUnsupportedFileFormat,
+			fmt.Errorf("invalid file_format: must be %v", supportedFileFormats))
 	}
 
 	// Set default values
@@ -115,7 +121,8 @@ func (c *Config) Validate() error {
 		}
 	}
 	if !validCompression {
-		return fmt.Errorf("invalid compression: must be none, gzip, or zip")
+		return errs.Precondition(errs.ConfigInvalid, codeCompressionInvalid,
+			fmt.Errorf("invalid compression: must be none, gzip, or zip"))
 	}
 
 	// Format-specific validation and defaults

--- a/drivers/s3/internal/errors.go
+++ b/drivers/s3/internal/errors.go
@@ -20,6 +20,11 @@ const (
 	codeCDCUnsupported        = "s3.cdc_unsupported"
 	codeUnsupportedFileFormat = "s3.unsupported_file_format"
 	codeNoFilesForStream      = "s3.no_files_for_stream"
+	codeBucketNameMissing     = "s3.bucket_name_missing"
+	codeRegionMissing         = "s3.region_missing"
+	codeCredentialsIncomplete = "s3.credentials_incomplete"
+	codeFileFormatMissing     = "s3.file_format_missing"
+	codeCompressionInvalid    = "s3.compression_invalid"
 )
 
 // Registered so ReportFailure can classify without knowing which connector ran. Only S3 evidence

--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -65,7 +65,8 @@ var discoverCmd = &cobra.Command{
 		}
 
 		if len(streams) == 0 {
-			return errors.New("no streams found in connector")
+			return errs.Precondition(errs.ObjectNotFound, codeNoStreams,
+				errors.New("no streams found in connector"))
 		}
 		types.LogCatalog(streams, catalog, connector.Type())
 

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -158,6 +158,7 @@ const (
 	// Codes for conditions the CLI detects itself, before any connector is reached.
 	codeFlagMissing    = "config.flag_missing"
 	codeNoValidStreams = "catalog.no_valid_streams"
+	codeNoStreams      = "catalog.no_streams_discovered"
 	// recovered panic as an internal error
 	codePanicRecovered = "sync.panic_recovered"
 )

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -158,7 +158,7 @@ var syncCmd = &cobra.Command{
 			telemetry.TrackSyncStarted(syncID, selectedStreamsMetadata.Mix, connector.Type(), destinationConfig, len(catalog.Streams))
 			defer func() {
 				stats := pool.GetStats()
-				telemetry.TrackSyncCompleted(syncID, selectedStreamsMetadata.Mix, destinationConfig, err == nil, stats.ReadCount.Load(), stats.BytesRead.Load())
+				telemetry.TrackSyncCompleted(syncID, selectedStreamsMetadata.Mix, connector.Type(), destinationConfig, err == nil, stats.ReadCount.Load(), stats.BytesRead.Load())
 				logger.Infof("Sync completed, wait 5 seconds cleanup in progress...")
 				time.Sleep(5 * time.Second)
 			}()

--- a/utils/ssl.go
+++ b/utils/ssl.go
@@ -37,8 +37,6 @@ type SSLConfig struct {
 	ClientKey  string `mapstructure:"client_key,omitempty" json:"client_key,omitempty" yaml:"client_key,omitempty"`
 }
 
-// codeSSLConfigInvalid marks an ssl block the user filled in wrong; no server was reached.
-// One code per condition: two checks a user would fix differently never share one.
 const (
 	// The ssl block itself is missing a field.
 	codeSSLMissing         = "config.ssl_missing"

--- a/utils/ssl.go
+++ b/utils/ssl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/datazip-inc/olake/utils/errs"
 	"github.com/datazip-inc/olake/utils/logger"
 )
 
@@ -36,20 +37,46 @@ type SSLConfig struct {
 	ClientKey  string `mapstructure:"client_key,omitempty" json:"client_key,omitempty" yaml:"client_key,omitempty"`
 }
 
+// codeSSLConfigInvalid marks an ssl block the user filled in wrong; no server was reached.
+// One code per condition: two checks a user would fix differently never share one.
+const (
+	// The ssl block itself is missing a field.
+	codeSSLMissing         = "config.ssl_missing"
+	codeSSLModeMissing     = "config.ssl_mode_missing"
+	codeSSLServerCAMissing = "config.ssl_server_ca_missing"
+
+	// The PEM material the user supplied is unusable; nothing was sent to a server yet.
+	codeSSLMaterialMissing        = "config.ssl_material_missing"
+	codeSSLPEMNotCertificate      = "config.ssl_pem_not_certificate"
+	codeSSLCertificateUnparseable = "config.ssl_certificate_unparseable"
+	codeSSLPEMMalformed           = "config.ssl_pem_malformed"
+	codeSSLPEMTrailingData        = "config.ssl_pem_trailing_data"
+	codeSSLCAUnusable             = "config.ssl_ca_unusable"
+	codeSSLClientKeypairInvalid   = "config.ssl_client_keypair_invalid"
+
+	// Raised during the handshake, against the CA the user supplied.
+	codeServerCertAbsent      = "tls.server_cert_absent"
+	codeServerCertUnparseable = "tls.server_cert_unparseable"
+	codeServerCertUnverified  = "tls.server_cert_unverified"
+)
+
 // Validate returns err if the ssl configuration is invalid
 func (sc *SSLConfig) Validate() error {
 	// TODO: Add Proper validations and test
 	if sc == nil {
-		return errors.New("'ssl' config is required")
+		return errs.Precondition(errs.ConfigInvalid, codeSSLMissing,
+			errors.New("'ssl' config is required"))
 	}
 
 	if sc.Mode == Unknown {
-		return errors.New("'ssl.mode' is required parameter")
+		return errs.Precondition(errs.ConfigInvalid, codeSSLModeMissing,
+			errors.New("'ssl.mode' is required parameter"))
 	}
 
 	if sc.Mode == SSLModeVerifyCA || sc.Mode == SSLModeVerifyFull {
 		if sc.ServerCA == "" {
-			return errors.New("'ssl.server_ca' is required parameter")
+			return errs.Precondition(errs.ConfigInvalid, codeSSLServerCAMissing,
+				errors.New("'ssl.server_ca' is required parameter"))
 		}
 	}
 
@@ -78,7 +105,8 @@ func BuildTLSConfig(host string, sc *SSLConfig) (*tls.Config, error) {
 		return nil, err
 	}
 	if ok := rootCertPool.AppendCertsFromPEM(serverCAPEM); !ok {
-		return nil, fmt.Errorf("failed to append CA certificate")
+		return nil, errs.Precondition(errs.ConfigInvalid, codeSSLCAUnusable,
+			fmt.Errorf("failed to append CA certificate"))
 	}
 
 	tlsConfig := &tls.Config{
@@ -91,11 +119,13 @@ func BuildTLSConfig(host string, sc *SSLConfig) (*tls.Config, error) {
 		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			if len(rawCerts) == 0 {
-				return fmt.Errorf("no server certificate provided")
+				return errs.Precondition(errs.TLSFailed, codeServerCertAbsent,
+					fmt.Errorf("no server certificate provided"))
 			}
 			cert, err := x509.ParseCertificate(rawCerts[0])
 			if err != nil {
-				return fmt.Errorf("failed to parse server certificate: %w", err)
+				return errs.Precondition(errs.TLSFailed, codeServerCertUnparseable,
+					fmt.Errorf("failed to parse server certificate: %w", err))
 			}
 
 			intermediates := x509.NewCertPool()
@@ -113,7 +143,8 @@ func BuildTLSConfig(host string, sc *SSLConfig) (*tls.Config, error) {
 				Intermediates: intermediates,
 			}
 			if _, err := cert.Verify(verifyOpts); err != nil {
-				return fmt.Errorf("failed to verify server certificate against CA: %w", err)
+				return errs.Precondition(errs.TLSFailed, codeServerCertUnverified,
+					fmt.Errorf("failed to verify server certificate against CA: %w", err))
 			}
 			return nil
 		}
@@ -133,7 +164,8 @@ func BuildTLSConfig(host string, sc *SSLConfig) (*tls.Config, error) {
 		}
 		clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate and key: %s", err)
+			return nil, errs.Precondition(errs.ConfigInvalid, codeSSLClientKeypairInvalid,
+				fmt.Errorf("failed to load client certificate and key: %s", err))
 		}
 		tlsConfig.Certificates = []tls.Certificate{clientCert}
 	}
@@ -144,7 +176,8 @@ func BuildTLSConfig(host string, sc *SSLConfig) (*tls.Config, error) {
 func readPEMData(value string, field SSLField, parseAsCert bool) ([]byte, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
-		return nil, fmt.Errorf("'%s' is required", string(field))
+		return nil, errs.Precondition(errs.ConfigInvalid, codeSSLMaterialMissing,
+			fmt.Errorf("'%s' is required", string(field)))
 	}
 
 	// PEM files may contain multiple blocks (e.g., certificate chains).
@@ -161,19 +194,23 @@ func readPEMData(value string, field SSLField, parseAsCert bool) ([]byte, error)
 
 		if parseAsCert {
 			if block.Type != "CERTIFICATE" {
-				return nil, fmt.Errorf("'%s' must contain CERTIFICATE PEM blocks", string(field))
+				return nil, errs.Precondition(errs.ConfigInvalid, codeSSLPEMNotCertificate,
+					fmt.Errorf("'%s' must contain CERTIFICATE PEM blocks", string(field)))
 			}
 			if _, err := x509.ParseCertificate(block.Bytes); err != nil {
-				return nil, fmt.Errorf("'%s' contains an invalid certificate: %w", string(field), err)
+				return nil, errs.Precondition(errs.ConfigInvalid, codeSSLCertificateUnparseable,
+					fmt.Errorf("'%s' contains an invalid certificate: %w", string(field), err))
 			}
 		}
 	}
 
 	if !foundBlock {
-		return nil, fmt.Errorf("'%s' is not a valid PEM encoded block", string(field))
+		return nil, errs.Precondition(errs.ConfigInvalid, codeSSLPEMMalformed,
+			fmt.Errorf("'%s' is not a valid PEM encoded block", string(field)))
 	}
 	if strings.TrimSpace(string(remaining)) != "" {
-		return nil, fmt.Errorf("'%s' must contain only PEM blocks", string(field))
+		return nil, errs.Precondition(errs.ConfigInvalid, codeSSLPEMTrailingData,
+			fmt.Errorf("'%s' must contain only PEM blocks", string(field)))
 	}
 
 	return []byte(trimmed), nil

--- a/utils/telemetry/telemetry.go
+++ b/utils/telemetry/telemetry.go
@@ -231,7 +231,7 @@ func TrackSyncStarted(syncID string, mix types.StreamMix, sourceType string, des
 	})
 }
 
-func TrackSyncCompleted(syncID string, mix types.StreamMix, destinationConfig *types.WriterConfig, status bool, records, bytesRead int64) {
+func TrackSyncCompleted(syncID string, mix types.StreamMix, sourceType string, destinationConfig *types.WriterConfig, status bool, records, bytesRead int64) {
 	destinationType, catalogType := destinationShape(destinationConfig)
 
 	send("sync completed", func() {
@@ -241,6 +241,7 @@ func TrackSyncCompleted(syncID string, mix types.StreamMix, destinationConfig *t
 			"sync_status":      utils.Ternary(status, "SUCCESS", "FAILED").(string),
 			"records_synced":   records,
 			"bytes_read":       bytesRead,
+			"source_type":      sourceType,
 			"destination_type": destinationType,
 			"catalog_type":     catalogType,
 		}

--- a/utils/telemetry/telemetry_test.go
+++ b/utils/telemetry/telemetry_test.go
@@ -187,7 +187,7 @@ func TestEventPropertyNames(t *testing.T) {
 		},
 		{
 			name:  "sync completed",
-			track: func() { TrackSyncCompleted("sync-1", mix, destination, false, 100, 2048) },
+			track: func() { TrackSyncCompleted("sync-1", mix, "postgres", destination, false, 100, 2048) },
 			expectedKeys: []string{
 				"sync_id", "sync_end", "sync_status", "records_synced", "bytes_read",
 				"destination_type", "catalog_type",
@@ -435,7 +435,7 @@ func TestTrackEventsSurviveASendFailure(t *testing.T) {
 	}{
 		{name: "discover", track: func() { TrackDiscover(1, "postgres") }},
 		{name: "sync started", track: func() { TrackSyncStarted("s", mix, "postgres", destination, 1) }},
-		{name: "sync completed", track: func() { TrackSyncCompleted("s", mix, destination, true, 1, 1) }},
+		{name: "sync completed", track: func() { TrackSyncCompleted("s", mix, "postgres", destination, true, 1, 1) }},
 		{name: "failure", track: func() { TrackFailure("sync", "postgres", "s", errs.Failure{Category: errs.AuthFailed}) }},
 	}
 

--- a/utils/telemetry/telemetry_test.go
+++ b/utils/telemetry/telemetry_test.go
@@ -190,7 +190,7 @@ func TestEventPropertyNames(t *testing.T) {
 			track: func() { TrackSyncCompleted("sync-1", mix, "postgres", destination, false, 100, 2048) },
 			expectedKeys: []string{
 				"sync_id", "sync_end", "sync_status", "records_synced", "bytes_read",
-				"destination_type", "catalog_type",
+				"source_type", "destination_type", "catalog_type",
 			},
 			expectedValues: streamMixProps,
 		},


### PR DESCRIPTION
# Description

- `Sync Completed` telemetry now carries `source_type`, matching what `Sync Started` already sends.

- Postgres CDC wrapped `constants.ErrNonRetryable` twice on the LSN validation path
   -  once inside `validateGlobalState`
   -  again at the caller 
```   
producing `failed with non retryable error: invalid global state: failed with non retryable error: lsn mismatch...`.
```

The sentinel now lives only at the call site (and uses `%w` instead of `%s`).



- Added `errs.Precondition` classification to every check in every driver's `Config.Validate` (postgres, mysql, mssql, mongodb, oracle, kafka, db2, s3) plus the shared SSL/PEM validators, and to the postgres CDC state checks. These previously reported `unclassified` with `error_type: *errors.errorString` in the failure event, since the chain walk can only surface evidence that already exists in the error.
- 
Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):