### PR TITLE
fix(postgres): make publication validation case-sensitive

### DIFF
--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/datazip-inc/olake/constants"
@@ -16,6 +17,85 @@ import (
 	"github.com/jackc/pglogrepl"
 	"github.com/jmoiron/sqlx"
 )
+
+// publicationTablesTmpl queries pg_publication_tables to return all (schemaname, tablename)
+// pairs tracked by the given publication name.
+const publicationTablesTmpl = `
+	SELECT schemaname, tablename
+	FROM pg_publication_tables
+	WHERE pubname = $1`
+
+// pubTable is an internal scan target for rows returned by publicationTablesTmpl.
+type pubTable struct {
+	Schema string `db:"schemaname"`
+	Table  string `db:"tablename"`
+}
+
+// fetchPublicationTables fetches all tables registered under a publication.
+func fetchPublicationTables(ctx context.Context, conn *sqlx.DB, publication string) ([]pubTable, error) {
+	var rows []pubTable
+	if err := conn.SelectContext(ctx, &rows, publicationTablesTmpl, publication); err != nil {
+		return nil, fmt.Errorf("failed to query publication tables for publication %q: %w", publication, err)
+	}
+	return rows, nil
+}
+
+// checkStreamsInPublication is the pure validation logic (no DB dependency).
+// Given the list of publication tables and selected streams, returns an error
+// if any stream is not covered by the publication.
+func checkStreamsInPublication(publication string, pubTables []pubTable, streams []types.StreamInterface) error {
+	if len(pubTables) == 0 {
+		return fmt.Errorf(
+			"%w: publication %q exists but contains no tables; "+
+				"add the required tables with: ALTER PUBLICATION %s ADD TABLE <schema>.<table>",
+			constants.ErrNonRetryable, publication, publication,
+		)
+	}
+
+	// Build a normalised lookup set: "schema.table" → present
+	pubSet := make(map[string]struct{}, len(pubTables))
+	for _, r := range pubTables {
+		key := strings.ToLower(r.Schema) + "." + strings.ToLower(r.Table)
+		pubSet[key] = struct{}{}
+	}
+
+	var missing []string
+	for _, stream := range streams {
+		key := strings.ToLower(stream.Namespace()) + "." + strings.ToLower(stream.Name())
+		if _, ok := pubSet[key]; !ok {
+			missing = append(missing, stream.Namespace()+"."+stream.Name())
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"%w: the following tables are selected in streams.json but are NOT tracked by "+
+				"publication %q — add them before starting the sync:\n  %s\n"+
+				"Run: ALTER PUBLICATION %s ADD TABLE %s",
+			constants.ErrNonRetryable,
+			publication,
+			strings.Join(missing, "\n  "),
+			publication,
+			strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
+
+// validatePublicationContainsStreams is called from PreCDC.
+// Fixes: https://github.com/datazip-inc/olake/issues/752
+func validatePublicationContainsStreams(ctx context.Context, conn *sqlx.DB, publication string, streams []types.StreamInterface) error {
+	if publication == "" || len(streams) == 0 {
+		return nil
+	}
+	pubTables, err := fetchPublicationTables(ctx, conn, publication)
+	if err != nil {
+		return err
+	}
+	return checkStreamsInPublication(publication, pubTables, streams)
+}
+
+
 
 func (p *Postgres) prepareWALJSConfig(streams ...types.StreamInterface) (*waljs.Config, error) {
 	if !p.CDCSupport {
@@ -44,6 +124,14 @@ func (p *Postgres) ChangeStreamConfig() (bool, bool, bool) {
 }
 
 func (p *Postgres) PreCDC(ctx context.Context, streams []types.StreamInterface) error {
+	// Validate all selected streams exist in the publication before touching the slot.
+    // Fixes: https://github.com/datazip-inc/olake/issues/752
+	
+	if err := validatePublicationContainsStreams(ctx, p.client, p.cdcConfig.Publication, streams); err != nil {
+        return fmt.Errorf("publication validation failed: %w", err)
+    }
+
+
 	slot, err := waljs.GetSlotPosition(ctx, p.client, p.cdcConfig.ReplicationSlot)
 	if err != nil {
 		return fmt.Errorf("failed to get slot position: %w", err)

--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -53,16 +53,15 @@ func checkStreamsInPublication(publication string, pubTables []pubTable, streams
 	}
 
 	// Build a normalised lookup set: "schema.table" -> present
-	pubSet := make(map[string]struct{}, len(pubTables))
+	pubSet := types.NewSet[string]()
 	for _, r := range pubTables {
-		key := strings.ToLower(r.Schema) + "." + strings.ToLower(r.Table)
-		pubSet[key] = struct{}{}
+		id := utils.StreamIdentifier(r.Table, r.Schema)
+		pubSet.Insert(id)
 	}
 
 	var missing []string
 	for _, stream := range streams {
-		key := strings.ToLower(stream.ID())
-		if _, ok := pubSet[key]; !ok {
+		if !pubSet.Exists(stream.ID()) {
 			missing = append(missing, stream.ID())
 		}
 	}

--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -142,7 +142,6 @@ func (p *Postgres) ChangeStreamConfig() (bool, bool, bool) {
 }
 
 func (p *Postgres) PreCDC(ctx context.Context, streams []types.StreamInterface) error {
-
 	if err := validatePublicationContainsStreams(ctx, p.client, p.cdcConfig.Publication, streams); err != nil {
 		return fmt.Errorf("publication validation failed: %w", err)
 	}

--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -81,6 +81,13 @@ func checkStreamsInPublication(publication string, pubTables []pubTable, streams
 	return nil
 }
 
+// checkPublicationExists verifies if a publication exists in the database.
+func checkPublicationExists(ctx context.Context, conn *sqlx.DB, publication string) (bool, error) {
+	var exists bool
+	err := conn.GetContext(ctx, &exists, "SELECT EXISTS(SELECT 1 FROM pg_publication WHERE pubname = $1)", publication)
+	return exists, err
+}
+
 // validatePublicationContainsStreams is called from PreCDC.
 // It fetches the publication's table list and delegates to
 // checkStreamsInPublication for the comparison.
@@ -88,6 +95,19 @@ func validatePublicationContainsStreams(ctx context.Context, conn *sqlx.DB, publ
 	if publication == "" || len(streams) == 0 {
 		return nil
 	}
+
+	exists, err := checkPublicationExists(ctx, conn, publication)
+	if err != nil {
+		return fmt.Errorf("failed to verify publication existence: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf(
+			"%w: publication %q does not exist; "+
+				"please create it with: CREATE PUBLICATION %s FOR TABLE <schema>.<table>",
+			constants.ErrNonRetryable, publication, publication,
+		)
+	}
+
 	pubTables, err := fetchPublicationTables(ctx, conn, publication)
 	if err != nil {
 		return err

--- a/drivers/postgres/internal/cdc.go
+++ b/drivers/postgres/internal/cdc.go
@@ -40,7 +40,7 @@ func fetchPublicationTables(ctx context.Context, conn *sqlx.DB, publication stri
 	return rows, nil
 }
 
-// checkStreamsInPublication is the pure validation logic (no DB dependency).
+// checkStreamsInPublication is the pure validation logic.
 // Given the list of publication tables and selected streams, returns an error
 // if any stream is not covered by the publication.
 func checkStreamsInPublication(publication string, pubTables []pubTable, streams []types.StreamInterface) error {
@@ -52,7 +52,7 @@ func checkStreamsInPublication(publication string, pubTables []pubTable, streams
 		)
 	}
 
-	// Build a normalised lookup set: "schema.table" → present
+	// Build a normalised lookup set: "schema.table" -> present
 	pubSet := make(map[string]struct{}, len(pubTables))
 	for _, r := range pubTables {
 		key := strings.ToLower(r.Schema) + "." + strings.ToLower(r.Table)
@@ -61,9 +61,9 @@ func checkStreamsInPublication(publication string, pubTables []pubTable, streams
 
 	var missing []string
 	for _, stream := range streams {
-		key := strings.ToLower(stream.Namespace()) + "." + strings.ToLower(stream.Name())
+		key := strings.ToLower(stream.ID())
 		if _, ok := pubSet[key]; !ok {
-			missing = append(missing, stream.Namespace()+"."+stream.Name())
+			missing = append(missing, stream.ID())
 		}
 	}
 
@@ -83,7 +83,8 @@ func checkStreamsInPublication(publication string, pubTables []pubTable, streams
 }
 
 // validatePublicationContainsStreams is called from PreCDC.
-// Fixes: https://github.com/datazip-inc/olake/issues/752
+// It fetches the publication's table list and delegates to
+// checkStreamsInPublication for the comparison.
 func validatePublicationContainsStreams(ctx context.Context, conn *sqlx.DB, publication string, streams []types.StreamInterface) error {
 	if publication == "" || len(streams) == 0 {
 		return nil
@@ -94,8 +95,6 @@ func validatePublicationContainsStreams(ctx context.Context, conn *sqlx.DB, publ
 	}
 	return checkStreamsInPublication(publication, pubTables, streams)
 }
-
-
 
 func (p *Postgres) prepareWALJSConfig(streams ...types.StreamInterface) (*waljs.Config, error) {
 	if !p.CDCSupport {
@@ -124,13 +123,10 @@ func (p *Postgres) ChangeStreamConfig() (bool, bool, bool) {
 }
 
 func (p *Postgres) PreCDC(ctx context.Context, streams []types.StreamInterface) error {
-	// Validate all selected streams exist in the publication before touching the slot.
-    // Fixes: https://github.com/datazip-inc/olake/issues/752
-	
-	if err := validatePublicationContainsStreams(ctx, p.client, p.cdcConfig.Publication, streams); err != nil {
-        return fmt.Errorf("publication validation failed: %w", err)
-    }
 
+	if err := validatePublicationContainsStreams(ctx, p.client, p.cdcConfig.Publication, streams); err != nil {
+		return fmt.Errorf("publication validation failed: %w", err)
+	}
 
 	slot, err := waljs.GetSlotPosition(ctx, p.client, p.cdcConfig.ReplicationSlot)
 	if err != nil {

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -44,6 +44,8 @@ func (m *mockStream) IsSelectedColumn() func(string) bool {
 	return func(_ string) bool { return true }
 }
 
+func (m *mockStream) ResolveColumnName(key string) string { return key }
+
 func ms(schema, table string) types.StreamInterface {
 	return &mockStream{name: table, namespace: schema}
 }

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -16,22 +16,27 @@ type mockStream struct {
 
 func (m *mockStream) Name() string      { return m.name }
 func (m *mockStream) Namespace() string { return m.namespace }
-func (m *mockStream) ID() string        { return m.namespace + "." + m.name }
+func (m *mockStream) ID() string {
+	if m.namespace != "" {
+		return m.namespace + "." + m.name
+	}
+	return m.name
+}
 
 // Remaining interface stubs — not exercised by these tests.
-func (m *mockStream) Self() *types.ConfiguredStream  { return nil }
-func (m *mockStream) Schema() *types.TypeSchema      { return nil }
-func (m *mockStream) GetStream() *types.Stream       { return nil }
-func (m *mockStream) GetSyncMode() types.SyncMode    { return "" }
+func (m *mockStream) Self() *types.ConfiguredStream { return nil }
+func (m *mockStream) Schema() *types.TypeSchema     { return nil }
+func (m *mockStream) GetStream() *types.Stream      { return nil }
+func (m *mockStream) GetSyncMode() types.SyncMode   { return "" }
 func (m *mockStream) GetFilter() (types.FilterConfig, bool, error) {
 	return types.FilterConfig{}, false, nil
 }
 func (m *mockStream) SupportedSyncModes() *types.Set[types.SyncMode] { return nil }
-func (m *mockStream) Cursor() (string, string)                        { return "", "" }
-func (m *mockStream) Validate(_ *types.Stream) error                  { return nil }
-func (m *mockStream) NormalizationEnabled() bool                      { return false }
-func (m *mockStream) GetDestinationDatabase(_ *string) string         { return "" }
-func (m *mockStream) GetDestinationTable() string                     { return "" }
+func (m *mockStream) Cursor() (string, string)                       { return "", "" }
+func (m *mockStream) Validate(_ *types.Stream) error                 { return nil }
+func (m *mockStream) NormalizationEnabled() bool                     { return false }
+func (m *mockStream) GetDestinationDatabase(_ *string) string        { return "" }
+func (m *mockStream) GetDestinationTable() string                    { return "" }
 func (m *mockStream) RetainSelectedColumns() func(map[string]interface{}) map[string]interface{} {
 	return func(r map[string]interface{}) map[string]interface{} { return r }
 }
@@ -43,22 +48,20 @@ func ms(schema, table string) types.StreamInterface {
 	return &mockStream{name: table, namespace: schema}
 }
 
-// Tests for checkStreamsInPublication (pure logic, no DB required)
+// Tests for checkStreamsInPublication
 
 func TestCheckStreamsInPublication(t *testing.T) {
 	tests := []struct {
-		name        string
-		publication string
-		pubTables   []pubTable
-		streams     []types.StreamInterface
-		wantErr     bool
-		// substrings that must appear in the error message
-		errContains []string
-		// isNonRetryable: error must wrap constants.ErrNonRetryable
+		name           string
+		publication    string
+		pubTables      []pubTable
+		streams        []types.StreamInterface
+		wantErr        bool
+		errContains    []string
 		isNonRetryable bool
 	}{
 		{
-			name:        "happy path — all streams present",
+			name:        "happy path — all streams present, matched via ID()",
 			publication: "my_pub",
 			pubTables: []pubTable{
 				{Schema: "public", Table: "orders"},
@@ -108,7 +111,7 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			isNonRetryable: true,
 		},
 		{
-			name:        "case-insensitive match — publication uses uppercase",
+			name:        "case-insensitive match — DB side uppercase, stream.ID() lowercase",
 			publication: "pub",
 			pubTables: []pubTable{
 				{Schema: "PUBLIC", Table: "ORDERS"},
@@ -119,7 +122,7 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "case-insensitive match — streams use uppercase",
+			name:        "case-insensitive match — stream.ID() uppercase, DB side lowercase",
 			publication: "pub",
 			pubTables: []pubTable{
 				{Schema: "public", Table: "orders"},
@@ -130,7 +133,7 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "multiple schemas — correct matching",
+			name:        "multiple schemas — correct matching via ID()",
 			publication: "cross_schema_pub",
 			pubTables: []pubTable{
 				{Schema: "public", Table: "orders"},
@@ -182,6 +185,16 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			wantErr:     true,
 			errContains: []string{"ALTER PUBLICATION mypub ADD TABLE", "public.t1", "public.t2"},
 		},
+		{
+			name:        "missing table names in error use stream.ID() format",
+			publication: "pub",
+			pubTables:   []pubTable{{Schema: "public", Table: "other"}},
+			streams: []types.StreamInterface{
+				ms("sales", "orders"),
+			},
+			wantErr:     true,
+			errContains: []string{"sales.orders"}, // exact ID() format, not reconstructed
+		},
 	}
 
 	for _, tt := range tests {
@@ -206,5 +219,13 @@ func TestCheckStreamsInPublication(t *testing.T) {
 				t.Errorf("expected ErrNonRetryable to be wrapped in error, got: %v", err)
 			}
 		})
+	}
+}
+
+func TestStreamID_FormatAssumption(t *testing.T) {
+	s := ms("public", "orders")
+	want := "public.orders"
+	if s.ID() != want {
+		t.Fatalf("mockStream.ID() = %q, want %q — checkStreamsInPublication assumes namespace.name format", s.ID(), want)
 	}
 }

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -1,0 +1,210 @@
+package driver
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/datazip-inc/olake/constants"
+	"github.com/datazip-inc/olake/types"
+)
+
+type mockStream struct {
+	name      string
+	namespace string
+}
+
+func (m *mockStream) Name() string      { return m.name }
+func (m *mockStream) Namespace() string { return m.namespace }
+func (m *mockStream) ID() string        { return m.namespace + "." + m.name }
+
+// Remaining interface stubs — not exercised by these tests.
+func (m *mockStream) Self() *types.ConfiguredStream  { return nil }
+func (m *mockStream) Schema() *types.TypeSchema      { return nil }
+func (m *mockStream) GetStream() *types.Stream       { return nil }
+func (m *mockStream) GetSyncMode() types.SyncMode    { return "" }
+func (m *mockStream) GetFilter() (types.FilterConfig, bool, error) {
+	return types.FilterConfig{}, false, nil
+}
+func (m *mockStream) SupportedSyncModes() *types.Set[types.SyncMode] { return nil }
+func (m *mockStream) Cursor() (string, string)                        { return "", "" }
+func (m *mockStream) Validate(_ *types.Stream) error                  { return nil }
+func (m *mockStream) NormalizationEnabled() bool                      { return false }
+func (m *mockStream) GetDestinationDatabase(_ *string) string         { return "" }
+func (m *mockStream) GetDestinationTable() string                     { return "" }
+func (m *mockStream) RetainSelectedColumns() func(map[string]interface{}) map[string]interface{} {
+	return func(r map[string]interface{}) map[string]interface{} { return r }
+}
+func (m *mockStream) IsSelectedColumn() func(string) bool {
+	return func(_ string) bool { return true }
+}
+
+func ms(schema, table string) types.StreamInterface {
+	return &mockStream{name: table, namespace: schema}
+}
+
+// Tests for checkStreamsInPublication (pure logic, no DB required)
+
+func TestCheckStreamsInPublication(t *testing.T) {
+	tests := []struct {
+		name        string
+		publication string
+		pubTables   []pubTable
+		streams     []types.StreamInterface
+		wantErr     bool
+		// substrings that must appear in the error message
+		errContains []string
+		// isNonRetryable: error must wrap constants.ErrNonRetryable
+		isNonRetryable bool
+	}{
+		{
+			name:        "happy path — all streams present",
+			publication: "my_pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "orders"},
+				{Schema: "public", Table: "users"},
+			},
+			streams: []types.StreamInterface{
+				ms("public", "orders"),
+				ms("public", "users"),
+			},
+			wantErr: false,
+		},
+		{
+			name:        "one stream missing from publication",
+			publication: "my_pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "orders"},
+			},
+			streams: []types.StreamInterface{
+				ms("public", "orders"),
+				ms("public", "payments"), // not in publication
+			},
+			wantErr:        true,
+			errContains:    []string{"public.payments", "ALTER PUBLICATION", "my_pub"},
+			isNonRetryable: true,
+		},
+		{
+			name:        "all streams missing from publication",
+			publication: "pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "other_table"},
+			},
+			streams: []types.StreamInterface{
+				ms("public", "orders"),
+				ms("analytics", "events"),
+			},
+			wantErr:        true,
+			errContains:    []string{"public.orders", "analytics.events"},
+			isNonRetryable: true,
+		},
+		{
+			name:           "publication has no tables at all",
+			publication:    "empty_pub",
+			pubTables:      []pubTable{},
+			streams:        []types.StreamInterface{ms("public", "orders")},
+			wantErr:        true,
+			errContains:    []string{"empty_pub", "no tables"},
+			isNonRetryable: true,
+		},
+		{
+			name:        "case-insensitive match — publication uses uppercase",
+			publication: "pub",
+			pubTables: []pubTable{
+				{Schema: "PUBLIC", Table: "ORDERS"},
+			},
+			streams: []types.StreamInterface{
+				ms("public", "orders"),
+			},
+			wantErr: false,
+		},
+		{
+			name:        "case-insensitive match — streams use uppercase",
+			publication: "pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "orders"},
+			},
+			streams: []types.StreamInterface{
+				ms("PUBLIC", "ORDERS"),
+			},
+			wantErr: false,
+		},
+		{
+			name:        "multiple schemas — correct matching",
+			publication: "cross_schema_pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "orders"},
+				{Schema: "analytics", Table: "events"},
+			},
+			streams: []types.StreamInterface{
+				ms("public", "orders"),
+				ms("analytics", "events"),
+			},
+			wantErr: false,
+		},
+		{
+			name:        "same table name different schema — must not cross-match",
+			publication: "pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "orders"}, // only public.orders is covered
+			},
+			streams: []types.StreamInterface{
+				ms("analytics", "orders"), // analytics.orders is NOT covered
+			},
+			wantErr:        true,
+			errContains:    []string{"analytics.orders"},
+			isNonRetryable: true,
+		},
+		{
+			name:        "no streams selected — no error",
+			publication: "pub",
+			pubTables: []pubTable{
+				{Schema: "public", Table: "orders"},
+			},
+			streams: nil,
+			wantErr: false,
+		},
+		{
+			name:        "single stream present — no error",
+			publication: "pub",
+			pubTables:   []pubTable{{Schema: "public", Table: "orders"}},
+			streams:     []types.StreamInterface{ms("public", "orders")},
+			wantErr:     false,
+		},
+		{
+			name:        "error message includes ALTER PUBLICATION hint with all missing tables",
+			publication: "mypub",
+			pubTables:   []pubTable{{Schema: "public", Table: "other"}},
+			streams: []types.StreamInterface{
+				ms("public", "t1"),
+				ms("public", "t2"),
+			},
+			wantErr:     true,
+			errContains: []string{"ALTER PUBLICATION mypub ADD TABLE", "public.t1", "public.t2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkStreamsInPublication(tt.publication, tt.pubTables, tt.streams)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr=%v but got err=%v", tt.wantErr, err)
+			}
+
+			if err == nil {
+				return
+			}
+
+			for _, substr := range tt.errContains {
+				if !strings.Contains(err.Error(), substr) {
+					t.Errorf("error must contain %q\ngot: %v", substr, err)
+				}
+			}
+
+			if tt.isNonRetryable && !errors.Is(err, constants.ErrNonRetryable) {
+				t.Errorf("expected ErrNonRetryable to be wrapped in error, got: %v", err)
+			}
+		})
+	}
+}

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -113,7 +113,7 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			isNonRetryable: true,
 		},
 		{
-			name:        "case-insensitive match — DB side uppercase, stream.ID() lowercase",
+			name:        "case-sensitive match DB side uppercase, stream.ID() lowercase",
 			publication: "pub",
 			pubTables: []pubTable{
 				{Schema: "PUBLIC", Table: "ORDERS"},
@@ -121,10 +121,12 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			streams: []types.StreamInterface{
 				ms("public", "orders"),
 			},
-			wantErr: false,
+			wantErr:        true,
+			errContains:    []string{"public.orders"},
+			isNonRetryable: true,
 		},
 		{
-			name:        "case-insensitive match — stream.ID() uppercase, DB side lowercase",
+			name:        "case-sensitive match stream.ID() uppercase, DB side lowercase",
 			publication: "pub",
 			pubTables: []pubTable{
 				{Schema: "public", Table: "orders"},
@@ -132,7 +134,9 @@ func TestCheckStreamsInPublication(t *testing.T) {
 			streams: []types.StreamInterface{
 				ms("PUBLIC", "ORDERS"),
 			},
-			wantErr: false,
+			wantErr:        true,
+			errContains:    []string{"PUBLIC.ORDERS"},
+			isNonRetryable: true,
 		},
 		{
 			name:        "multiple schemas — correct matching via ID()",

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -45,8 +45,8 @@ func (m *mockStream) IsSelectedColumn() func(string) bool {
 }
 
 func (m *mockStream) ResolveColumnName(key string) string { return key }
-func (m *mockStream) GetPartitionRegex() string             { return "" }
-func (m *mockStream) GetUpdateType() types.UpdateType       { return "" }
+func (m *mockStream) GetPartitionRegex() string           { return "" }
+func (m *mockStream) GetUpdateType() types.UpdateType     { return "" }
 
 func ms(schema, table string) types.StreamInterface {
 	return &mockStream{name: table, namespace: schema}

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -46,6 +46,7 @@ func (m *mockStream) IsSelectedColumn() func(string) bool {
 
 func (m *mockStream) ResolveColumnName(key string) string { return key }
 func (m *mockStream) GetPartitionRegex() string             { return "" }
+func (m *mockStream) GetUpdateType() types.UpdateType       { return "" }
 
 func ms(schema, table string) types.StreamInterface {
 	return &mockStream{name: table, namespace: schema}

--- a/drivers/postgres/internal/cdc_publication_test.go
+++ b/drivers/postgres/internal/cdc_publication_test.go
@@ -45,6 +45,7 @@ func (m *mockStream) IsSelectedColumn() func(string) bool {
 }
 
 func (m *mockStream) ResolveColumnName(key string) string { return key }
+func (m *mockStream) GetPartitionRegex() string             { return "" }
 
 func ms(schema, table string) types.StreamInterface {
 	return &mockStream{name: table, namespace: schema}


### PR DESCRIPTION
# Description

This PR takes over and supersedes #971 by implementing the requested reviewer changes regarding case-sensitive Set validations. It updates the Postgres CDC validation logic to use `types.Set[string]` natively and constructs the stream identifier using `utils.StreamIdentifier` to correctly handle schema and table case sensitivity. 

Fixes #752 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Verified unit tests in `cdc_publication_test.go` handle both uppercase and lowercase namespace matches correctly and assert failures appropriately.
- [x] Successfully ran end-to-end `olake sync` against a local Docker Postgres and MinIO instance. Safely connected, created replication slots, verified the publication correctly without errors, backfilled successfully and started CDC replication perfectly.

# Screenshots or Recordings

https://github.com/user-attachments/assets/736ef4e8-2b0b-4902-a978-cdc976a6a360



## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):
Supersedes #971
