### PR TITLE
perf: avoid duplicate hashing in Set.Insert

### DIFF
--- a/types/set.go
+++ b/types/set.go
@@ -100,11 +100,11 @@ func (st *Set[T]) Exists(element T) bool {
 // Add an element to the set
 func (st *Set[T]) Insert(elements ...T) {
 	for _, elem := range elements {
-		if st.Exists(elem) {
+		hash := st.Hash(elem)
+
+		if _, exists := st.hash[hash]; exists {
 			continue
 		}
-
-		hash := st.Hash(elem)
 
 		st.hash[hash] = nothing{}
 		st.storage[hash] = elem

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -1,0 +1,58 @@
+package types
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestSetInsertHashesOnce(t *testing.T) {
+	hashCalls := 0
+
+	set := NewSet[int]().WithHasher(func(v int) string {
+		hashCalls++
+		return strconv.Itoa(v)
+	})
+
+	set.Insert(10)
+
+	if hashCalls != 1 {
+		t.Fatalf("expected 1 hash call, got %d", hashCalls)
+	}
+}
+
+func TestSetInsertDuplicate(t *testing.T) {
+	set := NewSet[int]()
+
+	set.Insert(10)
+	set.Insert(10)
+
+	if set.Len() != 1 {
+		t.Fatalf("expected set length 1, got %d", set.Len())
+	}
+
+	if !set.Exists(10) {
+		t.Fatal("expected set to contain 10")
+	}
+}
+
+type benchmarkItem struct {
+	ID       int
+	Name     string
+	Database string
+	Table    string
+}
+
+func BenchmarkSetInsert(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		set := NewSet[benchmarkItem]()
+
+		for j := 0; j < 1000; j++ {
+			set.Insert(benchmarkItem{
+				ID:       j,
+				Name:     "customer",
+				Database: "production",
+				Table:    "orders",
+			})
+		}
+	}
+}


### PR DESCRIPTION
`Set.Insert` currently calls `Exists(elem)`, which computes `Hash(elem)`, and then computes the same hash again before inserting a new element.

This change computes the hash once and reuses it for both the existence check and insertion.

Current flow:

```text
Insert
  -> Exists(elem)
       -> Hash(elem)
  -> Hash(elem)
```

After this change:

```text
Insert
  -> Hash(elem)
  -> check whether the hash already exists
  -> insert using the same hash
```

This removes redundant hashing without changing the `Set` API or duplicate-insertion behavior.

### Benchmark

A local microbenchmark using the default structural hashing path and inserting 1000 unique elements per operation showed:

```text
Before:
~3.0–4.5 ms/op
~1.76 MB/op
65,536 allocs/op

After:
~1.6–1.9 ms/op
~1.10 MB/op
32,791 allocs/op
```

Benchmark command:

```bash
go test ./types \
  -run='^$' \
  -bench='^BenchmarkSetInsert$' \
  -benchmem \
  -count=10
```

The benchmark is included in `types/set_test.go` so the result can be reproduced.

### References

* HashiCorp `go-set` uses the same compute-once-and-reuse pattern in `HashSet.Insert`: https://github.com/hashicorp/go-set/blob/main/hashset.go
* Go runtime issue #70837 discusses reducing duplicate hashing/search work around lookup and insertion: https://github.com/golang/go/issues/70837

## Type of change

* [x] Performance improvement / refactor (non-breaking change)
* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] This change requires a documentation update

# How Has This Been Tested?

* [x] Added `TestSetInsertHashesOnce` to verify that a newly inserted element is hashed once.
* [x] Added `TestSetInsertDuplicate` to verify duplicate insertion semantics remain unchanged.
* [x] Added `BenchmarkSetInsert` to reproduce the performance comparison.
* [x] `go test ./types -count=1`
* [x] `go vet ./types`
* [x] Repository pre-commit lint checks pass.

# Screenshots or Recordings

N/A — internal performance/refactor change with no UI impact.

## Documentation

* [x] N/A (internal performance/refactor and test changes only)

## Related PR's (If Any):

N/A
