### PR TITLE
Fix/s3 same second incremental

### DIFF
--- a/drivers/s3/internal/incremental.go
+++ b/drivers/s3/internal/incremental.go
@@ -14,6 +14,48 @@ import (
 // ============================================
 // This file contains all incremental sync logic using cursor-based filtering
 
+// syncedKeysField is a companion state entry to the LastModified cursor. It
+// holds the file keys already synced whose LastModified equals the cursor's
+// second. S3 (and the S3 List API in general) only exposes LastModified at
+// whole-second granularity, so a same-second collision window is up to a full
+// second wide and cannot be disambiguated by timestamp alone. Remembering the
+// keys already read at that second lets us use a `>=` filter and still read
+// each file exactly once. See issue #1131.
+const syncedKeysField = "_last_modified_time_synced_keys"
+
+// syncedKeysFromState reconstructs the synced-key set from state. The value is
+// stored as []string in-process but round-trips through JSON as []any across
+// runs, so both are handled. A missing value (legacy state written before this
+// fix) yields an empty set, which degrades to reading same-second boundary
+// files once on the first post-upgrade sync.
+func syncedKeysFromState(v any) map[string]bool {
+	set := map[string]bool{}
+	switch keys := v.(type) {
+	case []string:
+		for _, k := range keys {
+			set[k] = true
+		}
+	case []any:
+		for _, k := range keys {
+			if s, ok := k.(string); ok {
+				set[s] = true
+			}
+		}
+	}
+	return set
+}
+
+// keysAtSecond returns the keys of files whose LastModified equals second.
+func keysAtSecond(files []FileObject, second string) []string {
+	var keys []string
+	for _, file := range files {
+		if file.LastModified == second {
+			keys = append(keys, file.FileKey)
+		}
+	}
+	return keys
+}
+
 // FetchMaxCursorValues returns the maximum LastModified timestamp for all files in the stream
 // This is used by the abstract layer to track incremental sync progress
 func (s *S3) FetchMaxCursorValues(_ context.Context, stream types.StreamInterface) (any, any, error) {
@@ -31,6 +73,13 @@ func (s *S3) FetchMaxCursorValues(_ context.Context, stream types.StreamInterfac
 		if file.LastModified > maxLastModified {
 			maxLastModified = file.LastModified
 		}
+	}
+
+	// Seed the synced-key set with every file at the max second. Backfill reads
+	// all discovered files, so those keys are covered once backfill completes;
+	// this stops the first incremental sync from re-reading them.
+	if configuredStream, ok := stream.(*types.ConfiguredStream); ok && s.state != nil {
+		s.state.SetCursor(configuredStream, syncedKeysField, keysAtSecond(files, maxLastModified))
 	}
 
 	logger.Infof("Max cursor value for stream %s: %s (from %d files)", streamName, maxLastModified, len(files))
@@ -85,11 +134,16 @@ func (s *S3) StreamIncrementalChanges(ctx context.Context, stream types.StreamIn
 		return nil
 	}
 
-	// Filter files to only include those modified AFTER the cursor
-	incrementalFiles := s.filterFilesByCursor(files, cursor)
+	// Keys already synced at the cursor's second, so a same-second arrival that
+	// has not been read yet is still picked up while an already-read one is not.
+	syncedKeys := syncedKeysFromState(s.state.GetCursor(configuredStream, syncedKeysField))
+
+	// Filter files to those strictly after the cursor, plus same-second files
+	// not already synced.
+	incrementalFiles := s.filterFilesByCursor(files, cursor, syncedKeys)
 
 	if len(incrementalFiles) == 0 {
-		logger.Infof("Stream %s: no new files to process (all files <= cursor)", streamName)
+		logger.Infof("Stream %s: no new files to process (all already synced up to cursor)", streamName)
 		return nil
 	}
 
@@ -116,25 +170,62 @@ func (s *S3) StreamIncrementalChanges(ctx context.Context, stream types.StreamIn
 		}
 	}
 
+	// Advance the synced-key set to match the new cursor second. The abstract
+	// layer advances the cursor itself from record data; this keeps the set of
+	// "already read at that second" keys consistent so the next sync does not
+	// re-read them (and does not skip a newer same-second arrival).
+	newCursor := cursor
+	for _, file := range incrementalFiles {
+		if file.LastModified > newCursor {
+			newCursor = file.LastModified
+		}
+	}
+	newSet := map[string]bool{}
+	if newCursor == cursor {
+		// The cursor second did not advance, so keys read at it earlier still count.
+		for k := range syncedKeys {
+			newSet[k] = true
+		}
+	}
+	for _, file := range incrementalFiles {
+		if file.LastModified == newCursor {
+			newSet[file.FileKey] = true
+		}
+	}
+	keys := make([]string, 0, len(newSet))
+	for k := range newSet {
+		keys = append(keys, k)
+	}
+	s.state.SetCursor(configuredStream, syncedKeysField, keys)
+
 	logger.Infof("Stream %s: completed incremental processing of %d file(s)",
 		streamName, len(incrementalFiles))
 
 	return nil
 }
 
-// filterFilesByCursor filters files based on LastModified timestamp cursor
-// Returns only files where LastModified > cursor
+// filterFilesByCursor returns files that still need to be read: those strictly
+// newer than the cursor, plus files stamped exactly at the cursor's second that
+// have not already been synced (tracked in syncedKeys). Because LastModified is
+// only second-granular, a strict `>` would permanently skip a file that arrived
+// in the same second as the cursor; the same-second-plus-key-set check closes
+// that window while still reading each file exactly once. See issue #1131.
 // The cursor timestamp is in ISO 8601 format (2006-01-02T15:04:05Z) and uses
 // string comparison which works correctly for this format.
-func (s *S3) filterFilesByCursor(files []FileObject, cursorTimestamp string) []FileObject {
+func (s *S3) filterFilesByCursor(files []FileObject, cursorTimestamp string, syncedKeys map[string]bool) []FileObject {
 	var filteredFiles []FileObject
 	for _, file := range files {
-		if file.LastModified > cursorTimestamp {
+		switch {
+		case file.LastModified > cursorTimestamp:
 			filteredFiles = append(filteredFiles, file)
 			logger.Debugf("File %s will be processed (modified: %s > cursor: %s)",
 				file.FileKey, file.LastModified, cursorTimestamp)
-		} else {
-			logger.Debugf("File %s skipped (modified: %s <= cursor: %s)",
+		case file.LastModified == cursorTimestamp && !syncedKeys[file.FileKey]:
+			filteredFiles = append(filteredFiles, file)
+			logger.Debugf("File %s will be processed (same-second arrival not yet synced: %s == cursor: %s)",
+				file.FileKey, file.LastModified, cursorTimestamp)
+		default:
+			logger.Debugf("File %s skipped (already synced up to cursor: %s <= %s)",
 				file.FileKey, file.LastModified, cursorTimestamp)
 		}
 	}

--- a/drivers/s3/internal/s3_test.go
+++ b/drivers/s3/internal/s3_test.go
@@ -304,6 +304,7 @@ func TestFilterFilesByCursor(t *testing.T) {
 	tests := []struct {
 		name            string
 		cursorTimestamp string
+		syncedKeys      map[string]bool
 		expectedCount   int
 		expectedFiles   []string
 	}{
@@ -314,8 +315,9 @@ func TestFilterFilesByCursor(t *testing.T) {
 			expectedFiles:   []string{"file1.csv", "file2.csv", "file3.csv", "file4.csv"},
 		},
 		{
-			name:            "cursor in middle - incremental mode",
+			name:            "cursor in middle - incremental mode (boundary file already synced)",
 			cursorTimestamp: "2024-01-02T10:00:00Z",
+			syncedKeys:      map[string]bool{"file2.csv": true},
 			expectedCount:   2,
 			expectedFiles:   []string{"file3.csv", "file4.csv"},
 		},
@@ -335,7 +337,7 @@ func TestFilterFilesByCursor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filtered := s.filterFilesByCursor(files, tt.cursorTimestamp)
+			filtered := s.filterFilesByCursor(files, tt.cursorTimestamp, tt.syncedKeys)
 
 			assert.Equal(t, tt.expectedCount, len(filtered), "filtered file count mismatch")
 

--- a/drivers/s3/internal/sync_test.go
+++ b/drivers/s3/internal/sync_test.go
@@ -208,6 +208,7 @@ func TestIncrementalSyncFiltering(t *testing.T) {
 		name            string
 		files           []FileObject
 		cursorTimestamp string
+		syncedKeys      map[string]bool
 		expectedCount   int
 		expectedFiles   []string
 	}{
@@ -222,13 +223,14 @@ func TestIncrementalSyncFiltering(t *testing.T) {
 			expectedFiles:   []string{"file1.csv", "file2.csv"},
 		},
 		{
-			name: "with cursor - only new files",
+			name: "with cursor - only new files (boundary file already synced)",
 			files: []FileObject{
 				{FileKey: "file1.csv", LastModified: "2024-01-01T10:00:00Z"},
 				{FileKey: "file2.csv", LastModified: "2024-01-02T10:00:00Z"},
 				{FileKey: "file3.csv", LastModified: "2024-01-03T10:00:00Z"},
 			},
 			cursorTimestamp: "2024-01-02T10:00:00Z",
+			syncedKeys:      map[string]bool{"file2.csv": true},
 			expectedCount:   1,
 			expectedFiles:   []string{"file3.csv"},
 		},
@@ -243,7 +245,7 @@ func TestIncrementalSyncFiltering(t *testing.T) {
 			expectedFiles:   []string{},
 		},
 		{
-			name: "with cursor - multiple new files",
+			name: "with cursor - multiple new files (boundary file already synced)",
 			files: []FileObject{
 				{FileKey: "file1.csv", LastModified: "2024-01-01T10:00:00Z"},
 				{FileKey: "file2.csv", LastModified: "2024-01-02T10:00:00Z"},
@@ -251,6 +253,7 @@ func TestIncrementalSyncFiltering(t *testing.T) {
 				{FileKey: "file4.csv", LastModified: "2024-01-02T15:00:00Z"},
 			},
 			cursorTimestamp: "2024-01-02T10:00:00Z",
+			syncedKeys:      map[string]bool{"file2.csv": true},
 			expectedCount:   2,
 			expectedFiles:   []string{"file3.csv", "file4.csv"},
 		},
@@ -261,7 +264,7 @@ func TestIncrementalSyncFiltering(t *testing.T) {
 			s := &S3{}
 
 			// Use filterFilesByCursor which is the actual implementation
-			filtered := s.filterFilesByCursor(tt.files, tt.cursorTimestamp)
+			filtered := s.filterFilesByCursor(tt.files, tt.cursorTimestamp, tt.syncedKeys)
 
 			assert.Equal(t, tt.expectedCount, len(filtered), "filtered file count mismatch")
 
@@ -284,6 +287,7 @@ func TestCursorTimestampComparison(t *testing.T) {
 		name            string
 		fileTimestamp   string
 		cursorTimestamp string
+		synced          bool
 		shouldInclude   bool
 	}{
 		{
@@ -299,10 +303,11 @@ func TestCursorTimestampComparison(t *testing.T) {
 			shouldInclude:   false,
 		},
 		{
-			name:            "file same as cursor",
+			name:            "file same second as cursor, already synced - excluded",
 			fileTimestamp:   "2024-01-01T10:00:00Z",
 			cursorTimestamp: "2024-01-01T10:00:00Z",
-			shouldInclude:   false, // Equal timestamps are not included
+			synced:          true,
+			shouldInclude:   false,
 		},
 		{
 			name:            "empty cursor - backfill mode",
@@ -319,7 +324,11 @@ func TestCursorTimestampComparison(t *testing.T) {
 				{FileKey: "test.csv", LastModified: tt.fileTimestamp},
 			}
 
-			filtered := s.filterFilesByCursor(files, tt.cursorTimestamp)
+			var syncedKeys map[string]bool
+			if tt.synced {
+				syncedKeys = map[string]bool{"test.csv": true}
+			}
+			filtered := s.filterFilesByCursor(files, tt.cursorTimestamp, syncedKeys)
 
 			if tt.shouldInclude {
 				assert.Len(t, filtered, 1, "file should be included")

--- a/drivers/s3/internal/sync_test.go
+++ b/drivers/s3/internal/sync_test.go
@@ -257,6 +257,37 @@ func TestIncrementalSyncFiltering(t *testing.T) {
 			expectedCount:   2,
 			expectedFiles:   []string{"file3.csv", "file4.csv"},
 		},
+		{
+			name: "same-second arrival not yet synced is picked up (issue #1131)",
+			files: []FileObject{
+				{FileKey: "seed_1.csv", LastModified: "2024-01-02T10:00:00Z"},
+				{FileKey: "insert_1.csv", LastModified: "2024-01-02T10:00:00Z"},
+			},
+			cursorTimestamp: "2024-01-02T10:00:00Z",
+			syncedKeys:      map[string]bool{"seed_1.csv": true},
+			expectedCount:   1,
+			expectedFiles:   []string{"insert_1.csv"},
+		},
+		{
+			name: "same-second file already synced is not re-read",
+			files: []FileObject{
+				{FileKey: "seed_1.csv", LastModified: "2024-01-02T10:00:00Z"},
+			},
+			cursorTimestamp: "2024-01-02T10:00:00Z",
+			syncedKeys:      map[string]bool{"seed_1.csv": true},
+			expectedCount:   0,
+			expectedFiles:   []string{},
+		},
+		{
+			name: "legacy state without synced set re-reads same-second boundary once",
+			files: []FileObject{
+				{FileKey: "seed_1.csv", LastModified: "2024-01-02T10:00:00Z"},
+			},
+			cursorTimestamp: "2024-01-02T10:00:00Z",
+			syncedKeys:      nil,
+			expectedCount:   1,
+			expectedFiles:   []string{"seed_1.csv"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -301,6 +332,13 @@ func TestCursorTimestampComparison(t *testing.T) {
 			fileTimestamp:   "2024-01-01T10:00:00Z",
 			cursorTimestamp: "2024-01-02T10:00:00Z",
 			shouldInclude:   false,
+		},
+		{
+			name:            "file same second as cursor, not yet synced - included (issue #1131)",
+			fileTimestamp:   "2024-01-01T10:00:00Z",
+			cursorTimestamp: "2024-01-01T10:00:00Z",
+			synced:          false,
+			shouldInclude:   true,
 		},
 		{
 			name:            "file same second as cursor, already synced - excluded",

--- a/tests/s3/s3_util_test.go
+++ b/tests/s3/s3_util_test.go
@@ -775,17 +775,17 @@ func ExecuteQueryFactory(variant S3TestVariant) func(ctx context.Context, t *tes
 		case "add":
 			// One plain file and, where the format allows it, one gzipped: a single stream
 			// mixing both proves compression is detected per file rather than per stream.
-			variant.putFile(ctx, t, src, prefix, "seed_1", variant.BuildFile, 1, seedValues, false, false)
-			variant.putFile(ctx, t, src, prefix, "seed_2", variant.BuildFile, 4, seedValues, variant.Gzipped, false)
+			variant.putFile(ctx, t, src, prefix, "seed_1", variant.BuildFile, 1, seedValues, false)
+			variant.putFile(ctx, t, src, prefix, "seed_2", variant.BuildFile, 4, seedValues, variant.Gzipped)
 
 		case "insert":
 			// A file the incremental cursor has not seen: it is stamped after the previous
 			// sync, so only its rows are re-read.
-			variant.putFile(ctx, t, src, prefix, "insert_1", variant.BuildFile, 7, seedValues, false, true)
+			variant.putFile(ctx, t, src, prefix, "insert_1", variant.BuildFile, 7, seedValues, false)
 
 		case "update":
 			// Object stores have no in-place update: changed data arrives as another file.
-			variant.putFile(ctx, t, src, prefix, "update_1", variant.BuildFile, 10, updatedValues, false, true)
+			variant.putFile(ctx, t, src, prefix, "update_1", variant.BuildFile, 10, updatedValues, false)
 
 		case "evolve-schema":
 			// An object store's ALTER TABLE: a file whose rows carry a column discover has
@@ -795,7 +795,7 @@ func ExecuteQueryFactory(variant S3TestVariant) func(ctx context.Context, t *tes
 			// ExpectedUpdatedData; evolvedColumn itself is asserted through the schema, not
 			// per row, since the "update" file's rows sync a null there.
 			if variant.BuildEvolvedFile != nil {
-				variant.putFile(ctx, t, src, prefix, "evolve_1", variant.BuildEvolvedFile, 13, updatedValues, false, true)
+				variant.putFile(ctx, t, src, prefix, "evolve_1", variant.BuildEvolvedFile, 13, updatedValues, false)
 			}
 
 		default:
@@ -807,7 +807,7 @@ func ExecuteQueryFactory(variant S3TestVariant) func(ctx context.Context, t *tes
 // putFile renders one file with build and uploads it under prefix. Gzipped files get a
 // ".gz" suffix, which is what both the driver's file matcher and its reader use to detect
 // compression.
-func (v S3TestVariant) putFile(ctx context.Context, t *testing.T, src s3Source, prefix, name string, build buildFileFn, startID int64, vals rowValues, gzipped bool, wait bool) {
+func (v S3TestVariant) putFile(ctx context.Context, t *testing.T, src s3Source, prefix, name string, build buildFileFn, startID int64, vals rowValues, gzipped bool) {
 	t.Helper()
 
 	data := build(t, startID, vals)
@@ -818,13 +818,6 @@ func (v S3TestVariant) putFile(ctx context.Context, t *testing.T, src s3Source, 
 	}
 
 	key := prefix + name + ext
-
-	// TODO: the driver should handle same-second arrivals itself (`>=` plus tracking the file keys
-	// already synced at the cursor's second); this guard papers over real, silent data loss.
-	if wait {
-		t.Logf("waiting before putting file to avoid s3 driver skipping the new file...")
-		time.Sleep(1 * time.Second)
-	}
 
 	_, err := src.client.PutObject(ctx, src.bucket, key, bytes.NewReader(data), int64(len(data)), minio.PutObjectOptions{})
 	require.NoError(t, err, "failed to upload %s", key)


### PR DESCRIPTION
# Description

Fixes #1131

OLake's S3 incremental source can silently skip files that arrive in the same second as the current incremental cursor.

S3 `LastModified` timestamps are exposed at second-level precision, while the existing incremental filter used a strict `>` comparison. As a result, a newly arrived file with the same timestamp as the cursor was considered already processed and was skipped permanently.

This change fixes the issue by:

- Changing the incremental timestamp comparison to `>=`.
- Tracking the file keys already synced at the current cursor timestamp.
- Reading same-second files only when their keys have not already been processed.
- Seeding and advancing the synced-key state during backfill and incremental sync.
- Removing the 1-second sleep workaround from the S3 integration tests.

This ensures that each file is processed exactly once, including files arriving within the same second.

No interface changes are required and other drivers are unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The following tests were run successfully:

- [x] Unit tests covering strictly-newer, same-second-unseen, same-second-seen, and legacy-state scenarios.
- [x] S3 end-to-end integration tests covering full-load and incremental insert/update flows.

### Unit tests

```bash
cd drivers/s3
go test ./internal/ -run 'TestIncrementalSyncFiltering|TestCursorTimestampComparison' -v