### PR TITLE
chore(iceberg): drop unused io.minio:minio test dependency

### DIFF
--- a/destination/iceberg/olake-iceberg-java-writer/pom.xml
+++ b/destination/iceberg/olake-iceberg-java-writer/pom.xml
@@ -503,12 +503,6 @@
       <version>42.7.13</version>
     </dependency>
     <dependency>
-      <groupId>io.minio</groupId>
-      <artifactId>minio</artifactId>
-      <version>8.5.17</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-assert</artifactId>
       <version>1.4</version>


### PR DESCRIPTION
# Description

Removes the `io.minio:minio` 8.5.17 test dependency from the Iceberg Java writer. It clears open Dependabot alert GHSA-h7rh-xfpj-hpcm (high, MinIO Java Client XML Tag Value Substitution).

No source file in the module references `io.minio` or `MinioClient`, so removal is preferable to bumping to 8.6.0. Dependabot proposed the bump in #1158; that PR was closed in favour of #1133, and Dependabot will not re-open it, so the alert has stayed open since 2025-09-29.

Fixes #1133 (partially)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Grepped the module for `io.minio` and `MinioClient`: zero references outside the pom.
- [ ] CI `Build Iceberg writer jar` — maven is not available on my machine, relying on CI.

# Screenshots or Recordings

## Documentation

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

- #1221 covers the other open high alert (GHSA-2v4p-qf9q-27wj, gRPC). No overlap with this PR.
- #1158 the closed Dependabot bump this replaces.

https://claude.ai/code/session_01FZc1SoBPPnmS5gK42WqS3q
