### PR TITLE
fix: give NonRetryable sync failures a distinct exit code and log line

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/datazip-inc/olake/destination/parquet" // registering parquet destination
 	"github.com/datazip-inc/olake/drivers/abstract"
 	protocol "github.com/datazip-inc/olake/protocol"
+	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/safego"
 )
@@ -18,6 +19,12 @@ func RegisterDriver(driver abstract.DriverInterface) {
 	err := protocol.CreateRootCommand(true, driver).Execute()
 	if err != nil {
 		protocol.ReportFailure(err)
+		// constants.ErrNonRetryable means retrying will not fix this: give a process supervisor
+		// (shell retry loop, systemd, Kubernetes restart policy) a distinct exit code and a
+		// greppable log line so it can stop retrying and page a human instead of looping forever.
+		if utils.IsNonRetryable(err) {
+			logger.FatalNonRetryable(err)
+		}
 		logger.Fatal(err)
 	}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -89,6 +89,12 @@ var ParallelCDCDrivers = []DriverType{MongoDB, MSSQL}
 var ErrNonRetryable = fmt.Errorf("failed with non retryable error")
 var ErrGlobalContextGroup = fmt.Errorf("global context group error")
 
+// ExitCodeNonRetryable is the process exit code used when a sync fails with ErrNonRetryable,
+// so a process supervisor (shell retry loop, systemd Restart=always, Kubernetes restart policy)
+// can tell a failure that needs a human apart from one worth retrying, instead of looping on it
+// forever the way a generic exit code 1 would.
+const ExitCodeNonRetryable = 2
+
 // DriversRequiringIncrementalFormatter are drivers that require special formatting for incremental value
 var DriversRequiringIncrementalFormatter = []DriverType{Oracle, DB2, MSSQL}
 

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -67,6 +67,18 @@ func Fatalf(format string, v ...interface{}) {
 	os.Exit(1)
 }
 
+// FatalNonRetryable logs a consistently-formatted, greppable FATAL line for a failure that
+// requires manual intervention (constants.ErrNonRetryable) and exits with
+// constants.ExitCodeNonRetryable instead of the generic exit code 1 used for ordinary failures.
+// This lets a process supervisor (shell retry loop, systemd, Kubernetes restart policy) match on
+// the exit code or the log line and stop retrying instead of looping on an error retrying can
+// never fix. zerolog's Fatal level always exits with code 1 itself, so this logs at Error level
+// and exits explicitly.
+func FatalNonRetryable(err error) {
+	logger.Error().Msgf("FATAL: manual intervention required: %s", err)
+	os.Exit(constants.ExitCodeNonRetryable)
+}
+
 // Error writes record into os.stdout with log level ERROR
 func Errorf(format string, v ...interface{}) {
 	logger.Error().Msgf(format, v...)

--- a/utils/retry_test.go
+++ b/utils/retry_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/datazip-inc/olake/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNonRetryable(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		require.False(t, IsNonRetryable(nil))
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		require.False(t, IsNonRetryable(errors.New("connection reset")))
+	})
+
+	t.Run("wrapped with %w", func(t *testing.T) {
+		err := fmt.Errorf("%w: lsn mismatch", constants.ErrNonRetryable)
+		require.True(t, IsNonRetryable(err))
+	})
+
+	t.Run("message-only match, e.g. wrapped with %s instead of %w", func(t *testing.T) {
+		err := fmt.Errorf("%s: clear destination and restart", constants.ErrNonRetryable)
+		require.True(t, IsNonRetryable(err))
+	})
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -478,6 +478,15 @@ func RetryWithSkip(ctx context.Context, maxRetries int, sleep time.Duration, sho
 	return err
 }
 
+// IsNonRetryable reports whether err carries constants.ErrNonRetryable, meaning a caller (a
+// retry loop, a process supervisor) should stop instead of retrying. It matches on the error
+// message rather than errors.Is because not every call site wraps with %w: for example
+// drivers/postgres/internal/cdc.go uses fmt.Errorf("%s: ...", constants.ErrNonRetryable, ...),
+// which breaks the chain errors.Is would need to walk.
+func IsNonRetryable(err error) bool {
+	return err != nil && strings.Contains(err.Error(), constants.ErrNonRetryable.Error())
+}
+
 // RetryOnBackoff retries the function f up to attempts times with a backoff sleep between attempts.
 func RetryOnBackoff(ctx context.Context, attempts int, sleep time.Duration, f func(ctx context.Context) error) (err error) {
 	for cur := range attempts {
@@ -491,7 +500,7 @@ func RetryOnBackoff(ctx context.Context, attempts int, sleep time.Duration, f fu
 		}
 
 		// check if error is non retryable
-		if strings.Contains(err.Error(), constants.ErrNonRetryable.Error()) {
+		if IsNonRetryable(err) {
 			return err
 		}
 


### PR DESCRIPTION
# Description

`olake sync` exits with the same generic code (1) and no distinguishing log line whether a
failure is transient or a `constants.ErrNonRetryable` failure that needs a human (e.g. a
Postgres LSN mismatch requiring `clear destination`). A process supervisor running `olake sync`
in a retry loop (shell loop, systemd `Restart=always`, a Kubernetes restart policy) can't tell
the two apart, so it keeps retrying a failure that will never succeed.

This adds a distinct exit code (`2`) and a consistently-formatted, greppable log line
(`FATAL: manual intervention required: ...`) for `ErrNonRetryable` failures, so a supervisor can
match on either and stop retrying instead of looping forever.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./constants/... ./utils/... ./protocol/... .` — the root package (`.`) is
      `connector.go`'s package and pulls in the full `destination/iceberg` +
      `destination/parquet` dependency tree; builds clean.
- [x] `go vet` on the same packages — clean.
- [x] `go test ./constants/... ./utils/... ./protocol/... .` — all pass, including a new
      `TestIsNonRetryable` covering: nil error, an unrelated error, an error wrapped with `%w`,
      and an error wrapped with `%s` (as `drivers/postgres/internal/cdc.go` already does at the
      `invalid global state` site), confirming the exit-code path is reachable even where the
      wrap chain doesn't survive `errors.Is`.
- [x] `gofmt -l` on every changed file — clean.
- [x] `golangci-lint` v1.64.8 (the version this repo's own `make olake.lint` / CI installs, per
      `.github/workflows/golang-ci.yml`, confirmed by reading the CI job's own install log) run
      against the changed packages — clean, no findings.
- [ ] Not run: the full `go build ./...` across every driver module (mongodb, oracle, mysql,
      db2, mssql, kafka, s3) — the sandbox this was built in ran out of local disk space partway
      through and could not fit the full dependency set. This change only touches shared code
      (`constants`, `utils`, `protocol`, `connector.go`); no changed function's signature is used
      differently by any driver, and every driver's `main()` calls the same unmodified
      `olake.RegisterDriver` entry point, so no driver-specific breakage is expected, but this
      specific check could not be executed here.

## Notes for reviewers

- Traced `constants.ErrNonRetryable` end to end: e.g.
  `drivers/postgres/internal/cdc.go` → `protocol/sync.go`'s `RunE` → `RootCmd.Execute()` →
  `connector.go`'s `RegisterDriver`. The error message substring survives every layer, so the new
  exit-code check fires for real non-retryable failures from any driver (Postgres, Kafka, etc. —
  every call site that wraps `constants.ErrNonRetryable` funnels through this one entry point).
- Two pre-existing things this PR does not touch, flagged for visibility since they affect how
  much weight the new signal should carry:
  - `drivers/abstract/cdc.go` wraps *any* error from backfill (including plausibly-transient
    ones) in `constants.ErrNonRetryable` unconditionally. That was cosmetic before (both paths
    hit the same generic exit code 1); after this change such a failure will now also produce
    the new "manual intervention required" exit code 2, which may be premature for a transient
    cause. Out of scope here since it's a separate, pre-existing tagging issue.
  - A panic recovered by `safego.Recovery` still always exits with code 1, regardless of whether
    the underlying cause would have been non-retryable — this PR is scoped to the
    `ErrNonRetryable` return-value path only, as the issue asks for.

# Screenshots or Recordings

N/A — this is a process exit-code / log-line change, no UI surface.

## Documentation

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

None.

Fixes #1196