### PR TITLE
test: assert exact row counts in Iceberg full-load and CDC sync verification

### DIFF
--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -901,25 +901,31 @@ func (cfg *IntegrationTest) testIcebergFullLoadAndCDC(
 
 	dbTestCases := []syncTestCase{
 		{
-			name:      "Full-Refresh",
-			operation: "",
-			useState:  false,
-			opSymbol:  "r",
-			expected:  cfg.ExpectedData,
+			name:                     "Full-Refresh",
+			operation:                "",
+			useState:                 false,
+			opSymbol:                 "r",
+			expected:                 cfg.ExpectedData,
+			verifyNoDuplicates:       true,
+			expectedRowCountByOpType: 5,
 		},
 		{
-			name:      "CDC - insert",
-			operation: "insert",
-			useState:  true,
-			opSymbol:  "c",
-			expected:  cfg.ExpectedData,
+			name:                     "CDC - insert",
+			operation:                "insert",
+			useState:                 true,
+			opSymbol:                 "c",
+			expected:                 cfg.ExpectedData,
+			verifyNoDuplicates:       true,
+			expectedRowCountByOpType: 1,
 		},
 		{
-			name:      "CDC - update",
-			operation: "update",
-			useState:  true,
-			opSymbol:  "u",
-			expected:  cfg.ExpectedUpdatedData,
+			name:                     "CDC - update",
+			operation:                "update",
+			useState:                 true,
+			opSymbol:                 "u",
+			expected:                 cfg.ExpectedUpdatedData,
+			verifyNoDuplicates:       true,
+			expectedRowCountByOpType: 1,
 		},
 		{
 			name:      "CDC - delete",
@@ -971,6 +977,13 @@ func (cfg *IntegrationTest) testIcebergFullLoadAndCDC(
 				tc.name != "Full-Refresh",
 			); err != nil {
 				t.Fatalf("%s test failed: %v", tc.name, err)
+			}
+
+			// require.NotEmpty on the returned rows only proves at least one row landed and every
+			// returned row is correct; it does not catch a sync that silently drops a subset of
+			// rows. Assert the exact distinct-by-_olake_id count so a dropped row fails here too.
+			if tc.verifyNoDuplicates {
+				VerifyIcebergNoDuplicates(ctx, t, testTable, cfg.DestinationDB, tc.opSymbol, tc.expectedRowCountByOpType)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

`testIcebergFullLoadAndCDC`'s sync verification only asserted that at least one row came back
from Iceberg and that every returned row was correct (`require.NotEmpty` + per-row equality). It
never checked how many rows arrived, so a sync that silently drops a subset of rows still passes
as long as more than one row was written. This wires the existing `VerifyIcebergNoDuplicates`
helper (already used by the 2PC recovery tests) into the Full-Refresh / CDC-insert / CDC-update
cases for relational drivers, asserting the exact distinct-by-`_olake_id` row count in addition
to the no-duplicates check it already performs.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is a test-infrastructure-only change (no production code touched). Validation:

- `gofmt -l tests/testutils/test_utils.go` — clean, confirms the new struct-literal fields and
  call site are syntactically valid Go.
- Could **not** run `go build`/`go test` for the `tests/testutils` module in this sandbox: the
  disk is essentially full (~165Mi free of 228Gi), so the module's dependency
  download/compile (spark-connect-go, arrow-go, minio-go, parquet-go, etc.) fails with
  "no space left on device". Verified with `git stash` that this failure is **pre-existing and
  unrelated to this diff** — it reproduces identically on the unmodified base commit. A real CI
  run (GitHub Actions "Integration Tests", which has working disk) would exercise this.
- The row-count constants (5 for Full-Refresh, 1 for a single-row insert/update) are not a
  guess: they match the same relational drivers' seed data used by the already-merged, currently
  CI-green `testIceberg2PCCDCRecovery` / `testIceberg2PCIncrementalRecovery` functions in the
  same file, which assert the identical counts (`expectedRowCountByOpType: 5` / `1`) against a
  live cluster today.
- Scope is intentionally narrow: only `testIcebergFullLoadAndCDC`'s relational-driver test cases
  are updated. The Kafka test cases and the "CDC - delete" case are untouched (kafka's counting
  semantics are cumulative and the issue didn't establish numbers for it — left as a follow-up
  rather than guessed). The Parquet destination (`VerifyParquetSync`) has the same
  `NotEmpty`-only gap described in the issue but has no analogous no-duplicates helper to wire up
  yet, and the S3/incremental path has a different row-count table — both are out of scope here.

- [x] Full-Refresh now asserts exactly 5 distinct rows land (relational drivers)
- [x] CDC - insert now asserts exactly 1 distinct row lands
- [x] CDC - update now asserts exactly 1 distinct row lands

# Screenshots or Recordings

N/A — test-only change.

## Documentation

- [x] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):

None.

Fixes #1178