### PR TITLE
feat: derive stream delete formats from target query engines

### DIFF
--- a/protocol/discover.go
+++ b/protocol/discover.go
@@ -39,6 +39,10 @@ var discoverCmd = &cobra.Command{
 			}
 		}
 
+		if err := resolveTargetQueryEngines(); err != nil {
+			return err
+		}
+
 		//version
 		logger.Infof("Ruuning OLake sync with version %s", version.GetOlakeCLIVersion())
 
@@ -67,7 +71,7 @@ var discoverCmd = &cobra.Command{
 		if len(streams) == 0 {
 			return errors.New("no streams found in connector")
 		}
-		types.LogCatalog(streams, catalog, connector.Type())
+		types.LogCatalog(streams, catalog, connector.Type(), queryEngines)
 
 		// Discover Telemetry Tracking
 		// Added this check to avoid the sleep when tracking telemetry is disabled
@@ -80,6 +84,26 @@ var discoverCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// resolveTargetQueryEngines reads the engines this discover run must satisfy. They are a
+// pure input: the run turns them into each stream's available_update_types and keeps
+// nothing else, so a caller that wants the constraint applied passes the flag every time.
+func resolveTargetQueryEngines() error {
+	engines, err := types.ParseQueryEngines(targetQueryEngines)
+	if err != nil {
+		return errs.Precondition(errs.ConfigInvalid, codeQueryEngineInvalid, err)
+	}
+
+	// An empty intersection cannot be written at all, so fail here rather than emitting a
+	// catalog whose streams offer no delete format.
+	if len(engines) > 0 && len(types.AvailableUpdateTypes(engines)) == 0 {
+		return errs.Precondition(errs.ConfigInvalid, codeQueryEngineInvalid,
+			fmt.Errorf("no delete format is readable by all of the selected query engines %v", engines))
+	}
+
+	queryEngines = engines
+	return nil
 }
 
 // compareStreams reads two streams.json files, computes the difference, and writes the result to difference_streams.json

--- a/protocol/query_engine_test.go
+++ b/protocol/query_engine_test.go
@@ -1,0 +1,49 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/datazip-inc/olake/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveTargetQueryEngines(t *testing.T) {
+	testCases := []struct {
+		name     string
+		flag     []string
+		expected []types.QueryEngine
+		wantErr  bool
+	}{
+		{
+			// Nothing is persisted, so an omitted flag means unconstrained, not "reuse".
+			name:     "no flag leaves the selection empty",
+			expected: []types.QueryEngine{},
+		},
+		{
+			name:     "flag is normalized",
+			flag:     []string{" Spark ", "duckdb"},
+			expected: []types.QueryEngine{types.QueryEngineSpark, types.QueryEngineDuckDB},
+		},
+		{
+			name:    "unknown engine fails the run",
+			flag:    []string{"spark", "sparkk"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			targetQueryEngines, queryEngines = tc.flag, nil
+			t.Cleanup(func() { targetQueryEngines, queryEngines = nil, nil })
+
+			err := resolveTargetQueryEngines()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, queryEngines)
+		})
+	}
+}

--- a/protocol/root.go
+++ b/protocol/root.go
@@ -33,6 +33,9 @@ var (
 	encryptionKey             string
 	destinationType           string
 	catalog                   *types.Catalog
+	availableQueryEngines     bool
+	targetQueryEngines        []string
+	queryEngines              []types.QueryEngine
 	state                     *types.State
 	timeout                   int64 // timeout in seconds
 	destinationConfig         *types.WriterConfig
@@ -147,6 +150,8 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&destinationDatabasePrefix, "destination-database-prefix", "", "", "(Optional) Destination database prefix is used as prefix for destination database name")
 	RootCmd.PersistentFlags().Int64VarP(&timeout, "timeout", "", -1, "(Optional) Timeout to override default timeouts (in seconds)")
 	RootCmd.PersistentFlags().StringVarP(&differencePath, "difference", "", "", "new streams.json file path to be compared. Generates a difference_streams.json file.")
+	RootCmd.PersistentFlags().BoolVarP(&availableQueryEngines, "available-query-engines", "", false, "(Optional) Print the query engines OLake supports and the delete formats each can read, then exit")
+	RootCmd.PersistentFlags().StringSliceVarP(&targetQueryEngines, "target-query-engines", "", nil, "(Optional) Comma separated query engines that will read the destination tables (e.g. spark,duckdb,hive). Narrows the delete formats available to each stream")
 	// Disable Cobra CLI's built-in usage and error handling
 	RootCmd.SilenceUsage = true
 	RootCmd.SilenceErrors = true
@@ -160,6 +165,8 @@ const (
 	// Codes for conditions the CLI detects itself, before any connector is reached.
 	codeFlagMissing    = "config.flag_missing"
 	codeNoValidStreams = "catalog.no_valid_streams"
+	// codeQueryEngineInvalid marks a target query engine selection the CLI cannot serve.
+	codeQueryEngineInvalid = "catalog.query_engine_invalid"
 	// recovered panic as an internal error
 	codePanicRecovered = "sync.panic_recovered"
 )

--- a/protocol/spec.go
+++ b/protocol/spec.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/datazip-inc/olake/types"
 	"github.com/datazip-inc/olake/utils"
 	"github.com/datazip-inc/olake/utils/logger"
 	"github.com/datazip-inc/olake/utils/spec"
@@ -15,6 +16,13 @@ var specCmd = &cobra.Command{
 	Use:   "spec",
 	Short: "spec command",
 	RunE: func(_ *cobra.Command, _ []string) error {
+		// Served independently of any driver or destination spec file: the engine matrix
+		// is static per OLake version, and callers need it before a destination is picked.
+		if availableQueryEngines {
+			logger.Info(map[string]interface{}{"query_engines": types.QueryEngineCatalog()})
+			return nil
+		}
+
 		specPath, err := resolveSpecPath()
 		if err != nil {
 			return err

--- a/protocol/sync.go
+++ b/protocol/sync.go
@@ -239,7 +239,7 @@ func classifyStreams(catalog *types.Catalog, streams []*types.Stream, state *typ
 			}
 		}
 
-		if err := elem.GetUpdateType().Validate(); err != nil {
+		if err := elem.GetUpdateType().ValidateAgainst(elem.Stream.AvailableUpdateTypes); err != nil {
 			logger.Warnf("Skipping; Configured Stream %s found invalid delete mode: %s", elem.ID(), err)
 			return false
 		}

--- a/types/catalog.go
+++ b/types/catalog.go
@@ -3,10 +3,12 @@ package types
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/datazip-inc/olake/constants"
 	"github.com/datazip-inc/olake/utils"
+	"github.com/datazip-inc/olake/utils/logger"
 )
 
 // Message is a dto for olake output row representation
@@ -80,14 +82,22 @@ type StreamMix struct {
 	StreamWithPosUpdateType int `json:"stream_with_pos_update_type_count"`
 }
 
-func GetWrappedCatalog(streams []*Stream, driver string) *Catalog {
+func GetWrappedCatalog(streams []*Stream, driver string, engines []QueryEngine) *Catalog {
 	catalog := &Catalog{
 		Streams:         []*ConfiguredStream{},
 		SelectedStreams: make(map[string][]StreamMetadata),
 	}
+	// The default delete format is the cheapest one every target engine can read.
+	available := AvailableUpdateTypes(engines)
+	updateType := PreferredUpdateType(available)
 
 	// Loop through each stream and populate Streams and SelectedStreams
 	for _, stream := range streams {
+		stream.AvailableUpdateTypes = available
+		if stream.DefaultStreamProperties != nil {
+			stream.DefaultStreamProperties.UpdateType = updateType
+		}
+
 		// Create ConfiguredStream and append to Streams
 		catalog.Streams = append(catalog.Streams, &ConfiguredStream{
 			Stream: stream,
@@ -103,7 +113,7 @@ func GetWrappedCatalog(streams []*Stream, driver string) *Catalog {
 			StreamName:      stream.Name,
 			AppendMode:      utils.Ternary(driver == string(constants.Kafka), true, false).(bool),
 			Normalization:   IsDriverRelational(driver),
-			UpdateType:      string(UpdateTypeEquality),
+			UpdateType:      string(updateType),
 			SelectedColumns: selectedCols,
 		})
 	}
@@ -116,7 +126,7 @@ func GetWrappedCatalog(streams []*Stream, driver string) *Catalog {
 // 2. SelectedColumns: Retain columns present in both old and new schemas, add NEW columns if sync_new_columns is true
 // 3. SyncMode: Use from oldCatalog if the stream exists in old catalog
 // 4. Everything else: Keep as new catalog
-func mergeCatalogs(oldCatalog, newCatalog *Catalog) *Catalog {
+func mergeCatalogs(oldCatalog, newCatalog *Catalog, engines []QueryEngine) *Catalog {
 	if oldCatalog == nil {
 		return newCatalog
 	}
@@ -145,6 +155,7 @@ func mergeCatalogs(oldCatalog, newCatalog *Catalog) *Catalog {
 					oldStream := oldStreams[streamID].Stream
 					newStream := newStreams[streamID].Stream
 					MergeSelectedColumns(&metadata, oldStream, newStream)
+					mergeUpdateType(&metadata, streamID, engines)
 
 					selectedStreams[namespace] = append(selectedStreams[namespace], metadata)
 				}
@@ -185,6 +196,36 @@ func mergeCatalogs(oldCatalog, newCatalog *Catalog) *Catalog {
 	})
 
 	return newCatalog
+}
+
+// mergeUpdateType keeps a previously configured delete format only while every current
+// target query engine can still read it. Changing the engine selection must not leave a
+// stream pinned to a format its readers cannot resolve, so an unreadable choice falls back
+// to the cheapest available one.
+func mergeUpdateType(metadata *StreamMetadata, streamID string, engines []QueryEngine) {
+	// Without target engines nothing constrains the choice, so leave the recorded value
+	// exactly as it was, blank included: ConfiguredStream.GetUpdateType still defaults it.
+	if len(engines) == 0 {
+		return
+	}
+
+	available := AvailableUpdateTypes(engines)
+	if metadata.UpdateType != "" && slices.Contains(available, UpdateType(metadata.UpdateType)) {
+		return
+	}
+
+	preferred := PreferredUpdateType(available)
+	if preferred == "" {
+		// No format satisfies every engine; discover fails before reaching here, so leave
+		// the value untouched rather than blanking a working configuration.
+		return
+	}
+
+	if metadata.UpdateType != "" {
+		logger.Warnf("Stream %s update mode changed from %s to %s; %s is not readable by the selected query engines",
+			streamID, metadata.UpdateType, preferred, metadata.UpdateType)
+	}
+	metadata.UpdateType = string(preferred)
 }
 
 // MergeSelectedColumns merges the selected columns based on the following rules:

--- a/types/catalog_test.go
+++ b/types/catalog_test.go
@@ -274,7 +274,7 @@ func TestCatalogGetWrappedCatalog(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GetWrappedCatalog(tc.streams, tc.driver)
+			result := GetWrappedCatalog(tc.streams, tc.driver, nil)
 			compareCatalogs(t, tc.expected, result, tc.name)
 
 			if len(tc.streams) > 0 {
@@ -775,7 +775,7 @@ func TestCatalogMergeCatalogs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := mergeCatalogs(tc.oldCatalog, tc.newCatalog)
+			result := mergeCatalogs(tc.oldCatalog, tc.newCatalog, nil)
 			compareCatalogs(t, tc.expected, result, tc.name)
 		})
 	}

--- a/types/delete_mode.go
+++ b/types/delete_mode.go
@@ -1,6 +1,9 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // UpdateMode iceberg update mode
 type UpdateType string
@@ -26,9 +29,25 @@ func (m UpdateType) NeedsTableIndex(destinationType DestinationType) bool {
 }
 
 func (m UpdateType) Validate() error {
-	if m == UpdateTypeEquality || m == UpdateTypePosition {
+	if slices.Contains(writableUpdateTypes, m) {
 		return nil
 	}
 
 	return fmt.Errorf("invalid update mode: %s", m)
+}
+
+// ValidateAgainst reports whether m is a delete format OLake can write and one the stream
+// still offers. Target query engines are a discover-time input that is never persisted, so
+// the list computed from them is the only record a later sync can check against. An empty
+// list means the catalog predates target query engines, so only writability is checked.
+func (m UpdateType) ValidateAgainst(available []UpdateType) error {
+	if err := m.Validate(); err != nil {
+		return err
+	}
+
+	if len(available) > 0 && !slices.Contains(available, m) {
+		return fmt.Errorf("update mode %q is not readable by the target query engines; available are %v", m, available)
+	}
+
+	return nil
 }

--- a/types/query_engine.go
+++ b/types/query_engine.go
@@ -1,0 +1,139 @@
+package types
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// QueryEngine is a downstream engine that reads the Iceberg tables OLake writes.
+type QueryEngine string
+
+const (
+	QueryEngineSpark      QueryEngine = "spark"
+	QueryEngineFlink      QueryEngine = "flink"
+	QueryEngineTrino      QueryEngine = "trino"
+	QueryEnginePresto     QueryEngine = "presto"
+	QueryEngineStarRocks  QueryEngine = "starrocks"
+	QueryEngineHive       QueryEngine = "hive"
+	QueryEngineDuckDB     QueryEngine = "duckdb"
+	QueryEngineAthena     QueryEngine = "athena"
+	QueryEngineSnowflake  QueryEngine = "snowflake"
+	QueryEngineBigQuery   QueryEngine = "bigquery"
+	QueryEngineDatabricks QueryEngine = "databricks"
+	QueryEngineDremio     QueryEngine = "dremio"
+	QueryEngineClickHouse QueryEngine = "clickhouse"
+)
+
+type QueryEngineSpec struct {
+	Engine QueryEngine `json:"engine"`
+	Label  string      `json:"label"`
+	// Supports are the delete formats the engine resolves at read time, independent of
+	// what OLake can write (writableUpdateTypes).
+	Supports []UpdateType `json:"supports"`
+}
+
+// writableUpdateTypes are the delete formats OLake can produce, cheapest first: equality
+// needs no index, positional needs a full identifier -> RowLocation index. Deletion
+// vectors are absent until the dv writer lands.
+var writableUpdateTypes = []UpdateType{UpdateTypeEquality, UpdateTypePosition}
+
+// queryEngines is the read-capability matrix. Support is version dependent and moves fast;
+// each row reflects the engine's current stable release. Positional deletes are the
+// universal denominator, equality deletes are read by far fewer engines.
+var queryEngines = []QueryEngineSpec{
+	{Engine: QueryEngineSpark, Label: "Apache Spark", Supports: []UpdateType{UpdateTypeEquality, UpdateTypePosition, UpdateTypeDeletionVector}},
+	{Engine: QueryEngineFlink, Label: "Apache Flink", Supports: []UpdateType{UpdateTypeEquality, UpdateTypePosition}},
+	{Engine: QueryEngineTrino, Label: "Trino", Supports: []UpdateType{UpdateTypeEquality, UpdateTypePosition, UpdateTypeDeletionVector}},
+	{Engine: QueryEnginePresto, Label: "Presto", Supports: []UpdateType{UpdateTypeEquality, UpdateTypePosition}},
+	{Engine: QueryEngineStarRocks, Label: "StarRocks", Supports: []UpdateType{UpdateTypeEquality, UpdateTypePosition}},
+	{Engine: QueryEngineHive, Label: "Apache Hive", Supports: []UpdateType{UpdateTypePosition}},
+	{Engine: QueryEngineDuckDB, Label: "DuckDB", Supports: []UpdateType{UpdateTypePosition}},
+	{Engine: QueryEngineAthena, Label: "AWS Athena", Supports: []UpdateType{UpdateTypePosition}},
+	{Engine: QueryEngineSnowflake, Label: "Snowflake", Supports: []UpdateType{UpdateTypePosition}},
+	{Engine: QueryEngineBigQuery, Label: "Google BigQuery", Supports: []UpdateType{UpdateTypePosition}},
+	{Engine: QueryEngineDatabricks, Label: "Databricks", Supports: []UpdateType{UpdateTypePosition, UpdateTypeDeletionVector}},
+	{Engine: QueryEngineDremio, Label: "Dremio", Supports: []UpdateType{UpdateTypePosition}},
+	{Engine: QueryEngineClickHouse, Label: "ClickHouse", Supports: []UpdateType{UpdateTypePosition}},
+}
+
+// QueryEngineCatalog is served by `spec --available-query-engines`. The engine names it
+// returns are exactly the values --target-query-engines accepts.
+func QueryEngineCatalog() map[string]interface{} {
+	return map[string]interface{}{
+		"engines":               queryEngines,
+		"writable_update_types": writableUpdateTypes,
+	}
+}
+
+// ParseQueryEngines normalizes raw values and rejects unknown names: a typo that silently
+// dropped an engine would widen AvailableUpdateTypes and let an unreadable format through.
+func ParseQueryEngines(values []string) ([]QueryEngine, error) {
+	engines := make([]QueryEngine, 0, len(values))
+	for _, value := range values {
+		engine := QueryEngine(strings.ToLower(strings.TrimSpace(value)))
+		if engine == "" {
+			continue
+		}
+		if _, found := lookupEngine(engine); !found {
+			return nil, fmt.Errorf("unknown query engine %q; supported are %s", value, strings.Join(engineNames(), ", "))
+		}
+		if !slices.Contains(engines, engine) {
+			engines = append(engines, engine)
+		}
+	}
+
+	return engines, nil
+}
+
+// AvailableUpdateTypes returns the writable delete formats every engine can read, cheapest
+// first. No engines means the choice is unconstrained.
+func AvailableUpdateTypes(engines []QueryEngine) []UpdateType {
+	available := make([]UpdateType, 0, len(writableUpdateTypes))
+	for _, updateType := range writableUpdateTypes {
+		if readableByAll(engines, updateType) {
+			available = append(available, updateType)
+		}
+	}
+
+	return available
+}
+
+// PreferredUpdateType returns the cheapest available format, empty when none satisfies
+// every engine.
+func PreferredUpdateType(available []UpdateType) UpdateType {
+	if len(available) == 0 {
+		return ""
+	}
+
+	return available[0]
+}
+
+func readableByAll(engines []QueryEngine, updateType UpdateType) bool {
+	for _, engine := range engines {
+		spec, found := lookupEngine(engine)
+		if !found || !slices.Contains(spec.Supports, updateType) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func lookupEngine(engine QueryEngine) (QueryEngineSpec, bool) {
+	idx := slices.IndexFunc(queryEngines, func(spec QueryEngineSpec) bool { return spec.Engine == engine })
+	if idx == -1 {
+		return QueryEngineSpec{}, false
+	}
+
+	return queryEngines[idx], true
+}
+
+func engineNames() []string {
+	names := make([]string, 0, len(queryEngines))
+	for _, spec := range queryEngines {
+		names = append(names, string(spec.Engine))
+	}
+
+	return names
+}

--- a/types/query_engine_test.go
+++ b/types/query_engine_test.go
@@ -1,0 +1,190 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQueryEngines(t *testing.T) {
+	testCases := []struct {
+		name     string
+		values   []string
+		expected []QueryEngine
+		wantErr  bool
+	}{
+		{name: "empty input", values: nil, expected: []QueryEngine{}},
+		{name: "normalizes case and spacing", values: []string{" Spark ", "DuckDB"}, expected: []QueryEngine{QueryEngineSpark, QueryEngineDuckDB}},
+		{name: "drops blanks", values: []string{"spark", "", "  "}, expected: []QueryEngine{QueryEngineSpark}},
+		{name: "deduplicates", values: []string{"hive", "hive"}, expected: []QueryEngine{QueryEngineHive}},
+		// A silently ignored typo would widen the available set, so it must be an error.
+		{name: "rejects unknown engine", values: []string{"spark", "sparkk"}, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			engines, err := ParseQueryEngines(tc.values)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, engines)
+		})
+	}
+}
+
+// The engine names spec hands a client are the same names discover accepts back, so a
+// client can round-trip the list without translating it.
+func TestQueryEngineCatalogRoundTripsThroughParse(t *testing.T) {
+	served, ok := QueryEngineCatalog()["engines"].([]QueryEngineSpec)
+	require.True(t, ok)
+	require.NotEmpty(t, served)
+
+	names := make([]string, 0, len(served))
+	for _, spec := range served {
+		names = append(names, string(spec.Engine))
+	}
+
+	parsed, err := ParseQueryEngines(names)
+	require.NoError(t, err)
+	assert.Len(t, parsed, len(served))
+}
+
+func TestAvailableUpdateTypes(t *testing.T) {
+	testCases := []struct {
+		name     string
+		engines  []QueryEngine
+		expected []UpdateType
+	}{
+		{
+			// No engines means unconstrained: everything OLake can write stays on the table.
+			name:     "no engines leaves every writable format",
+			engines:  nil,
+			expected: []UpdateType{UpdateTypeEquality, UpdateTypePosition},
+		},
+		{
+			name:     "single engine reading both formats",
+			engines:  []QueryEngine{QueryEngineSpark},
+			expected: []UpdateType{UpdateTypeEquality, UpdateTypePosition},
+		},
+		{
+			// DuckDB cannot resolve equality deletes, so the intersection drops to positional.
+			name:     "one restrictive engine narrows the set",
+			engines:  []QueryEngine{QueryEngineSpark, QueryEngineDuckDB, QueryEngineHive},
+			expected: []UpdateType{UpdateTypePosition},
+		},
+		{
+			name:     "restrictive engine alone",
+			engines:  []QueryEngine{QueryEngineSnowflake},
+			expected: []UpdateType{UpdateTypePosition},
+		},
+		{
+			// Spark and Trino both read deletion vectors, but OLake cannot write them yet.
+			name:     "unwritable formats never surface",
+			engines:  []QueryEngine{QueryEngineSpark, QueryEngineTrino},
+			expected: []UpdateType{UpdateTypeEquality, UpdateTypePosition},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, AvailableUpdateTypes(tc.engines))
+		})
+	}
+}
+
+func TestPreferredUpdateType(t *testing.T) {
+	// Equality outranks positional: it needs no identifier -> RowLocation index.
+	assert.Equal(t, UpdateTypeEquality, PreferredUpdateType([]UpdateType{UpdateTypeEquality, UpdateTypePosition}))
+	assert.Equal(t, UpdateTypePosition, PreferredUpdateType([]UpdateType{UpdateTypePosition}))
+	assert.Equal(t, UpdateType(""), PreferredUpdateType(nil))
+}
+
+func TestUpdateTypeValidateAgainst(t *testing.T) {
+	testCases := []struct {
+		name       string
+		updateType UpdateType
+		available  []UpdateType
+		wantErr    bool
+	}{
+		// Discover ran without target engines, so nothing narrows the choice.
+		{name: "equality with no available list", updateType: UpdateTypeEquality},
+		{name: "equality is offered", updateType: UpdateTypeEquality, available: []UpdateType{UpdateTypeEquality, UpdateTypePosition}},
+		// Hand-edited streams file, or engines that changed without a re-discover.
+		{name: "equality is not offered", updateType: UpdateTypeEquality, available: []UpdateType{UpdateTypePosition}, wantErr: true},
+		{name: "positional is offered", updateType: UpdateTypePosition, available: []UpdateType{UpdateTypePosition}},
+		{name: "deletion vector is not writable", updateType: UpdateTypeDeletionVector, wantErr: true},
+		{name: "garbage value", updateType: UpdateType("nope"), wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.updateType.ValidateAgainst(tc.available)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetWrappedCatalogUsesEngineDerivedUpdateType(t *testing.T) {
+	streams := []*Stream{{Name: "users", Namespace: "public", Schema: NewTypeSchema()}}
+
+	// DuckDB cannot read equality deletes, so the seeded default drops to positional.
+	catalog := GetWrappedCatalog(streams, "postgres", []QueryEngine{QueryEngineSpark, QueryEngineDuckDB})
+
+	assert.Equal(t, string(UpdateTypePosition), catalog.SelectedStreams["public"][0].UpdateType)
+}
+
+// The engines themselves are an input, never a field: only the list they produce is written.
+func TestLogCatalogPersistsOnlyTheDerivedList(t *testing.T) {
+	streams := []*Stream{{
+		Name: "users", Namespace: "public", Schema: NewTypeSchema(),
+		DefaultStreamProperties: &DefaultStreamProperties{},
+	}}
+
+	catalog := GetWrappedCatalog(streams, "postgres", []QueryEngine{QueryEngineSpark, QueryEngineDuckDB})
+	serialised, err := json.Marshal(catalog)
+	require.NoError(t, err)
+	assert.NotContains(t, string(serialised), "target_query_engines")
+}
+
+func TestMergeUpdateType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		existing string
+		engines  []QueryEngine
+		expected string
+	}{
+		{
+			// Legacy catalogs carry no engines; their recorded value must survive untouched.
+			name: "no engines leaves the value alone", existing: "", engines: nil, expected: "",
+		},
+		{
+			name: "readable value is kept", existing: "pos",
+			engines: []QueryEngine{QueryEngineSpark, QueryEngineDuckDB}, expected: "pos",
+		},
+		{
+			// The stream was configured before DuckDB joined the target engines.
+			name: "unreadable value is re-picked", existing: "eq",
+			engines: []QueryEngine{QueryEngineSpark, QueryEngineDuckDB}, expected: "pos",
+		},
+		{
+			name: "blank value is filled", existing: "",
+			engines: []QueryEngine{QueryEngineSpark}, expected: "eq",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metadata := &StreamMetadata{StreamName: "users", UpdateType: tc.existing}
+			mergeUpdateType(metadata, "public.users", tc.engines)
+			assert.Equal(t, tc.expected, metadata.UpdateType)
+		})
+	}
+}

--- a/types/stream.go
+++ b/types/stream.go
@@ -31,6 +31,10 @@ type Stream struct {
 	Schema *TypeSchema `json:"type_schema,omitempty"`
 	// Supported sync modes from driver for the respective Stream
 	SupportedSyncModes *Set[SyncMode] `json:"supported_sync_modes,omitempty"`
+	// Delete formats every target query engine can read, cheapest first. Discover without
+	// target engines is unconstrained and lists every format OLake can write. Absent only
+	// on catalogs written before target query engines existed.
+	AvailableUpdateTypes []UpdateType `json:"available_update_types,omitempty"`
 	// Primary key if available
 	SourceDefinedPrimaryKey *Set[string] `json:"source_defined_primary_key,omitempty"`
 	// Available cursor fields supported by driver
@@ -147,14 +151,14 @@ func StreamsToMap(streams ...*Stream) map[string]*Stream {
 	return output
 }
 
-func LogCatalog(streams []*Stream, oldCatalog *Catalog, driver string) {
+func LogCatalog(streams []*Stream, oldCatalog *Catalog, driver string, engines []QueryEngine) {
 	message := Message{
 		Type:    CatalogMessage,
-		Catalog: GetWrappedCatalog(streams, driver),
+		Catalog: GetWrappedCatalog(streams, driver, engines),
 	}
 	logger.Info(message)
 	// write catalog to the specified file
-	message.Catalog = mergeCatalogs(oldCatalog, message.Catalog)
+	message.Catalog = mergeCatalogs(oldCatalog, message.Catalog, engines)
 
 	err := logger.FileLoggerWithPath(message.Catalog, viper.GetString(constants.StreamsPath))
 	if err != nil {


### PR DESCRIPTION
# Description

Lets a client declare which engines will read the destination Iceberg tables, and
derives each stream's delete format from that instead of always defaulting to `eq`.

Equality deletes are cheapest (no index bootstrap) but only a few engines read them;
positional deletes are the universal denominator. Picking by hand meant picking wrong.

- `spec --available-query-engines` serves the read-capability matrix: 13 engines, the
  delete formats each resolves, and what OLake can write. The engine names it returns are
  exactly the values `--target-query-engines` accepts, locked by a round-trip test.
- `discover --target-query-engines spark,duckdb,hive` intersects those capabilities with
  what OLake can write and records the result per stream as `available_update_types`
  (cheapest first), seeding `update_type` from element 0.
- The engines are a pure discover-time input, never persisted. Only the derived list is
  written, so a caller passes the flag on every discover.
- Re-discover re-picks any stream whose stored `update_type` the current engines can't
  read, and logs the flip. Catalogs without engines behave exactly as before.
- Sync validates `update_type` against the stream's recorded list, catching a hand-edited
  streams file.

`dv` stays out of the writable set until the deletion-vector writer lands.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [ ] N/A (bug fix, refactor, or test changes only)

## Related PR's (If Any):